### PR TITLE
Fixes

### DIFF
--- a/zip_static/common/magic_mask.sh
+++ b/zip_static/common/magic_mask.sh
@@ -108,26 +108,19 @@ travel() {
             mktouch $DUMMDIR/$2/$ITEM
           fi
 
-          # Clone the original /system structure (depth 1)
-          if [ -e "/$2" ]; then
-            for DUMMY in /$2/* ; do
-              if [ -d "$DUMMY" ]; then
-                # Create dummy directory
-                mkdir -p $DUMMDIR$DUMMY
-              elif [ -L "$DUMMY" ]; then
-                # Symlinks are small, copy them
-                cp -afc $DUMMY $DUMMDIR$DUMMY
-              else
-                # Create dummy file
-                mktouch $DUMMDIR$DUMMY
-              fi
+          # Clone the original /system/$ITEM directory structure
+          ITEMDIR=$(dirname /$2/$ITEM)
+          if [ ! -f $DUMMDIR$ITEMDIR/.magisk ]; then
+            find "$ITEMDIR" -type f -o -type l |while read FILE; do
+              mktouch $DUMMDIR$FILE
             done
+            mktouch $DUMMDIR$ITEMDIR/.magisk
           fi
         fi
       fi
 
       if [ -d "$ITEM" ]; then
-        # It's an directory, travel deeper
+        # It's a directory, travel deeper
         (travel $1 $2/$ITEM)
       elif [ ! -L "$ITEM" ]; then
         # Mount this file

--- a/zip_static/common/magic_mask.sh
+++ b/zip_static/common/magic_mask.sh
@@ -333,6 +333,19 @@ case $1 in
       cp -afc linker* t*box app_process* $DUMMDIR/system/bin/
     fi
 
+    LIBDIRS=( lib lib64 )
+    LIBS=( libc++.so libc.so libcrypto.so libcutils.so liblog.so libm.so libpackagelistparser.so libpcre.so libselinux.so libstdc++.so )
+    for LIBDIR in ${LIBDIRS[@]}; do
+      if [ -f "$TMPDIR/dummy/system/$LIBDIR" ]; then
+        cd /system/$LIBDIR
+        for LIB in ${LIBS[@]}; do
+          if [ ! -f "$TMPDIR/dummy/system/$LIBDIR/$LIB" ]; then
+            cp -afc $LIB $DUMMDIR/system/$LIBDIR/
+          fi
+        done
+      fi
+    done
+
     # Unmount, shrink, remount
     if [ `umount $MOUNTPOINT >/dev/null 2>&1; echo $?` -eq 0 ]; then
       losetup -d $LOOPDEVICE


### PR DESCRIPTION
First commit allows dummy binding the lib or lib64 dirs, which partially fixes #4 

Second commit clones /system to full depth, which also fixes lib/lib64 dummy binding as single depth excludes things like /system/lib64/hw which breaks everything

I'm still have the problem of losing the /magisk/.core/bin directory when my openssh module is installed along with phh su though
