### PR TITLE
Use busybox for bind mounts

### DIFF
--- a/scripts/magic_mask.sh
+++ b/scripts/magic_mask.sh
@@ -57,7 +57,7 @@ unblock() {
 
 bind_mount() {
   if [ -e "$1" -a -e "$2" ]; then
-    mount -o bind "$1" "$2" || log_print "Mount Fail: $1 -> $2"
+    $BINPATH/busybox mount -o bind "$1" "$2" || log_print "Mount Fail: $1 -> $2"
   fi
 }
 

--- a/scripts/magic_mask.sh
+++ b/scripts/magic_mask.sh
@@ -57,7 +57,7 @@ unblock() {
 
 bind_mount() {
   if [ -e "$1" -a -e "$2" ]; then
-    $BINPATH/busybox mount -o bind "$1" "$2" || log_print "Mount Fail: $1 -> $2"
+    mount -o bind "$1" "$2" || $BINPATH/busybox mount -o bind "$1" "$2" || log_print "Mount Fail: $1 -> $2"
   fi
 }
 


### PR DESCRIPTION
My BLU R1 HD's mount binary just segfaults with the bind option. This change allows Magisk to work correctly on my phone.