### PR TITLE
list_monitor: only update_list() when file is actually written to

### DIFF
--- a/jni/magiskhide/list_monitor.c
+++ b/jni/magiskhide/list_monitor.c
@@ -5,7 +5,9 @@ void *monitor_list(void *path) {
 	signal(SIGQUIT, quit_pthread);
 
 	int inotifyFd = -1;
+	int length;
 	char str[512];
+	char buffer[BUF_LEN];
 
 	while(1) {
 		if (inotifyFd == -1 || read(inotifyFd, str, sizeof(str)) == -1) {
@@ -20,7 +22,10 @@ void *monitor_list(void *path) {
 				exit(1);
 			}
 		}
-		update_list(listpath);
+
+		length = read(inotifyFd, buffer, BUF_LEN);
+		if (length > 0)
+			update_list(listpath);
 	}
 
 	return NULL;

--- a/jni/magiskhide/magiskhide.h
+++ b/jni/magiskhide/magiskhide.h
@@ -24,6 +24,9 @@
 #define ENFORCE_FILE 	"/sys/fs/selinux/enforce"
 #define SEPOLICY_INJECT "/data/magisk/magiskpolicy"
 
+#define EVENT_SIZE  (sizeof(struct inotify_event))
+#define BUF_LEN     (1024 * (EVENT_SIZE + 16))
+
 // Main thread
 void monitor_proc();
 


### PR DESCRIPTION
this fixes the issue where magisk log gets flooded (over time) with messages about list being updated when its not