### PR TITLE
Update magiskhide enable script to run daemon in su subshell

### DIFF
--- a/zip_static/common/magiskhide/enable
+++ b/zip_static/common/magiskhide/enable
@@ -72,4 +72,4 @@ while read PROCESS; do
 done < $MODDIR/hidelist
 
 log_print "Starting MagiskHide daemon"
-$BINPATH/magiskhide --daemon
+su -c $BINPATH/magiskhide --daemon


### PR DESCRIPTION
I'm using magisk / magisk hide on a xiaomi Mi5 miui based rom. 

It hasn't worked properly for me since v9 + phh however, as discussed in https://github.com/topjohnwu/Magisk/issues/99#issuecomment-286910905

This issue report however got me on a track to fixing it: https://github.com/topjohnwu/MagiskManager/issues/112

Running the magiskhide enable script from adb su shell worked fine with recent releases!

Interestingly when enable is run through magisk manager, the magiskhide daemon appears as such in ps:
```
gemini:/ # ps | grep magiskhide
root      7815  1     10536  600   hrtimer_na 7f94df30a0 S /magisk/.core/bin/magiskhide
root      7816  7815  7456   372    pipe_wait 7f94df31a8 S /magisk/.core/bin/magiskhide
```

but when run from adb su shell it shows up as: 
```
root      7976  1     10536  528    pipe_wait 7f798ce1a8 S /magisk/.core/bin/magiskhide
root      7977  7976  7456   372    pipe_wait 7f798ce1a8 S /magisk/.core/bin/magiskhide
```
the WCHAN column always shows the parent process stuck waiting at a different point in the kernel.
Not sure if this is a permissions thing related to starting from an app rather than shell (even with su) related to https://doridori.github.io/Android-Security-welcome-to-shell/#sthash.LS0yvVWX.dpbs ?

regardless of the reason, the attached change appears to completely fix it on my device; just simply running magisk daemon within a separate su process 

The manager app is certainly already running the enable/disable under su, the fact that the disable script still works means it has permission to kill the daemon, but there's clearly something different about running it inside a separate su shell because it works every time for me.

Not understanding the root cause, I don't know if this is the "correct" way to fix the issue, but at least it's simple.