### PR TITLE
Explicitely add path to magisk-binary if called in recovery.

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -133,12 +133,16 @@ recovery_actions() {
   # Add all possible library paths
   OLD_LD_PATH=$LD_LIBRARY_PATH
   $IS64BIT && export LD_LIBRARY_PATH=/system/lib64:/system/vendor/lib64 || export LD_LIBRARY_PATH=/system/lib:/system/vendor/lib
+  # Add /data/magisk to the system-path
+  OLD_PATH=$PATH
+  export PATH=/data/magisk:$PATH
 }
 
 recovery_cleanup() {
   mv /sbin_tmp /sbin
   # Clear LD_LIBRARY_PATH
   export LD_LIBRARY_PATH=$OLD_LD_PATH
+  export PATH=$OLD_PATH
   ui_print "- Unmounting partitions"
   umount -l /system
   umount -l /vendor 2>/dev/null


### PR DESCRIPTION
Needed for new module-template, tha fixes access-denied when running execv from below /data.