### PR TITLE
Fix: boot_patch.sh failed to parse return value of magiskboot

### DIFF
--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -117,9 +117,8 @@ chmod +x ./*
 ##########################################################################################
 
 ui_print_wrap "- Unpacking boot image"
-./magiskboot --unpack "$BOOTIMAGE"
-
 CHROMEOS=false
+./magiskboot --unpack "$BOOTIMAGE"
 case $? in
   1 )
     abort_wrap "! Unable to unpack boot image"


### PR DESCRIPTION
Just a small mistake. But cause the script to run out of control on my Sony Z5C.