### PR TITLE
Bootimg.h: added support only for PXA marvell devices

### DIFF
--- a/jni/magiskboot/bootimg.h
+++ b/jni/magiskboot/bootimg.h
@@ -41,16 +41,14 @@ struct boot_img_hdr
     uint32_t second_size;  /* size in bytes */
     uint32_t second_addr;  /* physical load addr */
 
-    uint32_t tags_addr;    /* physical addr for kernel tags */
-    uint32_t page_size;    /* flash page size we assume */
+    /* only for Maarvell PXA boards */
     uint32_t dt_size;      /* device tree in bytes */
 
-    /* operating system version and security patch level; for
-     * version "A.B.C" and patch level "Y-M-D":
-     * ver = A << 14 | B << 7 | C         (7 bits for each of A, B, C)
-     * lvl = ((Y - 2000) & 127) << 4 | M  (7 bits for Y, 4 bits for M)
-     * os_version = ver << 11 | lvl */
-    uint32_t os_version;
+    uint32_t unknown;      /* 0x02000000, 0x02800000 or 0x03000000 */
+    uint32_t tags_addr;    /* physical addr for kernel tags */
+    uint32_t page_size;    /* flash page size we assume */
+    uint32_t dummy[2];     /* this is because id[8] is placed higher */
+    /* all PXA boards doesn't have name, cmdline and extra_cmdline */
 
     uint8_t name[BOOT_NAME_SIZE]; /* asciiz product name */
 


### PR DESCRIPTION
There are some devices which uses non-standart kernel header structure. I modified Magisk sources to support this different header, but I am still not pretty sure how to implement header recognition. Samsung PXA1088 and PXA1908 devices use this different header. First 32 bytes are similiar with AOSP kernel, then dt_size, unknown, tags_addr, page_size. Unknown value is unknown and can take values: 0x02000000, 0x02800000 or 0x03000000.
id[8] is placed at offset 0x248h not 0x240h like in normal AOSP kernel.
All checked kernels doesn't have name, cmdline and extra_cmdline.
Kernels with unknown = 0x02800000 or 0x03000000 has SEANDROIDENFORCE before signature and kernel image is not raw zImage, but zImage packed in uImage with u-tools.
Kernel examples can be taken [here](https://yadi.sk/d/uiglXj-33MCMPj).

I still don't know how better check kernel for this structure. @osm0sis in his android-kitchen checks value at offset 24h and if it matches one of 3 possible unknown values (0x02000000, 0x02800000 or 0x03000000) then it is PXA kernel. to my mind it is better to check value at 240h and if it is zero it is PXA kernel (cause timestamp cannot be zero).

More info about PXA kernels in [my repository](https://github.com/AKuHAK/pxa-mkbootimg).