### PR TITLE
Fix build error in magiskhide

### DIFF
--- a/jni/magiskhide/proc_monitor.c
+++ b/jni/magiskhide/proc_monitor.c
@@ -70,10 +70,11 @@ static void store_zygote_ns(int pid) {
 }
 
 static void lazy_unmount(const char* mountpoint) {
-	if (umount2(mountpoint, MNT_DETACH) != -1)
+	if (umount2(mountpoint, MNT_DETACH) != -1) {
 		LOGD("hide_daemon: Unmounted (%s)\n", mountpoint);
-	else
+	} else {
 		LOGD("hide_daemon: Unmount Failed (%s)\n", mountpoint);
+	}
 }
 
 static void hide_daemon_err() {


### PR DESCRIPTION
This conditional in MagiskHide's process monitor causes an error in NDK version 15.2.4203891 for some reason. Simply adding braces resolves it and allows the build to complete successfully.

```
[x86] Compile        : magisk <= rules.c
jni/magiskhide/proc_monitor.c:75:2: error: expected expression
        else
        ^
1 error generated.
make: *** [obj/local/x86/objs/magisk/magiskhide/proc_monitor.o] Error 1
make: *** Waiting for unfinished jobs....

Build Magisk binary failed!
```