### PR TITLE
Fix missing includes for ndk r16

### DIFF
--- a/jni/utils/file.c
+++ b/jni/utils/file.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <errno.h>
 #include <sys/sendfile.h>
 #include <sys/mman.h>
 

--- a/jni/utils/misc.c
+++ b/jni/utils/misc.c
@@ -10,6 +10,7 @@
 #include <pwd.h>
 #include <signal.h>
 #include <sched.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/mount.h>
 #include <sys/wait.h>


### PR DESCRIPTION
The build fails with ndk r16, because a number of transitive includes were removed. This change fixes the build with the current version.