### PR TITLE
Fix segmentation fault

### DIFF
--- a/core/jni/magiskboot/ramdisk.c
+++ b/core/jni/magiskboot/ramdisk.c
@@ -21,6 +21,7 @@ static void cpio_patch(struct vector *v, int keepverity, int keepforceencrypt) {
 				fprintf(stderr, "Remove [verity_key]\n");
 				cpio_free(e);
 				vec_cur(v) = NULL;
+				continue;
 			}
 		}
 		if (!keepforceencrypt) {


### PR DESCRIPTION
When both keepverity and keepforceencrypt are false, ‘e’ will be freed after removing ‘verity_key’ and segmentation fault might happened in strstr(e->filename, “fstab”)

Signed-off-by: Shaka Huang <shakalaca@gmail.com>