### PR TITLE
Fix error installing manager in 6.x devices

### DIFF
--- a/core/jni/include/magisk.h
+++ b/core/jni/include/magisk.h
@@ -29,7 +29,7 @@
 #define HIDELIST        COREDIR "/hidelist"
 #define MAINIMG         "/data/adb/magisk.img"
 #define DATABIN         "/data/adb/magisk"
-#define MANAGERAPK      DATABIN "/magisk.apk"
+#define MANAGERAPK      "/data/magisk.apk"
 #define MAGISKRC        "/init.magisk.rc"
 
 

--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -89,6 +89,7 @@ rm -rf $MAGISKBIN/* 2>/dev/null
 mkdir -p $MAGISKBIN 2>/dev/null
 cp -af $BINDIR/. $COMMONDIR/. $CHROMEDIR $TMPDIR/bin/busybox $MAGISKBIN
 chmod -R 755 $MAGISKBIN
+mv $MAGISKBIN/magisk.apk /data
 
 # addon.d
 if [ -d /system/addon.d ]; then


### PR DESCRIPTION
For Android 6.x packagemanager could not install apk under /data/adb due to linux security configuration (0700). It should be safe to change the location of apk since the file will be deleted after installation.

Signed-off-by: Shaka Huang <shakalaca@gmail.com>