### PR TITLE
utils/file.c: NULL terminate all files read into memory

### DIFF
--- a/native/jni/utils/file.c
+++ b/native/jni/utils/file.c
@@ -401,8 +401,9 @@ int mmap_rw(const char *filename, void **buf, size_t *size) {
 void fd_full_read(int fd, void **buf, size_t *size) {
 	*size = lseek(fd, 0, SEEK_END);
 	lseek(fd, 0, SEEK_SET);
-	*buf = xmalloc(*size);
+	*buf = xmalloc(*size + 1);
 	xxread(fd, *buf, *size);
+	((char *) *buf)[*size] = '\0';
 }
 
 void full_read(const char *filename, void **buf, size_t *size) {


### PR DESCRIPTION
Some functions, like `patch_init_rc()`, treat buffers read into memory
as a string instead of a byte buffer. Since the buffers weren't
NULL-terminated, this resulted in out-of-bounds reads and caused crashes
in certain conditions.

THis commit updates fd_full_read() to always NULL-terminate the buffers
so that they can be treated as strings when working with text files.