### PR TITLE
utils/cpio.c: Fix off-by-one error in cpio_vec_insert

### DIFF
--- a/native/jni/utils/cpio.c
+++ b/native/jni/utils/cpio.c
@@ -46,7 +46,7 @@ int cpio_cmp(const void *a, const void *b) {
 
 void cpio_vec_insert(struct vector *v, cpio_entry *n) {
 	int i = cpio_find(v, n->filename);
-	if (i > 0) {
+	if (i >= 0) {
 		// Replace, then all is done
 		cpio_free(vec_entry(v)[i]);
 		vec_entry(v)[i] = n;


### PR DESCRIPTION
Previously, if `cpio_vec_insert()` needed to replace a file and the file
already exists as the first entry, then a duplicate entry would get
created.

This fixes the bug I reported at:
https://forum.xda-developers.com/showpost.php?p=75449768&postcount=22647