### PR TITLE
Fix error parsing MTK boot.img

### DIFF
--- a/native/jni/magiskboot/bootimg.c
+++ b/native/jni/magiskboot/bootimg.c
@@ -207,7 +207,7 @@ int parse_img(const char *image, boot_img *boot) {
 				fprintf(stderr, "NAME [%s]\n", boot->r_hdr->name);
 				boot->ramdisk += 512;
 				lheader(boot, ramdisk_size, -= 512);
-				boot->k_fmt = check_fmt(boot->ramdisk, header(boot, ramdisk_size));
+				boot->r_fmt = check_fmt(boot->ramdisk, header(boot, ramdisk_size));
 			}
 
 			char fmt[16];
@@ -333,7 +333,7 @@ void repack(const char* orig_image, const char* out_image) {
 			lheader(&boot, ramdisk_size, = comp(boot.r_fmt, fd, cpio, cpio_size));
 			munmap(cpio, cpio_size);
 		} else {
-			lheader(&boot, kernel_size, = restore(KERNEL_FILE, fd));
+			lheader(&boot, ramdisk_size, = restore(RAMDISK_FILE, fd));
 		}
 		file_align();
 	}

--- a/native/jni/magiskboot/bootimg.c
+++ b/native/jni/magiskboot/bootimg.c
@@ -202,7 +202,7 @@ int parse_img(const char *image, boot_img *boot) {
 				fprintf(stderr, "MTK_RAMDISK_HDR\n");
 				boot->flags |= MTK_RAMDISK;
 				boot->r_hdr = malloc(sizeof(mtk_hdr));
-				memcpy(boot->r_hdr, boot->kernel, sizeof(mtk_hdr));
+				memcpy(boot->r_hdr, boot->ramdisk, sizeof(mtk_hdr));
 				fprintf(stderr, "RAMDISK [%u]\n", boot->r_hdr->size);
 				fprintf(stderr, "NAME [%s]\n", boot->r_hdr->name);
 				boot->ramdisk += 512;


### PR DESCRIPTION
Both should be copy & paste error:
1. boot->r_fmt should be re-checked instead of boot->k_fmt once MTK header was found in ramdisk.
2. ramdisk_size should be restored instead of kernel_size when uncompressed ramdisk was found.

Signed-off-by: Shaka Huang <shakalaca@gmail.com>