### PR TITLE
Check dtb file even if kernel image is not available

### DIFF
--- a/native/jni/magiskboot/bootimg.c
+++ b/native/jni/magiskboot/bootimg.c
@@ -312,12 +312,13 @@ void repack(const char* orig_image, const char* out_image) {
 		} else {
 			lheader(&boot, kernel_size, = restore(KERNEL_FILE, fd));
 		}
-		// dtb
-		if (access(DTB_FILE, R_OK) == 0) {
-			lheader(&boot, kernel_size, += restore(DTB_FILE, fd));
-		}
-		file_align();
 	}
+
+	// dtb
+	if (access(DTB_FILE, R_OK) == 0) {
+		lheader(&boot, kernel_size, += restore(DTB_FILE, fd));
+	}
+	file_align();
 
 	// ramdisk
 	ramdisk_off = lseek(fd, 0, SEEK_CUR);


### PR DESCRIPTION
By the flow of unpacking boot image of Chrome OS there will be no kernel file but an dtb image. In that case the dtb image won’t be added when repacking boot image.

Signed-off-by: Shaka Huang <shakalaca@gmail.com>