### PR TITLE
Fix early mount on S9/S9+

### DIFF
--- a/native/jni/core/magiskinit.c
+++ b/native/jni/core/magiskinit.c
@@ -131,7 +131,7 @@ static int setup_block(struct device *dev, const char *partname) {
 		buffer[size] = '\0';
 		close(fd);
 		parse_device(dev, buffer);
-		if (strcmp(dev->partname, partname) == 0) {
+		if (strcasecmp(dev->partname, partname) == 0) {
 			snprintf(dev->path, sizeof(dev->path), "/dev/block/%s", dev->devname);
 			found = 1;
 			break;


### PR DESCRIPTION
Unlike other common OEMs, Samsung use uppper case partition name.

e.g. /dev/block/platform/11120000.ufs/by-name/SYSTEM

This will cause setup_block() fails to find a match partition.
Thus, we should use strcasecmp instead of strcmp.

Signed-off-by: msdx321 <msdx321@gmail.com>