### PR TITLE
Added a check to ensure the patched boot image can fit in the boot partition

### DIFF
--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -124,6 +124,17 @@ cd $MAGISKBIN
 # Source the boot patcher
 . $COMMONDIR/boot_patch.sh "$BOOTIMAGE"
 
+ui_print "- Checking patched image size against partition size..."
+
+exact_file_size new-boot.img
+exact_partition_size "$BOOTIMAGE"
+ui_print "- New image size: $EXACT_FILESIZE, boot partition size: $PARTITION_SIZE"
+
+if [ "$EXACT_FILESIZE" -gt "$PARTITION_SIZE" ]; then
+  ui_print "The patched image is too big!"
+  abort "You need to patch the boot image from the MagiskManager apk, reduce it size manually and flash it manually." 
+fi  
+
 flash_boot_image new-boot.img "$BOOTIMAGE"
 rm -f new-boot.img
 

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -342,6 +342,13 @@ mktouch() {
   chmod 644 $1
 }
 
+exact_file_size() {
+  EXACT_FILESIZE=$(stat -c%s "$1")
+}
+exact_partition_size() {
+  PARTITION_SIZE=$(blockdev --getsize64 "$1")
+}
+
 request_size_check() {
   reqSizeM=`du -s $1 | cut -f1`
   reqSizeM=$((reqSizeM / 1024 + 1))


### PR DESCRIPTION
Added a check in the install script to ensure the patched boot image can fit in the boot partition before attempting to write the image. If the size is too big the installation fails with a descriptive error message.

This missing check may result in broken boot images (due to image truncation when writing on boot partition).

On the device Honor 7 (PLK-L01 16GB EU version) this problem prevented correct installation. 