### PR TITLE
Remove update file on boot

### DIFF
--- a/native/jni/core/bootstages.c
+++ b/native/jni/core/bootstages.c
@@ -432,6 +432,8 @@ static int prepare_img() {
 				rm_rf(buf);
 				continue;
 			}
+			snprintf(buf, PATH_MAX, "%s/%s/update", MOUNTPOINT, entry->d_name);
+			unlink(buf);
 			snprintf(buf, PATH_MAX, "%s/%s/disable", MOUNTPOINT, entry->d_name);
 			if (access(buf, F_OK) == 0)
 				continue;


### PR DESCRIPTION
It's not important to check the return value of unlink(2) or even verify
that the file exists. If this code is running, it means the system has
rebooted, and thus the update file, if any, should be removed so that
MagiskManager doesn't keep displaying the same message. We also handle
this before we handle "disable" so that disabled modules don't keep
requesting a reboot to update.