### PR TITLE
Prevent setting zero over than bound in magiskinit.c

### DIFF
--- a/native/jni/core/magiskinit.c
+++ b/native/jni/core/magiskinit.c
@@ -75,7 +75,7 @@ struct device {
 
 static void parse_cmdline(struct cmdline *cmd) {
 	// cleanup
-	memset(cmd, 0, sizeof(&cmd));
+	memset(cmd, 0, sizeof(*cmd));
 
 	char cmdline[4096];
 	mkdir("/proc", 0555);


### PR DESCRIPTION
Hi, @topjohnwu 

The &cmd will return a pointer which point to a pointer of cmdline.
It is a memory address which is usually 8 bytes in 64 bits machine.

However, the struct cmdline is 4 bytes. This will cause setting zero
beyond the bound.

Below is a simple example to show the differentiation:
```
struct cmdline {
        char skip_initramfs;
        char slot[3];
};

static void parse_cmdline(struct cmdline *cmd)
{
        printf("%lu\n", sizeof(*cmd)); /* 4 */
        printf("%lu\n", sizeof(&cmd)); /* 8 */
}

int main()
{
        struct cmdline cmd;
        parse_cmdline(&cmd);
        return 0;
}
```
This patch prevents this.

Thanks.

Signed-off-by: npes87184 <npes87184@gmail.com>