### PR TITLE
Fix survival script for AVB 1.0 signed boot image

### DIFF
--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -13,7 +13,9 @@
 main() {
   # Magisk binaries
   MAGISKBIN=/data/adb/magisk
-  APK=/data/magisk.apk
+  APK=/data/adb/magisk.apk
+  [ -f $APK ] || APK=/data/magisk/magisk.apk
+  [ -f $APK ] || APK=/data/app/com.topjohnwu.magisk*/*.apk
 
   mount /data 2>/dev/null
 
@@ -43,7 +45,7 @@ main() {
   [ -z $BOOTIMAGE ] && abort "! Unable to detect boot image"
   ui_print "- Found boot image: $BOOTIMAGE"
 
-  eval $BOOTSIGNER -verify < $BOOTIMAGE && BOOTSIGNED=true
+  [ -f $APK ] && eval $BOOTSIGNER -verify < $BOOTIMAGE && BOOTSIGNED=true
   $BOOTSIGNED && ui_print "- Boot image is signed with AVB 1.0"
 
   SOURCEDMODE=true

--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -13,6 +13,7 @@
 main() {
   # Magisk binaries
   MAGISKBIN=/data/adb/magisk
+  APK=/data/magisk.apk
 
   mount /data 2>/dev/null
 
@@ -41,6 +42,9 @@ main() {
 
   [ -z $BOOTIMAGE ] && abort "! Unable to detect boot image"
   ui_print "- Found boot image: $BOOTIMAGE"
+
+  eval $BOOTSIGNER -verify < $BOOTIMAGE && BOOTSIGNED=true
+  $BOOTSIGNED && ui_print "- Boot image is signed with AVB 1.0"
 
   SOURCEDMODE=true
   cd $MAGISKBIN


### PR DESCRIPTION
The survival script didn't check if the boot.img was signed. This will cause failing boot on devices required signed boot images.

This patch checks AVB 1.0 in the survival script with `$BOOTSIGNER`, and assign the `$BOOTSIGNED`, in the same way the flash script does.