### PR TITLE
Respect filesystem type when mounting mirrors

### DIFF
--- a/native/jni/core/bootstages.c
+++ b/native/jni/core/bootstages.c
@@ -22,7 +22,7 @@
 #include "resetprop.h"
 #include "magiskpolicy.h"
 
-static char *buf, *buf2;
+static char *buf, *buf2, *buf3;
 static struct vector module_list;
 
 extern char **environ;
@@ -500,6 +500,7 @@ void startup() {
 		// Allocate buffer
 		buf = xmalloc(PATH_MAX);
 		buf2 = xmalloc(PATH_MAX);
+		buf3 = xmalloc(PATH_MAX); // used for detecting fs type
 
 		simple_mount("/system");
 		simple_mount("/vendor");
@@ -626,8 +627,8 @@ void startup() {
 			bind_mount("/system_root/system", MIRRDIR "/system");
 			skip_initramfs = 1;
 		} else if (!skip_initramfs && strstr(line, " /system ")) {
-			sscanf(line, "%s", buf);
-			xmount(buf, MIRRDIR "/system", "ext4", MS_RDONLY, NULL);
+			sscanf(line, "%s %*s %s", buf, buf3); // buf3 holds fs type
+			xmount(buf, MIRRDIR "/system", buf3, MS_RDONLY, NULL);
 #ifdef MAGISK_DEBUG
 			LOGI("mount: %s <- %s\n", MIRRDIR "/system", buf);
 #else
@@ -683,6 +684,7 @@ void post_fs_data(int client) {
 	// Allocate buffer
 	buf = xmalloc(PATH_MAX);
 	buf2 = xmalloc(PATH_MAX);
+	buf3 = xmalloc(PATH_MAX); // used for detecting fs type
 	vec_init(&module_list);
 
 	// Merge, trim, mount magisk.img, which will also travel through the modules
@@ -802,6 +804,7 @@ void late_start(int client) {
 	// Allocate buffer
 	if (buf == NULL) buf = xmalloc(PATH_MAX);
 	if (buf2 == NULL) buf2 = xmalloc(PATH_MAX);
+	if (buf3 == NULL) buf3 = xmalloc(PATH_MAX);
 
 	// Wait till the full patch is done
 	if (full_patch_pid > 0)

--- a/native/jni/core/bootstages.c
+++ b/native/jni/core/bootstages.c
@@ -500,7 +500,7 @@ void startup() {
 		// Allocate buffer
 		buf = xmalloc(PATH_MAX);
 		buf2 = xmalloc(PATH_MAX);
-		buf_fs_type = xmalloc(PATH_MAX); // used for detecting fs type
+		buf_fs_type = xmalloc(64);
 
 		simple_mount("/system");
 		simple_mount("/vendor");
@@ -627,7 +627,7 @@ void startup() {
 			bind_mount("/system_root/system", MIRRDIR "/system");
 			skip_initramfs = 1;
 		} else if (!skip_initramfs && strstr(line, " /system ")) {
-			sscanf(line, "%s %*s %s", buf, buf_fs_type); // buf_fs_type holds fs type
+			sscanf(line, "%s %*s %s", buf, buf_fs_type);
 			xmount(buf, MIRRDIR "/system", buf_fs_type, MS_RDONLY, NULL);
 #ifdef MAGISK_DEBUG
 			LOGI("mount: %s <- %s\n", MIRRDIR "/system", buf);
@@ -636,7 +636,7 @@ void startup() {
 #endif
 		} else if (strstr(line, " /vendor ")) {
 			seperate_vendor = 1;
-			sscanf(line, "%s %*s %s", buf, buf_fs_type); // buf_fs_type holds fs type
+			sscanf(line, "%s %*s %s", buf, buf_fs_type);
 			xmkdir(MIRRDIR "/vendor", 0755);
 			xmount(buf, MIRRDIR "/vendor", buf_fs_type, MS_RDONLY, NULL);
 #ifdef MAGISK_DEBUG
@@ -684,7 +684,7 @@ void post_fs_data(int client) {
 	// Allocate buffer
 	buf = xmalloc(PATH_MAX);
 	buf2 = xmalloc(PATH_MAX);
-	buf_fs_type = xmalloc(PATH_MAX); // used for detecting fs type
+	buf_fs_type = xmalloc(64);
 	vec_init(&module_list);
 
 	// Merge, trim, mount magisk.img, which will also travel through the modules
@@ -804,7 +804,7 @@ void late_start(int client) {
 	// Allocate buffer
 	if (buf == NULL) buf = xmalloc(PATH_MAX);
 	if (buf2 == NULL) buf2 = xmalloc(PATH_MAX);
-	if (buf_fs_type == NULL) buf_fs_type = xmalloc(PATH_MAX);
+	if (buf_fs_type == NULL) buf_fs_type = xmalloc(64);
 
 	// Wait till the full patch is done
 	if (full_patch_pid > 0)

--- a/native/jni/core/bootstages.c
+++ b/native/jni/core/bootstages.c
@@ -636,9 +636,9 @@ void startup() {
 #endif
 		} else if (strstr(line, " /vendor ")) {
 			seperate_vendor = 1;
-			sscanf(line, "%s", buf);
+			sscanf(line, "%s %*s %s", buf, buf3); // buf3 holds fs type
 			xmkdir(MIRRDIR "/vendor", 0755);
-			xmount(buf, MIRRDIR "/vendor", "ext4", MS_RDONLY, NULL);
+			xmount(buf, MIRRDIR "/vendor", buf3, MS_RDONLY, NULL);
 #ifdef MAGISK_DEBUG
 			LOGI("mount: %s <- %s\n", MIRRDIR "/vendor", buf);
 #else


### PR DESCRIPTION
This change reads the filesystem type from /proc/mounts as well and passes that to mount when mounting the mirrors.

This _fixes_ the issue in which devices with ubifs filesystems throw the error
```
mount /dev/ubi0_0->/sbin/.core/mirror/system failed with 15: Block device required
```
about which I think I complained at you a few months ago.

It should also improve compatibility with other strange filesystem types, but I have no way of testing that.