### PR TITLE
Let PATH include Magic Mounts

### DIFF
--- a/native/jni/core/bootstages.c
+++ b/native/jni/core/bootstages.c
@@ -117,8 +117,8 @@ static struct node_entry *insert_child(struct node_entry *p, struct node_entry *
 static void set_path(struct vector *v) {
 	for (int i = 0; environ[i]; ++i) {
 		if (strncmp(environ[i], "PATH=", 5) == 0) {
-			vec_push_back(v, strdup("PATH=" BBPATH ":/sbin:" MIRRDIR "/system/bin:"
-						MIRRDIR "/system/xbin:" MIRRDIR "/vendor/bin"));
+			vec_push_back(v, strdup("PATH=" BBPATH ":/sbin:/system/xbin:"
+						"/system/bin:/vendor/bin"));
 		} else {
 			vec_push_back(v, strdup(environ[i]));
 		}


### PR DESCRIPTION
@topjohnwu,

Currently system/vendor mirrors are used in PATH which make modules which magic mount executables disfunctional, Using mirrors for post-fs-data mode wouldn't gain much since there has no Magic happened, while service.sh requires Magic Mounted executables. So, it should work for both cases.

Regards.