### PR TITLE
Avoid crashes when opening links on device without Internet browser

### DIFF
--- a/app/src/full/java/com/topjohnwu/magisk/AboutActivity.java
+++ b/app/src/full/java/com/topjohnwu/magisk/AboutActivity.java
@@ -1,6 +1,5 @@
 package com.topjohnwu.magisk;
 
-import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -12,6 +11,7 @@ import android.view.View;
 import com.topjohnwu.magisk.asyncs.MarkDownWindow;
 import com.topjohnwu.magisk.components.AboutCardRow;
 import com.topjohnwu.magisk.components.BaseActivity;
+import com.topjohnwu.magisk.utils.Utils;
 
 import java.util.Locale;
 
@@ -65,13 +65,13 @@ public class AboutActivity extends BaseActivity {
         }
 
         appSourceCode.removeSummary();
-        appSourceCode.setOnClickListener(view -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Const.Url.SOURCE_CODE_URL))));
+        appSourceCode.setOnClickListener(view -> Utils.openLink(this, Uri.parse(Const.Url.SOURCE_CODE_URL)));
 
         supportThread.removeSummary();
-        supportThread.setOnClickListener(view -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Const.Url.XDA_THREAD))));
+        supportThread.setOnClickListener(view -> Utils.openLink(this, Uri.parse(Const.Url.XDA_THREAD)));
 
         donation.removeSummary();
-        donation.setOnClickListener(view -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Const.Url.DONATION_URL))));
+        donation.setOnClickListener(view -> Utils.openLink(this, Uri.parse(Const.Url.DONATION_URL)));
 
         setFloating();
     }

--- a/app/src/full/java/com/topjohnwu/magisk/components/MagiskInstallDialog.java
+++ b/app/src/full/java/com/topjohnwu/magisk/components/MagiskInstallDialog.java
@@ -1,6 +1,5 @@
 package com.topjohnwu.magisk.components;
 
-import android.content.Intent;
 import android.net.Uri;
 import android.text.TextUtils;
 
@@ -42,9 +41,7 @@ public class MagiskInstallDialog extends CustomAlertDialog {
             setNeutralButton(R.string.release_notes, (d, i) -> {
                 if (Data.magiskNoteLink.contains("forum.xda-developers")) {
                     // Open forum links in browser
-                    Intent openLink = new Intent(Intent.ACTION_VIEW, Uri.parse(Data.magiskNoteLink));
-                    openLink.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    mm.startActivity(openLink);
+                    Utils.openLink(activity, Uri.parse(Data.magiskNoteLink));
                 } else {
                     new MarkDownWindow(activity, null, Data.magiskNoteLink).exec();
                 }

--- a/app/src/full/java/com/topjohnwu/magisk/utils/Utils.java
+++ b/app/src/full/java/com/topjohnwu/magisk/utils/Utils.java
@@ -91,6 +91,7 @@ public class Utils {
 
     public static void openLink(Context context, Uri link) {
         Intent intent = new Intent(Intent.ACTION_VIEW, link);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         if (intent.resolveActivity(context.getPackageManager()) != null) {
             context.startActivity(intent);
         }

--- a/app/src/full/java/com/topjohnwu/magisk/utils/Utils.java
+++ b/app/src/full/java/com/topjohnwu/magisk/utils/Utils.java
@@ -15,6 +15,7 @@ import android.widget.Toast;
 import com.topjohnwu.magisk.Const;
 import com.topjohnwu.magisk.Data;
 import com.topjohnwu.magisk.MagiskManager;
+import com.topjohnwu.magisk.R;
 import com.topjohnwu.magisk.container.Module;
 import com.topjohnwu.magisk.container.ValueSortedMap;
 import com.topjohnwu.magisk.services.UpdateCheckService;
@@ -94,6 +95,8 @@ public class Utils {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         if (intent.resolveActivity(context.getPackageManager()) != null) {
             context.startActivity(intent);
+        } else {
+            toast(R.string.open_link_failed_toast, Toast.LENGTH_SHORT);
         }
     }
 

--- a/app/src/full/java/com/topjohnwu/magisk/utils/Utils.java
+++ b/app/src/full/java/com/topjohnwu/magisk/utils/Utils.java
@@ -4,6 +4,7 @@ import android.app.job.JobInfo;
 import android.app.job.JobScheduler;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.net.Uri;
@@ -85,6 +86,13 @@ public class Utils {
             }
         } else {
             scheduler.cancel(Const.UPDATE_SERVICE_VER);
+        }
+    }
+
+    public static void openLink(Context context, Uri link) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, link);
+        if (intent.resolveActivity(context.getPackageManager()) != null) {
+            context.startActivity(intent);
         }
     }
 

--- a/app/src/full/res/values/strings.xml
+++ b/app/src/full/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="hide_manager_toast">Hiding Magisk Manager…</string>
     <string name="hide_manager_toast2">This might take a while…</string>
     <string name="hide_manager_fail_toast">Hide Magisk Manager failed…</string>
+    <string name="open_link_failed_toast">No application found to open the link…</string>
     <string name="download_zip_only">Download Zip Only</string>
     <string name="patch_boot_file">Patch Boot Image File</string>
     <string name="direct_install">Direct Install (Recommended)</string>


### PR DESCRIPTION
If there is no available application to handle the intent, `context.startActivity(intent)` will crash... (It's the case when trying to open a link while on an Android device where there is no Internet browser, for instance.)
Here we try to resolve the intent first before showing a toast to warn the user the link cannot be opened.