### PR TITLE
Update SnackbarMaker.java string

### DIFF
--- a/app/src/full/java/com/topjohnwu/magisk/components/SnackbarMaker.java
+++ b/app/src/full/java/com/topjohnwu/magisk/components/SnackbarMaker.java
@@ -40,7 +40,7 @@ public class SnackbarMaker {
 
     public static void showUri(Activity activity, Uri uri) {
         make(activity, activity.getString(R.string.internal_storage,
-                "/MagiskManager/" + Utils.getNameFromUri(activity, uri)),
+                "/Download/" + Utils.getNameFromUri(activity, uri)),
                 Snackbar.LENGTH_LONG)
                 .setAction(R.string.ok, (v)->{}).show();
     }


### PR DESCRIPTION
Zip downloads don't go into /MagiskManager anymore, they go into /Download instead. Snackbar should be updated accordingly.