### PR TITLE
Make sure they have a value

### DIFF
--- a/app/src/full/java/com/topjohnwu/magisk/container/BaseModule.java
+++ b/app/src/full/java/com/topjohnwu/magisk/container/BaseModule.java
@@ -10,7 +10,7 @@ import androidx.annotation.NonNull;
 
 public abstract class BaseModule implements Comparable<BaseModule> {
 
-    private String mId = null, mName, mVersion, mAuthor, mDescription;
+    private String mId = null, mName = "", mVersion = "v0", mAuthor = "", mDescription = "";
     private int mVersionCode = -1, minMagiskVersion = -1;
 
     protected BaseModule() {}


### PR DESCRIPTION
https://github.com/Magisk-Modules-Repo/Stock_Camera_Port_Redmi_Note5 ,its module.prop is no `description`, Magisk Manager will crash when search module.
```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.topjohnwu.magisk, PID: 21960
    java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.toLowerCase()' on a null object reference
        at com.topjohnwu.magisk.adapters.ReposAdapter$override.filter(ReposAdapter.java:134)
```