### PR TITLE
utils/misc.c: prevent file staying opened when function leaving

### DIFF
--- a/native/jni/utils/misc.c
+++ b/native/jni/utils/misc.c
@@ -184,9 +184,9 @@ int check_proc_name(int pid, const char *name) {
 	sprintf(buf, "/proc/%d/cmdline", pid);
 	f = fopen(buf, "r");
 	fgets(buf, sizeof(buf), f);
+	fclose(f);
 	if (strcmp(basename(buf), name) == 0)
 		return 1;
-	fclose(f);
 
 	sprintf(buf, "/proc/%d/exe", pid);
 	if (access(buf, F_OK) != 0)


### PR DESCRIPTION
Hi, @topjohnwu 

The utils function may be called in any situation, such as in daemon. We should guarantee that all the resource got from this function released normally.

Signed-off-by: yuchenlin <npes87184@gmail.com>