### PR TITLE
Fix bootloop for some devices with two /data

### DIFF
--- a/native/jni/utils/misc.c
+++ b/native/jni/utils/misc.c
@@ -57,9 +57,10 @@ int check_data() {
 	int mnt = 0;
 	vec_for_each(&v, line) {
 		if (strstr(line, " /data ")) {
-			if (strstr(line, "tmpfs") == NULL)
+			if (strstr(line, "tmpfs") == NULL) {
 				mnt = 1;
-			break;
+				break;
+			}
 		}
 	}
 	vec_deep_destroy(&v);


### PR DESCRIPTION
Some devices have two /data mount points, one with tmpfs and the other is ext4/f2fs. The startup() in bootstage.c won’t work if the first match goes with tmpfs, leaving the phone in the bootloop.

Signed-off-by: Shaka Huang <shakalaca@gmail.com>