### PR TITLE
Make dark theme cards slightly darker

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -22,6 +22,6 @@
     <color name="ic_launcher_background">#00AF9C</color>
 
     <!-- Card colors -->
-    <color name="card_background_color_dark">#ff424242</color>
+    <color name="card_background_color_dark">#ff323232</color>
     <color name="card_background_color_light">#ffffffff</color>
 </resources>


### PR DESCRIPTION
Use #323232 instead of #424242

Of course this is just a suggestion, use other codes if you wish. I just find the current color a bit too light for a dark theme. For #705.

Current: [https://drive.google.com/open?id=18fSnP-gtdli3qFoDF8Gb_pkGROvTKrIU](https://drive.google.com/open?id=18fSnP-gtdli3qFoDF8Gb_pkGROvTKrIU)
Proposed: [https://drive.google.com/open?id=1F_cJCnwuHwf_DGNlaTWGGnSH4pxQef3s](https://drive.google.com/open?id=1F_cJCnwuHwf_DGNlaTWGGnSH4pxQef3s)
