### PR TITLE
Ensure that icon and text of item selected in navigation drawer are visible/legible with dark theme.

### DIFF
--- a/app/src/full/java/com/topjohnwu/magisk/MainActivity.java
+++ b/app/src/full/java/com/topjohnwu/magisk/MainActivity.java
@@ -87,14 +87,15 @@ public class MainActivity extends BaseActivity
 
         navigationView.setNavigationItemSelectedListener(this);
 
-	// Ensure navigation drawer text is legible with dark theme.
+        // Ensure navigation drawer text and icons are legible with dark theme.
         ColorStateList csl = ColorStateList.valueOf(
-                getResources().getColor(R.color.item_text_color_dark));
+                getResources().getColor(R.color.nav_item_color_dark));
         if (Data.isDarkTheme) {
             csl = ColorStateList.valueOf(
-                    getResources().getColor(R.color.item_text_color_light));
+                    getResources().getColor(R.color.nav_item_color_light));
         }
         navigationView.setItemTextColor(csl);
+        navigationView.setItemIconTintList(csl);
     }
 
     @Override

--- a/app/src/full/java/com/topjohnwu/magisk/MainActivity.java
+++ b/app/src/full/java/com/topjohnwu/magisk/MainActivity.java
@@ -1,6 +1,7 @@
 package com.topjohnwu.magisk;
 
 import android.content.Intent;
+import android.content.res.ColorStateList;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.Menu;
@@ -85,6 +86,15 @@ public class MainActivity extends BaseActivity
         }
 
         navigationView.setNavigationItemSelectedListener(this);
+
+	// Ensure navigation drawer text is legible with dark theme.
+        ColorStateList csl = ColorStateList.valueOf(
+                getResources().getColor(R.color.item_text_color_dark));
+        if (Data.isDarkTheme) {
+            csl = ColorStateList.valueOf(
+                    getResources().getColor(R.color.item_text_color_light));
+        }
+        navigationView.setItemTextColor(csl);
     }
 
     @Override

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,6 +25,6 @@
     <color name="card_background_color_dark">#ff424242</color>
     <color name="card_background_color_light">#ffffffff</color>
 
-    <color name="item_text_color_dark">#000000</color>
-    <color name="item_text_color_light">#ffffff</color>
+    <color name="nav_item_color_dark">#000000</color>
+    <color name="nav_item_color_light">#ffffff</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -24,4 +24,7 @@
     <!-- Card colors -->
     <color name="card_background_color_dark">#ff424242</color>
     <color name="card_background_color_light">#ffffffff</color>
+
+    <color name="item_text_color_dark">#000000</color>
+    <color name="item_text_color_light">#ffffff</color>
 </resources>


### PR DESCRIPTION
When the dark theme is in use, the item highlighted in the navigation drawer has a barely visible icon and barely legible text. This is because the icon and text are displayed in black on a dark grey background.

This patch adds new colour properties nav_item_color_dark and nav_item_color_light, which are used to set the colour of the navigation drawer items, including the currently highlighted one, according to the currently selected theme.