### PR TITLE
Add 15 and 45 second Request Timeout options.

### DIFF
--- a/app/src/full/res/values-ar/strings.xml
+++ b/app/src/full/res/values-ar/strings.xml
@@ -92,8 +92,10 @@
     <string name="settings_su_adb">ADB فقط</string>
     <string name="settings_su_disable">معطل</string>
     <string name="settings_su_request_10">10 ثواني</string>
+    <string name="settings_su_request_15">15 ثانية</string>
     <string name="settings_su_request_20">20 ثانية</string>
     <string name="settings_su_request_30">30 ثانية</string>
+    <string name="settings_su_request_45">45 ثانية</string>
     <string name="settings_su_request_60">60 ثانية</string>
     <string name="superuser_access">Superuser صلاحيات</string>
     <string name="auto_response">استجابة تلقائية</string>

--- a/app/src/full/res/values-bg/strings.xml
+++ b/app/src/full/res/values-bg/strings.xml
@@ -153,8 +153,10 @@
     <string name="settings_su_adb">Само ADB</string>
     <string name="settings_su_disable">Изключен</string>
     <string name="settings_su_request_10">10 секунди</string>
+    <string name="settings_su_request_15">15 секунди</string>
     <string name="settings_su_request_20">20 секунди</string>
     <string name="settings_su_request_30">30 секунди</string>
+    <string name="settings_su_request_45">45 секунди</string>
     <string name="settings_su_request_60">60 секунди</string>
     <string name="superuser_access">Superuser достъп</string>
     <string name="auto_response">Автоматичен отговор</string>

--- a/app/src/full/res/values-ca/strings.xml
+++ b/app/src/full/res/values-ca/strings.xml
@@ -151,8 +151,10 @@
     <string name="settings_su_adb">Només ADB</string>
     <string name="settings_su_disable">Deshabilitat</string>
     <string name="settings_su_request_10">10 segons</string>
+    <string name="settings_su_request_15">15 segons</string>
     <string name="settings_su_request_20">20 segons</string>
     <string name="settings_su_request_30">30 segons</string>
+    <string name="settings_su_request_45">45 segons</string>
     <string name="settings_su_request_60">60 segons</string>
     <string name="superuser_access">Accés de superusuari</string>
     <string name="auto_response">Resposta automàtica</string>

--- a/app/src/full/res/values-cs/strings.xml
+++ b/app/src/full/res/values-cs/strings.xml
@@ -90,8 +90,10 @@
     <string name="settings_su_adb">Pouze ADB</string>
     <string name="settings_su_disable">Zakázáno</string>
     <string name="settings_su_request_10">10 sekund</string>
+    <string name="settings_su_request_15">15 sekund</string>
     <string name="settings_su_request_20">20 sekund</string>
     <string name="settings_su_request_30">30 sekund</string>
+    <string name="settings_su_request_45">45 sekund</string>
     <string name="settings_su_request_60">60 sekund</string>
     <string name="superuser_access">Přístup Superuser</string>
     <string name="auto_response">Automatická Reakce</string>

--- a/app/src/full/res/values-de/strings.xml
+++ b/app/src/full/res/values-de/strings.xml
@@ -153,8 +153,10 @@
     <string name="settings_su_adb">Nur ADB</string>
     <string name="settings_su_disable">Deaktiviert</string>
     <string name="settings_su_request_10">10 Sekunden</string>
+    <string name="settings_su_request_15">15 Sekunden</string>
     <string name="settings_su_request_20">20 Sekunden</string>
     <string name="settings_su_request_30">30 Sekunden</string>
+    <string name="settings_su_request_45">45 Sekunden</string>
     <string name="settings_su_request_60">60 Sekunden</string>
     <string name="superuser_access">Superuser-Zugriff</string>
     <string name="auto_response">Automatisch beantworten</string>

--- a/app/src/full/res/values-el/strings.xml
+++ b/app/src/full/res/values-el/strings.xml
@@ -137,8 +137,10 @@
     <string name="settings_su_adb">ADB μόνο</string>
     <string name="settings_su_disable">Απενεργοποιημένο</string>
     <string name="settings_su_request_10">10 δευτερόλεπτα</string>
+    <string name="settings_su_request_15">15 δευτερόλεπτα</string>
     <string name="settings_su_request_20">20 δευτερόλεπτα</string>
     <string name="settings_su_request_30">30 δευτερόλεπτα</string>
+    <string name="settings_su_request_45">45 δευτερόλεπτα</string>
     <string name="settings_su_request_60">60 δευτερόλεπτα</string>
     <string name="superuser_access">Πρόσβαση Υπερχρήστη</string>
     <string name="auto_response">Αυτόματη Απόκριση</string>

--- a/app/src/full/res/values-es/strings.xml
+++ b/app/src/full/res/values-es/strings.xml
@@ -152,8 +152,10 @@
     <string name="settings_su_adb">Sólo ADB</string>
     <string name="settings_su_disable">Deshabilitado</string>
     <string name="settings_su_request_10">10 segundos</string>
+    <string name="settings_su_request_15">15 segundos</string>
     <string name="settings_su_request_20">20 segundos</string>
     <string name="settings_su_request_30">30 segundos</string>
+    <string name="settings_su_request_45">45 segundos</string>
     <string name="settings_su_request_60">60 segundos</string>
     <string name="superuser_access">Acceso de superusuario</string>
     <string name="auto_response">Respuesta automática</string>

--- a/app/src/full/res/values-et/strings.xml
+++ b/app/src/full/res/values-et/strings.xml
@@ -149,8 +149,10 @@
     <string name="settings_su_adb">Ainult ADB</string>
     <string name="settings_su_disable">Keelatud</string>
     <string name="settings_su_request_10">10 sekundit</string>
+    <string name="settings_su_request_15">15 sekundit</string>
     <string name="settings_su_request_20">20 sekundit</string>
     <string name="settings_su_request_30">30 sekundit</string>
+    <string name="settings_su_request_45">45 sekundit</string>
     <string name="settings_su_request_60">60 sekundit</string>
     <string name="superuser_access">Superkasutaja ligipääs</string>
     <string name="auto_response">Automaatne vastus</string>

--- a/app/src/full/res/values-fr/strings.xml
+++ b/app/src/full/res/values-fr/strings.xml
@@ -153,8 +153,10 @@
     <string name="settings_su_adb">ADB uniquement</string>
     <string name="settings_su_disable">Désactivé</string>
     <string name="settings_su_request_10">10 secondes</string>
+    <string name="settings_su_request_15">15 secondes</string>
     <string name="settings_su_request_20">20 secondes</string>
     <string name="settings_su_request_30">30 secondes</string>
+    <string name="settings_su_request_45">45 secondes</string>
     <string name="settings_su_request_60">60 secondes</string>
     <string name="superuser_access">Accès Superuser</string>
     <string name="auto_response">Réponse automatique</string>

--- a/app/src/full/res/values-hr/strings.xml
+++ b/app/src/full/res/values-hr/strings.xml
@@ -125,8 +125,10 @@
     <string name="settings_su_adb">Samo ADB</string>
     <string name="settings_su_disable">Onemogućeno</string>
     <string name="settings_su_request_10">10 sekundi</string>
+    <string name="settings_su_request_15">15 sekundi</string>
     <string name="settings_su_request_20">20 sekundi</string>
     <string name="settings_su_request_30">30 sekundi</string>
+    <string name="settings_su_request_45">45 sekundi</string>
     <string name="settings_su_request_60">60 sekundi</string>
     <string name="superuser_access">Superuser pristup</string>
     <string name="auto_response">Automatski odgovor</string>

--- a/app/src/full/res/values-in/strings.xml
+++ b/app/src/full/res/values-in/strings.xml
@@ -150,8 +150,10 @@
     <string name="settings_su_adb">ADB saja</string>
     <string name="settings_su_disable">Nonaktif</string>
     <string name="settings_su_request_10">10 detik</string>
+    <string name="settings_su_request_15">15 detik</string>
     <string name="settings_su_request_20">20 detik</string>
     <string name="settings_su_request_30">30 detik</string>
+    <string name="settings_su_request_45">45 detik</string>
     <string name="settings_su_request_60">60 detik</string>
     <string name="superuser_access">Akses Superuser</string>
     <string name="auto_response">Tanggapan Otomatis</string>

--- a/app/src/full/res/values-it/strings.xml
+++ b/app/src/full/res/values-it/strings.xml
@@ -155,8 +155,10 @@
 	<string name="settings_su_adb">Solo ADB</string>
 	<string name="settings_su_disable">Disabilitato</string>
 	<string name="settings_su_request_10">10 secondi</string>
+	<string name="settings_su_request_15">15 secondi</string>
 	<string name="settings_su_request_20">20 secondi</string>
 	<string name="settings_su_request_30">30 secondi</string>
+	<string name="settings_su_request_45">45 secondi</string>
 	<string name="settings_su_request_60">60 secondi</string>
 	<string name="superuser_access">Accesso Superuser</string>
 	<string name="auto_response">Accesso predefinito</string>

--- a/app/src/full/res/values-lt/strings.xml
+++ b/app/src/full/res/values-lt/strings.xml
@@ -148,8 +148,10 @@
     <string name="settings_su_adb">Tik ADB</string>
     <string name="settings_su_disable">Išjungta</string>
     <string name="settings_su_request_10">10 sekundžių</string>
+    <string name="settings_su_request_15">15 sekundžių</string>
     <string name="settings_su_request_20">20 sekundžių</string>
     <string name="settings_su_request_30">30 sekundžių</string>
+    <string name="settings_su_request_45">45 sekundžių</string>
     <string name="settings_su_request_60">60 sekundžių</string>
     <string name="superuser_access">Supervartotojo prieiga</string>
     <string name="auto_response">Automatinis atsakymas</string>

--- a/app/src/full/res/values-nl/strings.xml
+++ b/app/src/full/res/values-nl/strings.xml
@@ -142,8 +142,10 @@
     <string name="settings_su_adb">Alleen ADB</string>
     <string name="settings_su_disable">Uitgeschakeld</string>
     <string name="settings_su_request_10">10 seconden</string>
+    <string name="settings_su_request_15">15 seconden</string>
     <string name="settings_su_request_20">20 seconden</string>
     <string name="settings_su_request_30">30 seconden</string>
+    <string name="settings_su_request_45">45 seconden</string>
     <string name="settings_su_request_60">60 seconden</string>
     <string name="superuser_access">Superuser toegang</string>
     <string name="auto_response">Automatisch antwoord</string>

--- a/app/src/full/res/values-pl/strings.xml
+++ b/app/src/full/res/values-pl/strings.xml
@@ -145,8 +145,10 @@
     <string name="settings_su_adb">Tylko ADB</string>
     <string name="settings_su_disable">Wyłączone</string>
     <string name="settings_su_request_10">10 sekund</string>
+    <string name="settings_su_request_15">15 sekund</string>
     <string name="settings_su_request_20">20 sekund</string>
     <string name="settings_su_request_30">30 sekund</string>
+    <string name="settings_su_request_45">45 sekund</string>
     <string name="settings_su_request_60">60 sekund</string>
     <string name="superuser_access">Dostęp Superuser</string>
     <string name="auto_response">Automatyczna Odpowiedź</string>

--- a/app/src/full/res/values-pt-rBR/strings.xml
+++ b/app/src/full/res/values-pt-rBR/strings.xml
@@ -143,8 +143,10 @@
     <string name="settings_su_adb">ADB apenas</string>
     <string name="settings_su_disable">Desativado</string>
     <string name="settings_su_request_10">10 segundos</string>
+    <string name="settings_su_request_15">15 segundos</string>
     <string name="settings_su_request_20">20 segundos</string>
     <string name="settings_su_request_30">30 segundos</string>
+    <string name="settings_su_request_45">45 segundos</string>
     <string name="settings_su_request_60">60 segundos</string>
     <string name="superuser_access">Acesso de Superusuário</string>
     <string name="auto_response">Resposta Automática</string>

--- a/app/src/full/res/values-pt-rPT/strings.xml
+++ b/app/src/full/res/values-pt-rPT/strings.xml
@@ -112,8 +112,10 @@
     <string name="settings_su_adb">Somente ADB</string>
     <string name="settings_su_disable">Desativado</string>
     <string name="settings_su_request_10">10 segundos</string>
+    <string name="settings_su_request_15">15 segundos</string>
     <string name="settings_su_request_20">20 segundos</string>
     <string name="settings_su_request_30">30 segundos</string>
+    <string name="settings_su_request_45">45 segundos</string>
     <string name="settings_su_request_60">60 segundos</string>
     <string name="superuser_access">Acesso de root</string>
     <string name="auto_response">Resposta Automática</string>

--- a/app/src/full/res/values-ro/strings.xml
+++ b/app/src/full/res/values-ro/strings.xml
@@ -135,8 +135,10 @@
     <string name="settings_su_adb">Doar ADB</string>
     <string name="settings_su_disable">Dezactivat</string>
     <string name="settings_su_request_10">10 secunde</string>
+    <string name="settings_su_request_15">15 de secunde</string>
     <string name="settings_su_request_20">20 de secunde</string>
     <string name="settings_su_request_30">30 de secunde</string>
+    <string name="settings_su_request_45">45 de secunde</string>
     <string name="settings_su_request_60">60 de secunde</string>
     <string name="superuser_access">Acces Superuser</string>
     <string name="auto_response">Răspuns automat</string>

--- a/app/src/full/res/values-ru/strings.xml
+++ b/app/src/full/res/values-ru/strings.xml
@@ -153,8 +153,10 @@
     <string name="settings_su_adb">Только ADB</string>
     <string name="settings_su_disable">Отключен</string>
     <string name="settings_su_request_10">10 секунд</string>
+    <string name="settings_su_request_15">15 секунд</string>
     <string name="settings_su_request_20">20 секунд</string>
     <string name="settings_su_request_30">30 секунд</string>
+    <string name="settings_su_request_45">45 секунд</string>
     <string name="settings_su_request_60">60 секунд</string>
     <string name="superuser_access">Уровень доступа</string>
     <string name="auto_response">Автоматический ответ</string>

--- a/app/src/full/res/values-sk/strings.xml
+++ b/app/src/full/res/values-sk/strings.xml
@@ -152,8 +152,10 @@
     <string name="settings_su_adb">Iba ADB</string>
     <string name="settings_su_disable">Zakázané</string>
     <string name="settings_su_request_10">10 sekúnd</string>
+    <string name="settings_su_request_15">15 sekúnd</string>
     <string name="settings_su_request_20">20 sekúnd</string>
     <string name="settings_su_request_30">30 sekúnd</string>
+    <string name="settings_su_request_45">45 sekúnd</string>
     <string name="settings_su_request_60">60 sekúnd</string>
     <string name="superuser_access">Prístup Superuser</string>
     <string name="auto_response">Automatická odpoveď</string>

--- a/app/src/full/res/values-sr/strings.xml
+++ b/app/src/full/res/values-sr/strings.xml
@@ -130,8 +130,10 @@
     <string name="settings_su_adb">Само АДБ</string>
     <string name="settings_su_disable">Онемогућено</string>
     <string name="settings_su_request_10">10 секунди</string>
+    <string name="settings_su_request_15">15 секунди</string>
     <string name="settings_su_request_20">20 секунди</string>
     <string name="settings_su_request_30">30 секунди</string>
+    <string name="settings_su_request_45">45 секунди</string>
     <string name="settings_su_request_60">60 секунди</string>
     <string name="superuser_access">Приступ Супер-кориснику</string>
     <string name="auto_response">Аутоматски одговор</string>

--- a/app/src/full/res/values-sv/strings.xml
+++ b/app/src/full/res/values-sv/strings.xml
@@ -97,8 +97,10 @@
     <string name="settings_su_adb">Endast ADB</string>
     <string name="settings_su_disable">Inaktiverad</string>
     <string name="settings_su_request_10">10 sekunder</string>
+    <string name="settings_su_request_15">15 sekunder</string>
     <string name="settings_su_request_20">20 sekunder</string>
     <string name="settings_su_request_30">30 sekunder</string>
+    <string name="settings_su_request_45">45 sekunder</string>
     <string name="settings_su_request_60">60 sekunder</string>
     <string name="superuser_access">Superuser-tillgång</string>
     <string name="auto_response">Automatiskt svar</string>

--- a/app/src/full/res/values-tr/strings.xml
+++ b/app/src/full/res/values-tr/strings.xml
@@ -153,8 +153,10 @@
     <string name="settings_su_adb">Sadece ADB</string>
     <string name="settings_su_disable">Devre dışı</string>
     <string name="settings_su_request_10">10 saniye</string>
+    <string name="settings_su_request_15">15 saniye</string>
     <string name="settings_su_request_20">20 saniye</string>
     <string name="settings_su_request_30">30 saniye</string>
+    <string name="settings_su_request_45">45 saniye</string>
     <string name="settings_su_request_60">60 saniye</string>
     <string name="superuser_access">Yetkili Kullanıcı Erişimi</string>
     <string name="auto_response">Otomatik Yanıt</string>

--- a/app/src/full/res/values-uk/strings.xml
+++ b/app/src/full/res/values-uk/strings.xml
@@ -153,8 +153,10 @@
     <string name="settings_su_adb">ADB</string>
     <string name="settings_su_disable">Вимкнено</string>
     <string name="settings_su_request_10">10 секунд</string>
+    <string name="settings_su_request_15">15 секунд</string>
     <string name="settings_su_request_20">20 секунд</string>
     <string name="settings_su_request_30">30 секунд</string>
+    <string name="settings_su_request_45">45 секунд</string>
     <string name="settings_su_request_60">60 секунд</string>
     <string name="superuser_access">Доступ суперкористувача</string>
     <string name="auto_response">Автоматична відповідь</string>

--- a/app/src/full/res/values-vi/strings.xml
+++ b/app/src/full/res/values-vi/strings.xml
@@ -89,8 +89,10 @@
     <string name="settings_su_adb">Chỉ ADB</string>
     <string name="settings_su_disable">Đã vô hiệu</string>
     <string name="settings_su_request_10">10 giây</string>
+    <string name="settings_su_request_15">15 giây</string>
     <string name="settings_su_request_20">20 giây</string>
     <string name="settings_su_request_30">30 giây</string>
+    <string name="settings_su_request_45">45 giây</string>
     <string name="settings_su_request_60">60 giây</string>
     <string name="superuser_access">Truy nhập Superuser</string>
     <string name="auto_response">Tự phản hồi</string>

--- a/app/src/full/res/values-zh-rCN/strings.xml
+++ b/app/src/full/res/values-zh-rCN/strings.xml
@@ -153,8 +153,10 @@
     <string name="settings_su_adb">仅 ADB</string>
     <string name="settings_su_disable">已禁用</string>
     <string name="settings_su_request_10">10 秒</string>
+    <string name="settings_su_request_15">15 秒</string>
     <string name="settings_su_request_20">20 秒</string>
     <string name="settings_su_request_30">30 秒</string>
+    <string name="settings_su_request_45">45 秒</string>
     <string name="settings_su_request_60">60 秒</string>
     <string name="superuser_access">超级用户访问权限</string>
     <string name="auto_response">自动响应</string>

--- a/app/src/full/res/values-zh-rTW/strings.xml
+++ b/app/src/full/res/values-zh-rTW/strings.xml
@@ -83,8 +83,10 @@
     <string name="settings_su_adb">僅 ADB</string>
     <string name="settings_su_disable">已禁用</string>
     <string name="settings_su_request_10">10 秒</string>
+    <string name="settings_su_request_15">15 秒</string>
     <string name="settings_su_request_20">20 秒</string>
     <string name="settings_su_request_30">30 秒</string>
+    <string name="settings_su_request_45">45 秒</string>
     <string name="settings_su_request_60">60 秒</string>
     <string name="superuser_access">超級用戶訪問權限</string>
     <string name="auto_response">自動回應</string>

--- a/app/src/full/res/values/arrays.xml
+++ b/app/src/full/res/values/arrays.xml
@@ -25,15 +25,19 @@
 
     <string-array name="request_timeout">
         <item>@string/settings_su_request_10</item>
+        <item>@string/settings_su_request_15</item>
         <item>@string/settings_su_request_20</item>
         <item>@string/settings_su_request_30</item>
+        <item>@string/settings_su_request_45</item>
         <item>@string/settings_su_request_60</item>
     </string-array>
 
     <string-array name="request_timeout_value">
         <item>10</item>
+        <item>15</item>
         <item>20</item>
         <item>30</item>
+        <item>45</item>
         <item>60</item>
     </string-array>
 

--- a/app/src/full/res/values/strings.xml
+++ b/app/src/full/res/values/strings.xml
@@ -153,8 +153,10 @@
     <string name="settings_su_adb">ADB only</string>
     <string name="settings_su_disable">Disabled</string>
     <string name="settings_su_request_10">10 seconds</string>
+    <string name="settings_su_request_15">15 seconds</string>
     <string name="settings_su_request_20">20 seconds</string>
     <string name="settings_su_request_30">30 seconds</string>
+    <string name="settings_su_request_45">45 seconds</string>
     <string name="settings_su_request_60">60 seconds</string>
     <string name="superuser_access">Superuser Access</string>
     <string name="auto_response">Automatic Response</string>


### PR DESCRIPTION
I prefer a 15 second time-out. 10 is sometimes a little too short, particularly when Magisk is hidden behind AppLock or similar and a PIN or a fingerprint is required before one can grant permission.

45 seconds added, too, just for a little extra granularity.