### PR TITLE
Fix SIGWINCH never called

### DIFF
--- a/native/jni/su/pts.cpp
+++ b/native/jni/su/pts.cpp
@@ -216,8 +216,11 @@ static void *watch_sigwinch(void *data) {
 
 		// Set the new terminal size
 		ioctl(slave, TIOCSWINSZ, &w);
+		
+		// sleep 500 milliseconds (0.5 sec)
+		usleep(500);
 
-	} while (sigwait(&winch, &sig) == 0);
+	} while (1); //while (sigwait(&winch, &sig) == 0); dont work.
 
 	free(data);
 	return NULL;

--- a/native/jni/su/pts.cpp
+++ b/native/jni/su/pts.cpp
@@ -217,8 +217,8 @@ static void *watch_sigwinch(void *data) {
 		// Set the new terminal size
 		ioctl(slave, TIOCSWINSZ, &w);
 		
-		// sleep 500 milliseconds (0.5 sec)
-		usleep(500);
+		// sleep 300000 microseconds (0.3 sec)
+		usleep(300000);
 
 	} while (1); //while (sigwait(&winch, &sig) == 0); dont work.
 


### PR DESCRIPTION
Remove sigwait(&winch, &sig) because it is never handled, with this simple hack we are able to properly handle SIGWINCH from all terminal emulators, turn while loop ever true to prevent fails and force get size and resize.