### PR TITLE
Make onResult use main thread

### DIFF
--- a/core/src/main/java/com/topjohnwu/core/tasks/FlashZip.java
+++ b/core/src/main/java/com/topjohnwu/core/tasks/FlashZip.java
@@ -70,12 +70,14 @@ public abstract class FlashZip {
 
     public void exec() {
         AsyncTask.THREAD_POOL_EXECUTOR.execute(() -> {
-            boolean success = false;
             try {
-                success = flash();
-            } catch (IOException ignored) {}
-            Shell.su("cd /", "rm -rf " + tmpFile.getParent() + " " + Const.TMP_FOLDER_PATH).submit();
-            onResult(success);
+                boolean success = flash();
+                Shell.su("cd /", "rm -rf " + tmpFile.getParent() + " " + Const.TMP_FOLDER_PATH).submit();
+                App.mainHandler.post(() -> onResult(success));
+            } catch (IOException ignored) {
+                Shell.su("cd /", "rm -rf " + tmpFile.getParent() + " " + Const.TMP_FOLDER_PATH).submit();
+                App.mainHandler.post(() -> onResult(false));
+            }
         });
     }
 


### PR DESCRIPTION
```
12-19 00:40:00.802 30490 30559 E AndroidRuntime: FATAL EXCEPTION: AsyncTask #1
12-19 00:40:00.802 30490 30559 E AndroidRuntime: Process: com.topjohnwu.magisk, PID: 30490
12-19 00:40:00.802 30490 30559 E AndroidRuntime: android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:7753)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.ViewRootImpl.requestLayout(ViewRootImpl.java:1225)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.View.requestLayout(View.java:23093)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.View.requestLayout(View.java:23093)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.View.requestLayout(View.java:23093)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.View.requestLayout(View.java:23093)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.View.requestLayout(View.java:23093)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.View.requestLayout(View.java:23093)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.View.requestLayout(View.java:23093)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.View.setFlags(View.java:14102)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at android.view.View.setVisibility(View.java:9992)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at com.topjohnwu.magisk.FlashActivity$FlashModule.onResult(FlashActivity.java:173)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at com.topjohnwu.core.tasks.FlashZip.lambda$exec$0(FlashZip.java:78)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at com.topjohnwu.core.tasks.-$$Lambda$FlashZip$qp5OwQCFoDFp7_LSXgCUpqJ0d5s.run(Unknown Source:2)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
12-19 00:40:00.802 30490 30559 E AndroidRuntime:        at java.lang.Thread.run(Thread.java:764)
```