### PR TITLE
Add config.prop path to ZipSigner build properties

### DIFF
--- a/build.py
+++ b/build.py
@@ -109,7 +109,7 @@ def sign_zip(unsigned, output, release):
 
 	if not os.path.exists(zipsigner):
 		header('* Building ' + signer_name)
-		proc = execv([gradlew, 'utils:shadowJar'])
+		proc = execv([gradlew, 'utils:shadowJar', '-PconfigPath=' + os.path.abspath(args.config)])
 		if proc.returncode != 0:
 			error('Build {} failed!'.format(signer_name))
 


### PR DESCRIPTION
Building with a custom config.prop file causes the ZipSigner build to fail.
```
$ python build.py --verbose --config ./test.conf all

...

* Building zipsigner-3.0.jar

Parallel execution is an incubating feature.

> Configure project :app
Project evaluation failed including an error in afterEvaluate {}. Run with --stacktrace for details of the afterEvaluate {} error.


FAILURE: Build failed with an exception.

* Where:
Build file '/Users/tlamb96/Magisk/app/build.gradle' line: 5

* What went wrong:
A problem occurred evaluating project ':app'.
> /Users/tlamb96/Magisk/config.prop (No such file or directory)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s

Build zipsigner-3.0.jar failed!
```
This PR fixes this issue by adding the config path to ZipSigner's Gradle build properties.