### PR TITLE
Support EMUI 9 on hi3660 as well

### DIFF
--- a/native/jni/misc/init.cpp
+++ b/native/jni/misc/init.cpp
@@ -93,6 +93,9 @@ static void parse_cmdline(struct cmdline *cmd) {
 			sscanf(tok, "enter_recovery=%d", &enter_recovery);
 		} else if (strncmp(tok, "androidboot.hardware", 20) == 0) {
 			kirin = strstr(tok, "kirin") != nullptr;
+			if (kirin == false) {
+				kirin = strstr(tok, "hi3660") != nullptr;
+			}
 		}
 	}
 


### PR DESCRIPTION
So, with the Mate 9 release of EMUI 9, I pulled it down here today to install it.

After much poking at my device, it finally installed (rebranding is such fun); but then I go to install Magisk. Follow the instructions, reboot holding down volume-up with no power cable attached - it reboots into recovery, instead of bypassing recovery to boot into EMUI.

Start looking at the code and I find that magiskinit is checking for "androidboot.hardware=kirin..."; this fails on the Mate 9 and other Kirin 960 devices, as it's hardware name is "hi3660", not "kirin970" or "kirin980".

To make sure this worked, I did a binary patch of magiskinit (changing "kirin" to "hi366"), which had the desired result - rooted EMUI 9 on Kirin 960.
