### PR TITLE
Fix multi-user issue

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/container/Policy.java
+++ b/app/src/main/java/com/topjohnwu/magisk/container/Policy.java
@@ -24,9 +24,9 @@ public class Policy implements Comparable<Policy>{
         String[] pkgs = pm.getPackagesForUid(uid);
         if (pkgs == null || pkgs.length == 0)
             throw new PackageManager.NameNotFoundException();
-        this.uid = uid;
         packageName = pkgs[0];
-        info = pm.getApplicationInfo(packageName, 0);
+        info = pm.getApplicationInfo(packageName, PackageManager.GET_UNINSTALLED_PACKAGES);
+        this.uid = info.uid;
         appName = Utils.getAppLabel(info, pm);
     }
 
@@ -37,7 +37,7 @@ public class Policy implements Comparable<Policy>{
         until = values.getAsInteger("until");
         logging = values.getAsInteger("logging") != 0;
         notification = values.getAsInteger("notification") != 0;
-        info = pm.getApplicationInfo(packageName, 0);
+        info = pm.getApplicationInfo(packageName, PackageManager.GET_UNINSTALLED_PACKAGES);
         if (info.uid != uid)
             throw new PackageManager.NameNotFoundException();
         appName = info.loadLabel(pm).toString();

--- a/native/jni/su/connect.cpp
+++ b/native/jni/su/connect.cpp
@@ -65,9 +65,7 @@ void app_log(struct su_context *ctx) {
 	setup_user(user, ctx->info);
 
 	char fromUid[8];
-	sprintf(fromUid, "%d",
-			ctx->info->cfg[SU_MULTIUSER_MODE] == MULTIUSER_MODE_OWNER_MANAGED ?
-			ctx->info->uid % 100000 : ctx->info->uid);
+	sprintf(fromUid, "%d", ctx->info->uid);
 
 	char toUid[8];
 	sprintf(toUid, "%d", ctx->req.uid);


### PR DESCRIPTION
fix #848 
`GET_UNINSTALLED_PACKAGES` flag can match other user's apps, and the `info.uid` is this user's uid.