### PR TITLE
Fix cat: write error

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -252,7 +252,7 @@ sign_chromeos() {
 }
 
 is_mounted() {
-  cat /proc/mounts | grep -q " `readlink -f $1` " 2>/dev/null
+  grep -q " `readlink -f $1` " /proc/mounts 2>/dev/null
   return $?
 }
 


### PR DESCRIPTION
Eliminates `cat: write error`

https://stackoverflow.com/questions/49664991/why-am-i-getting-cat-write-error-broken-pipe-rarely-and-not-always