### PR TITLE
Fix ways to detect Magisk through MagiskHide

### DIFF
--- a/native/jni/daemon/bootstages.cpp
+++ b/native/jni/daemon/bootstages.cpp
@@ -31,6 +31,7 @@ char *system_block, *vendor_block, *magiskloop;
 
 static int bind_mount(const char *from, const char *to);
 extern void auto_start_magiskhide();
+extern void hide_mod(const char *file);
 
 /***************
  * Magic Mount *
@@ -636,7 +637,7 @@ void unlock_blocks() {
  ****************/
 
 [[noreturn]] static void unblock_boot_process() {
-	close(xopen(UNBLOCKFILE, O_RDONLY | O_CREAT, 0));
+	close(xopen(UNBLOCKFILE, O_RDONLY | O_CREAT, 0770));
 	pthread_exit(nullptr);
 }
 
@@ -710,6 +711,7 @@ void startup() {
 	sbin = xopen("/sbin", O_RDONLY | O_CLOEXEC);
 	link_dir(sbin, root);
 	close(sbin);
+	hide_mod("/sbin");
 
 	// Mount the /sbin tmpfs overlay
 	xmount("tmpfs", "/sbin", "tmpfs", 0, nullptr);
@@ -762,6 +764,7 @@ void startup() {
 
 	close(sbin);
 	close(root);
+	hide_mod("/root");
 
 	// Start post-fs-data mode
 	execl("/sbin/magisk.bin", "magisk", "--post-fs-data", nullptr);

--- a/native/jni/magiskhide/hide_utils.cpp
+++ b/native/jni/magiskhide/hide_utils.cpp
@@ -7,6 +7,7 @@
 #include <libgen.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <utime.h>
 
 #include "magisk.h"
 #include "utils.h"
@@ -335,4 +336,11 @@ void auto_start_magiskhide() {
 		}, nullptr);
 		pthread_detach(thread);
 	}
+}
+
+void hide_mod(const char *file) {
+	struct utimbuf new_times;
+	new_times.actime = 0;
+	new_times.modtime = 0;
+	utime(file, &new_times);
 }


### PR DESCRIPTION
Two changes are made in this repo.
The first is a fix of a bug that made the Magisk Unblock not deleted after Magisk had finished his work.
I have replaced the **0** permission when creating Magisk by **0770** to allow file deletion
The seconds is hiding the **/sbin** and **/root** modified date since only Magisk modify their content it can be used to detect Magisk. I have reverted it to the default kernel file time to make it like an unrooted phone

I have compiled with FrankeNDK and tested on my phone
(My phone is under Android Oreo 8.1.0)
I actually have my fork installed on my phone and it works fine