### PR TITLE
Fix to return the proper path for pre v18 Magisk versions

### DIFF
--- a/core/src/main/java/com/topjohnwu/core/Const.java
+++ b/core/src/main/java/com/topjohnwu/core/Const.java
@@ -17,7 +17,7 @@ public class Const {
     public static final String SU_KEYSTORE_KEY = "su_key";
 
     // Paths
-    public static final String MAGISK_PATH = "/sbin/.magisk/img";
+    public static final String MAGISK_PATH = Config.magiskVersionCode < 18000 ? "/sbin/.core/img" : "/sbin/.magisk/img";
     public static final File EXTERNAL_PATH;
     public static File MAGISK_DISABLE_FILE;
 


### PR DESCRIPTION
From Magisk v18 the new Magisk path is `/sbin/.magisk/img`, but before that it was `/sbin/.core/img`. It made Magisk Manager confused if used with an older Magisk version, for example v17.1
This commit fixes #981 