### PR TITLE
Setuid after read proc

### DIFF
--- a/native/jni/su/su_daemon.cpp
+++ b/native/jni/su/su_daemon.cpp
@@ -335,7 +335,6 @@ void su_daemon_handler(int client, struct ucred *credential) {
 
 		// Setup environment
 		umask(022);
-		set_identity(ctx.req.uid);
 		char path[32], buf[4096];
 		snprintf(path, sizeof(path), "/proc/%d/cwd", ctx.pid);
 		xreadlink(path, buf, sizeof(buf));
@@ -363,6 +362,7 @@ void su_daemon_handler(int client, struct ucred *credential) {
 			}
 		}
 
+		set_identity(ctx.req.uid);
 		execvp(ctx.req.shell, (char **) argv);
 		fprintf(stderr, "Cannot execute %s: %s\n", ctx.req.shell, strerror(errno));
 		PLOGE("exec");


### PR DESCRIPTION
```
$ su
:/sdcard # su 2000
1|:/sdcard # id
uid=0(root) gid=0(root) groups=0(root) context=u:r:magisk:s0
:/sdcard #
```
log:
```
02-01 18:37:30.318 10492 23822 D Magisk  : su: request from pid=[23821], client=[14]
02-01 18:37:30.318 10492 23822 D Magisk  : su: request from uid=[10115] (#1)
02-01 18:37:30.318 10492 23822 D Magisk  : magiskdb: query su_fingerprint=[0]
02-01 18:37:30.318 10492 23822 D Magisk  : magiskdb: query magiskhide=[1]
02-01 18:37:30.319 10492 23822 D Magisk  : magiskdb: query policy=[2] log=[1] notify=[1]
02-01 18:37:30.320 10492 23822 D Magisk  : su: waiting child pid=[23823]
02-01 18:37:30.320 23823 23823 D Magisk  : su: fork handler
02-01 18:37:30.320 23823 23823 D Magisk  : su: pts_slave=[/dev/pts/1]
02-01 18:37:30.321 23823 23823 D Magisk  : su: use namespace of pid=[23821]
02-01 18:37:30.325 23823 23823 E Magisk  : readlink /proc/23821/cwd failed with 2: No such file or directory
02-01 18:37:30.327 10492 23822 D Magisk  : su: return code=[1]
```
`/proc` has `hidepid=2`, so it will return `No such file or directory`if uid isn't root. We can only use root and cannot be other users.