### PR TITLE
Updated French translation

### DIFF
--- a/app/src/full/res/values-fr/strings.xml
+++ b/app/src/full/res/values-fr/strings.xml
@@ -7,6 +7,8 @@
     <string name="log">Journal</string>
     <string name="settings">Paramètres</string>
     <string name="install">Installer</string>
+    <string name="unsupport_magisk_title">Version de Magisk non prise en charge</string>
+    <string name="unsupport_magisk_message">Cette version of Magisk Manager ne prend pas en charge les versions de Magisk antérieures à 18.0.\n\nVous pouvez soit mettre à jour Magisk manuellement, soit rétrograder la version de l’application Magisk Manager.</string>
 
     <!--Status Fragment-->
     <string name="magisk_version_error">Magisk n’est pas installé.</string>
@@ -28,7 +30,7 @@
     <string name="uninstall_magisk_title">Désinstaller Magisk</string>
     <string name="uninstall_magisk_msg">Tous les modules seront désactivés ou supprimés. Les permissions de super‐utilisateur seront perdues et vos données seront potentiellement chiffrées si elles ne le sont pas déjà.</string>
     <string name="update">Mise à jour</string>
-    <string name="core_only_enabled">(Mode noyau uniquement activé)</string>
+    <string name="core_only_enabled">(mode « sans modules » activé)</string>
 
     <!--Module Fragment-->
     <string name="no_info_provided">(aucune information transmise)</string>
@@ -182,7 +184,7 @@
     <string name="android_o_not_support">Android 8.0 et supérieurs ne sont pas pris en charge.</string>
     <string name="disable_fingerprint">Aucune empreinte digitale n’a été définie ou le lecteur d’empreinte n’est pas pris en charge.</string>
 
-<!--Superuser-->
+    <!--Superuser-->
     <string name="su_request_title">Requête super‐utilisateur</string>
     <string name="deny_with_str">Refuser %1$s</string>
     <string name="deny">Refuser</string>
@@ -212,7 +214,11 @@
     <string name="auth_fail">Échec de l’authentification</string>
 
     <!--Superuser logs-->
+    <string name="pid">PID : %1$d</string>
     <string name="target_uid">UID cible : %1$d</string>
     <string name="command">Commande : %1$s</string>
+
+    <!-- MagiskHide -->
+    <string name="show_system_app">Afficher les applications système</string>
 
 </resources>


### PR DESCRIPTION
- added three missing strings (unsupport_magisk_title, unsupport_magisk_message and show_system_app)
- add “pid” string even if it is marked as not translatable, just to ease comparison
- better meaning for core_only_enabled string translation
- indent XML comment <!--Superuser logs-->