### PR TITLE
Support Direct Boot

### DIFF
--- a/app-core/src/main/java/com/topjohnwu/magisk/App.java
+++ b/app-core/src/main/java/com/topjohnwu/magisk/App.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.preference.PreferenceManager;
 
 import com.topjohnwu.magisk.core.BuildConfig;
@@ -40,9 +41,18 @@ public class App extends Application {
         super.attachBaseContext(base);
         self = this;
 
-        prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        Context deContext;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            deContext = base.createDeviceProtectedStorageContext();
+            deContext.moveSharedPreferencesFrom(base,
+                    PreferenceManager.getDefaultSharedPreferencesName(base));
+            deContext.moveDatabaseFrom(base, "repo.db");
+        } else {
+            deContext = base;
+        }
+        prefs = PreferenceManager.getDefaultSharedPreferences(deContext);
+        repoDB = new RepoDatabaseHelper(deContext);
         mDB = new MagiskDB(this);
-        repoDB = new RepoDatabaseHelper(this);
 
         Networking.init(this);
         LocaleManager.setLocale(this);

--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -5,7 +5,6 @@
 
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:name="a.e"
@@ -39,6 +38,7 @@
 
         <activity
             android:name="a.m"
+            android:directBootAware="true"
             android:excludeFromRecents="true"
             android:launchMode="singleTask"
             android:taskAffinity="internal.superuser"
@@ -46,7 +46,8 @@
 
         <!-- Receiver -->
 
-        <receiver android:name="a.h">
+        <receiver android:name="a.h"
+            android:directBootAware="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.LOCALE_CHANGED" />

--- a/app/src/full/java/com/topjohnwu/magisk/SuRequestActivity.java
+++ b/app/src/full/java/com/topjohnwu/magisk/SuRequestActivity.java
@@ -21,6 +21,7 @@ import com.topjohnwu.magisk.components.BaseActivity;
 import com.topjohnwu.magisk.container.Policy;
 import com.topjohnwu.magisk.utils.FingerprintHelper;
 import com.topjohnwu.magisk.utils.SuConnector;
+import com.topjohnwu.magisk.utils.Utils;
 
 import java.io.IOException;
 
@@ -75,7 +76,7 @@ public class SuRequestActivity extends BaseActivity {
 
         PackageManager pm = getPackageManager();
         app.mDB.clearOutdated();
-        timeoutPrefs = getSharedPreferences("su_timeout", 0);
+        timeoutPrefs = Utils.getDEContext().getSharedPreferences("su_timeout", 0);
 
         // Get policy
         Intent intent = getIntent();

--- a/app/src/full/java/com/topjohnwu/magisk/fragments/SettingsFragment.java
+++ b/app/src/full/java/com/topjohnwu/magisk/fragments/SettingsFragment.java
@@ -42,6 +42,9 @@ public class SettingsFragment extends BasePreferenceFragment implements Topic.Su
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            getPreferenceManager().setStorageDeviceProtected();
+        }
         setPreferencesFromResource(R.xml.app_settings, rootKey);
         requireActivity().setTitle(R.string.settings);
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <application
         android:installLocation="internalOnly"
         android:allowBackup="true"
-        android:directBootAware="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
#1018 
only system app can set android:directBootAware="true" at the application level.
for support direct boot, app need use de storage.

now, manager can log su and start request activity  before unlock