### PR TITLE
fix extract_bb

### DIFF
--- a/scripts/update_binary.sh
+++ b/scripts/update_binary.sh
@@ -4,7 +4,7 @@ extract_bb() {
   touch "$BBBIN"
   chmod 755 "$BBBIN"
   dd if="$0" of="$BBBIN" bs=1024 skip=$(($X86_CNT + 1))
-  "./$BBBIN" >/dev/null || dd if="$0" of="$BBBIN" bs=1024 skip=1 count=$X86_CNT
+  "$BBBIN" >/dev/null || dd if="$0" of="$BBBIN" bs=1024 skip=1 count=$X86_CNT
 }
 setup_bb() {
   BBDIR=$TMPDIR/bin


### PR DESCRIPTION
```
# BBBIN=/dev/tmp/bin/busybox
# "./$BBBIN" >/dev/null || echo x86
/system/bin/sh: .//dev/tmp/bin/busybox: not found
x86
# 
```