### PR TITLE
early boot magisk hide extension for sony ric daemon

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -638,6 +638,10 @@ static const char wrapper[] =
 "unset LD_PRELOAD\n"
 "exec /sbin/magisk.bin \"${0##*/}\" \"$@\"\n";
 
+static const char ric_wrapper[] =
+"#!/system/bin/sh\n"
+"exec /sbin/magiskhide --exec /sbin/ric \"$@\"\n";
+
 void startup() {
 	android_logging();
 	if (!check_data())
@@ -749,6 +753,12 @@ void startup() {
 	while((entry = xreaddir(dir))) {
 		if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;
 		snprintf(buf, PATH_MAX, "/root/%s", entry->d_name);
+		if (strcmp(entry->d_name, "ric") == 0) {
+			fd = creat("/sbin/ric", 0750);
+			xwrite(fd, ric_wrapper, sizeof(ric_wrapper) - 1);
+			close(fd);
+			continue;
+		}
 		xsymlinkat(buf, sbin, entry->d_name);
 	}
 

--- a/native/jni/magiskhide/magiskhide.h
+++ b/native/jni/magiskhide/magiskhide.h
@@ -23,6 +23,7 @@ void proc_monitor();
 void manage_selinux();
 void hide_sensitive_props();
 void clean_magisk_props();
+void do_hide_daemon(int pid);
 
 // List managements
 int add_list(const char *proc);
@@ -39,6 +40,7 @@ enum {
 	RM_HIDELIST,
 	LS_HIDELIST,
 	HIDE_STATUS,
+	EXEC_CMD,
 };
 
 enum {

--- a/native/jni/magiskhide/proc_monitor.cpp
+++ b/native/jni/magiskhide/proc_monitor.cpp
@@ -64,17 +64,9 @@ static int parse_ppid(int pid) {
 	return ppid;
 }
 
-static void hide_daemon(int pid) {
-	LOGD("hide_daemon: handling pid=[%d]\n", pid);
-
+void do_hide_daemon(int pid) {
 	char buffer[4096];
 	vector<string> mounts;
-
-	manage_selinux();
-	clean_magisk_props();
-
-	if (switch_mnt_ns(pid))
-		goto exit;
 
 	snprintf(buffer, sizeof(buffer), "/proc/%d", pid);
 	chdir(buffer);
@@ -100,8 +92,20 @@ static void hide_daemon(int pid) {
 			lazy_unmount(buffer);
 		}
 	}
+}
 
-exit:
+
+static void hide_daemon(int pid) {
+	LOGD("hide_daemon: handling pid=[%d]\n", pid);
+
+	manage_selinux();
+	clean_magisk_props();
+
+	if (switch_mnt_ns(pid))
+		return;
+
+	do_hide_daemon(pid);
+
 	// Send resume signal
 	kill(pid, SIGCONT);
 	_exit(0);


### PR DESCRIPTION
This might be a bit specific to sony xperia xz1c/xz1/xzp phones with oreo fw, but maybe you can use at least the "extend magiskhide with exec option" commit and possibly implement a more generalized solution for the "detect sony ric daemon and hide magisk from it on boot" commit.
These two commits allow to do FOTA system update with unlocked bootloader on sony xperia xz1c/xz1/xzp phones with oreo fw if running a patched kernel which masks unlocked state in response from Trust Zone. The kernel is not flashed but booted from usb via 'fastboot boot' instead, having magisk root before and after fota.
For more details please see here:
https://forum.xda-developers.com/xperia-xz1-compact/development/rooted-kernel-hiding-bootloader-unlock-t3898711
Thank you very much for your excellent magisk tools.