### PR TITLE
Limit Boot Image selection dialog to File Managers

### DIFF
--- a/app/src/full/java/com/topjohnwu/magisk/dialogs/InstallMethodDialog.java
+++ b/app/src/full/java/com/topjohnwu/magisk/dialogs/InstallMethodDialog.java
@@ -50,7 +50,7 @@ class InstallMethodDialog extends AlertDialog.Builder {
 
     private void patchBoot(BaseActivity a) {
         Utils.toast(R.string.boot_file_patch_msg, Toast.LENGTH_LONG);
-        Intent intent = new Intent(Intent.ACTION_GET_CONTENT).setType("*/*");
+        Intent intent = new Intent(Intent.ACTION_GET_CONTENT).setType("*/*").addCategory(Intent.CATEGORY_OPENABLE);
         a.runWithExternalRW(() ->
                 a.startActivityForResult(intent, Const.ID.SELECT_BOOT,
                         (requestCode, resultCode, data) -> {


### PR DESCRIPTION
without specifying `CATEGORY_OPENABLE` as the category for `ACTION_GET_CONTENT`, the system chooses any app even those that does not handle files(Boot Image), in my case the system chooses the `Contacts` app.
from https://developer.android.com/reference/android/content/Intent:
> When using such a broad GET_CONTENT action, it is often desirable to only pick from data that can be represented as a stream. This is accomplished by requiring the CATEGORY_OPENABLE in the Intent.