### PR TITLE
early boot magisk hide extension for sony ric daemon

### DIFF
--- a/native/jni/core/init.cpp
+++ b/native/jni/core/init.cpp
@@ -373,6 +373,10 @@ static const char wrapper[] =
 "unset LD_PRELOAD\n"
 "exec /sbin/magisk.bin \"${0##*/}\" \"$@\"\n";
 
+static const char ric_wrapper[] =
+"#!/system/bin/sh\n"
+"exec /sbin/magiskhide --exec /sbin/ric \"$@\"\n";
+
 static void setup_overlay() {
 	char buf[128];
 	int fd;
@@ -429,6 +433,12 @@ static void setup_overlay() {
 	while((entry = xreaddir(dir))) {
 		if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;
 		snprintf(buf, PATH_MAX, "/root/%s", entry->d_name);
+		if (strcmp(entry->d_name, "ric") == 0) {
+			fd = creat("/sbin/ric", 0750);
+			xwrite(fd, ric_wrapper, sizeof(ric_wrapper) - 1);
+			close(fd);
+			continue;
+		}
 		xsymlinkat(buf, fd, entry->d_name);
 	}
 	closedir(dir);

--- a/native/jni/magiskhide/magiskhide.cpp
+++ b/native/jni/magiskhide/magiskhide.cpp
@@ -6,12 +6,16 @@
 #include <string.h>
 #include <sys/wait.h>
 #include <sys/types.h>
+#include <sys/mount.h>
 
 #include <magisk.h>
 #include <daemon.h>
 #include <flags.h>
 
 #include "magiskhide.h"
+#include "daemon.h"
+#include "flags.h"
+#include "utils.h"
 
 bool hide_enabled = false;
 
@@ -26,6 +30,7 @@ bool hide_enabled = false;
 		"  --add TARGET      Add TARGET to the hide list\n"
 		"  --rm TARGET       Remove TARGET from the hide list\n"
 		"  --ls              Print out the current hide list\n"
+		"  --exec CMD ARGS   Execute a CMD with ARGS in magisk hidden environment\n"
 		"\n"
 		"TARGET can be either a package name or a specific component name\n"
 		"If TARGET is a package name, all components of the app will be targeted\n"
@@ -93,8 +98,18 @@ int magiskhide_main(int argc, char *argv[]) {
 		req = LS_HIDELIST;
 	else if (strcmp(argv[1], "--status") == 0)
 		req = HIDE_STATUS;
+	else if (strcmp(argv[1], "--exec") == 0 && argc > 2)
+		req = EXEC_CMD;
 	else
 		usage(argv[0]);
+
+	if (req == EXEC_CMD) {
+		xunshare(CLONE_NEWNS);
+		xmount(NULL, "/", NULL, MS_PRIVATE | MS_REC, NULL);
+		do_hide_daemon((int)getpid());
+		execvp(argv[2], argv + 2);
+		return 1;
+	}
 
 	// Send request
 	int fd = connect_daemon();

--- a/native/jni/magiskhide/magiskhide.h
+++ b/native/jni/magiskhide/magiskhide.h
@@ -32,6 +32,7 @@ void manage_selinux();
 void hide_sensitive_props();
 void clean_magisk_props();
 void refresh_uid();
+void do_hide_daemon(int pid);
 
 extern bool hide_enabled;
 extern pthread_mutex_t list_lock;
@@ -46,6 +47,7 @@ enum {
 	RM_HIDELIST,
 	LS_HIDELIST,
 	HIDE_STATUS,
+	EXEC_CMD,
 };
 
 enum {


### PR DESCRIPTION
This might be a bit specific to sony xperia xz1c/xz1/xzp phones with oreo fw, but maybe you can use at least the "extend magiskhide with exec option" commit and possibly implement a more generalized solution for the "detect sony ric daemon and hide magisk from it on boot" commit.
These two commits allow to do FOTA system update with unlocked bootloader on sony xperia xz1c/xz1/xzp phones with oreo fw if running a patched kernel which masks unlocked state in response from Trust Zone. The kernel is not flashed but booted from usb via 'fastboot boot' instead, having magisk root before and after fota.
For more details please see here:
https://forum.xda-developers.com/xperia-xz1-compact/development/rooted-kernel-hiding-bootloader-unlock-t3898711
Thank you very much for your excellent magisk tools.