### PR TITLE
Fix error initializing magisk with bad init.rc file

### DIFF
--- a/native/jni/core/magiskrc.h
+++ b/native/jni/core/magiskrc.h
@@ -3,6 +3,8 @@
 
 static const char magiskrc[] =
 
+"\n"
+
 "on early-init\n"
 "    write " EARLYINIT " 1\n"
 "    wait " EARLYINITDONE "\n"


### PR DESCRIPTION
The “early-init” section won’t be executed if the init.rc file ends without newline in the last section, e.g., the following lines:
```
on property:persist.sys.ultrabatterylife=0
    # ultra battery life mode disable
    write /cache/charger/CHGLimit 0
# ASUS_BSP --- LiJen ultra battery life mode
```

When patched by magiskinit it will become:

```
on property:persist.sys.ultrabatterylife=0
    # ultra battery life mode disable
    write /cache/charger/CHGLimit 0
# ASUS_BSP --- LiJen ultra battery life modeon early-init
    write /dev/.magisk_early_init 1
    wait /dev/.magisk_early_init_done
    rm /dev/.magisk_early_init_done
```

and the setup_overlay() will be stuck in the loop

Signed-off-by: Shaka Huang <shakalaca@gmail.com>