### PR TITLE
Fix bootloop when removing system SuperSU in <5.0

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -292,7 +292,7 @@ remove_system_su() {
       cd /system/bin
       if [ -e app_process64 ]; then
         ln -sf app_process64 app_process
-      else
+      elif [ -e app_process32 ]; then
         ln -sf app_process32 app_process
       fi
     fi


### PR DESCRIPTION
There is no app_process32/64 in kitkat...
app_process is hardlinked binary in kitkat..