### PR TITLE
Use REBOOT foreground broadcast

### DIFF
--- a/app/src/full/java/com/topjohnwu/magisk/components/GeneralReceiver.java
+++ b/app/src/full/java/com/topjohnwu/magisk/components/GeneralReceiver.java
@@ -40,6 +40,23 @@ public class GeneralReceiver extends BroadcastReceiver {
         if (action == null)
             return;
         switch (action) {
+            case Intent.ACTION_REBOOT:
+                String rebootAction = intent.getStringExtra("action");
+                switch (rebootAction) {
+                    case "request":
+                        Intent i = new Intent(app, ClassMap.get(SuRequestActivity.class))
+                                .putExtra("socket", intent.getStringExtra("socket"))
+                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        app.startActivity(i);
+                        break;
+                    case "log":
+                        SU_LOGGER.handleLogs(intent);
+                        break;
+                    case "notify":
+                        SU_LOGGER.handleNotify(intent);
+                        break;
+                }
+                break;
             case Intent.ACTION_BOOT_COMPLETED:
                 String bootAction = intent.getStringExtra("action");
                 if (bootAction == null)

--- a/app/src/full/java/com/topjohnwu/magisk/components/GeneralReceiver.java
+++ b/app/src/full/java/com/topjohnwu/magisk/components/GeneralReceiver.java
@@ -41,27 +41,11 @@ public class GeneralReceiver extends BroadcastReceiver {
             return;
         switch (action) {
             case Intent.ACTION_REBOOT:
-                String rebootAction = intent.getStringExtra("action");
-                switch (rebootAction) {
-                    case "request":
-                        Intent i = new Intent(app, ClassMap.get(SuRequestActivity.class))
-                                .putExtra("socket", intent.getStringExtra("socket"))
-                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        app.startActivity(i);
-                        break;
-                    case "log":
-                        SU_LOGGER.handleLogs(intent);
-                        break;
-                    case "notify":
-                        SU_LOGGER.handleNotify(intent);
-                        break;
-                }
-                break;
             case Intent.ACTION_BOOT_COMPLETED:
-                String bootAction = intent.getStringExtra("action");
-                if (bootAction == null)
-                    bootAction = "boot";
-                switch (bootAction) {
+                String realAction = intent.getStringExtra("action");
+                if (realAction == null)
+                    realAction = "boot_complete";
+                switch (realAction) {
                     case "request":
                         Intent i = new Intent(app, ClassMap.get(SuRequestActivity.class))
                                 .putExtra("socket", intent.getStringExtra("socket"))
@@ -74,7 +58,7 @@ public class GeneralReceiver extends BroadcastReceiver {
                     case "notify":
                         SU_LOGGER.handleNotify(intent);
                         break;
-                    case "boot":
+                    case "boot_complete":
                     default:
                         /* Devices with DTBO might want to patch dtbo.img.
                          * However, that is not possible if Magisk is installed by

--- a/native/jni/su/connect.cpp
+++ b/native/jni/su/connect.cpp
@@ -18,10 +18,10 @@
 
 #include "su.h"
 
-#define BROADCAST_BOOT_COMPLETED \
+#define BROADCAST_REBOOT_COMPLETED \
 "/system/bin/app_process", "/system/bin", "com.android.commands.am.Am", \
-"broadcast", nullptr, nullptr, "-a", "android.intent.action.BOOT_COMPLETED", \
-"-f", "0x00000020"
+"broadcast", nullptr, nullptr, "-a", "android.intent.action.REBOOT", \
+"-f", "0x10000020"
 
 static inline const char *get_command(const struct su_request *to) {
 	if (to->command[0])
@@ -33,14 +33,9 @@ static inline const char *get_command(const struct su_request *to) {
 
 static void silent_run(const char **args, struct su_info *info) {
 	char component[128];
-	if (SDK_INT >= 22) {
-		args[4] = "-p";
-		args[5] = info->str[SU_MANAGER];
-	} else {
-		sprintf(component, "%s/a.h", info->str[SU_MANAGER]);
-		args[4] = "-n";
-		args[5] = component;
-	}
+	sprintf(component, "%s/a.h", info->str[SU_MANAGER]);
+	args[4] = "-n";
+	args[5] = component;
 	exec_t exec {
 		.pre_exec = []() -> void {
 			int null = xopen("/dev/null", O_WRONLY | O_CLOEXEC);
@@ -85,7 +80,7 @@ void app_log(struct su_context *ctx) {
 	sprintf(policy, "%d", ctx->info->access.policy);
 
 	const char *cmd[] = {
-		BROADCAST_BOOT_COMPLETED,
+		BROADCAST_REBOOT_COMPLETED,
 		"--user", user,
 		"--es", "action", "log",
 		"--ei", "from.uid", fromUid,
@@ -112,7 +107,7 @@ void app_notify(struct su_context *ctx) {
 	sprintf(policy, "%d", ctx->info->access.policy);
 
 	const char *cmd[] = {
-		BROADCAST_BOOT_COMPLETED,
+		BROADCAST_REBOOT_COMPLETED,
 		"--user", user,
 		"--es", "action", "notify",
 		"--ei", "from.uid", fromUid,
@@ -127,7 +122,7 @@ void app_connect(const char *socket, struct su_info *info) {
 	setup_user(user, info);
 
 	const char *cmd[] = {
-		BROADCAST_BOOT_COMPLETED,
+		BROADCAST_REBOOT_COMPLETED,
 		"--user", user,
 		"--es", "action", "request",
 		"--es", "socket", socket,

--- a/native/jni/su/connect.cpp
+++ b/native/jni/su/connect.cpp
@@ -18,9 +18,9 @@
 
 #include "su.h"
 
-#define BROADCAST_REBOOT_COMPLETED \
+#define BROADCAST_REBOOT \
 "/system/bin/app_process", "/system/bin", "com.android.commands.am.Am", \
-"broadcast", nullptr, nullptr, "-a", "android.intent.action.REBOOT", \
+"broadcast", "-n", nullptr, "-a", "android.intent.action.REBOOT", \
 "-f", "0x10000020"
 
 static inline const char *get_command(const struct su_request *to) {
@@ -34,7 +34,6 @@ static inline const char *get_command(const struct su_request *to) {
 static void silent_run(const char **args, struct su_info *info) {
 	char component[128];
 	sprintf(component, "%s/a.h", info->str[SU_MANAGER]);
-	args[4] = "-n";
 	args[5] = component;
 	exec_t exec {
 		.pre_exec = []() -> void {
@@ -80,7 +79,7 @@ void app_log(struct su_context *ctx) {
 	sprintf(policy, "%d", ctx->info->access.policy);
 
 	const char *cmd[] = {
-		BROADCAST_REBOOT_COMPLETED,
+		BROADCAST_REBOOT,
 		"--user", user,
 		"--es", "action", "log",
 		"--ei", "from.uid", fromUid,
@@ -107,7 +106,7 @@ void app_notify(struct su_context *ctx) {
 	sprintf(policy, "%d", ctx->info->access.policy);
 
 	const char *cmd[] = {
-		BROADCAST_REBOOT_COMPLETED,
+		BROADCAST_REBOOT,
 		"--user", user,
 		"--es", "action", "notify",
 		"--ei", "from.uid", fromUid,
@@ -122,7 +121,7 @@ void app_connect(const char *socket, struct su_info *info) {
 	setup_user(user, info);
 
 	const char *cmd[] = {
-		BROADCAST_REBOOT_COMPLETED,
+		BROADCAST_REBOOT,
 		"--user", user,
 		"--es", "action", "request",
 		"--es", "socket", socket,


### PR DESCRIPTION
Many Chinese ROMs block BOOT_COMPLETED  broadcast. Some ROMs require users to add app to system whitelist, but some ROMs only system app can auto start. Users have to install Manager as system app and give up hide Manager.
This PR use REBOOT broadcast. Send broadcast to component instead of package will skip intent filter and permission check. REBOOT broadcast only root and system can sent. 