### PR TITLE
Do not create UNBLOCKFILE if it taken too long

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -571,7 +571,9 @@ static void dump_logs() {
  ****************/
 
 [[noreturn]] static void unblock_boot_process() {
-	close(xopen(UNBLOCKFILE, O_RDONLY | O_CREAT, 0));
+	if (access( POSTFSDATA, F_OK ) != -1 ) {
+		close(xopen(UNBLOCKFILE, O_RDONLY | O_CREAT, 0));
+	}
 	pthread_exit(nullptr);
 }
 

--- a/native/jni/core/magiskrc.h
+++ b/native/jni/core/magiskrc.h
@@ -14,8 +14,10 @@ static const char magiskrc[] =
 "    start logd\n"
 "    load_persist_props\n"
 "    rm " UNBLOCKFILE "\n"
+"    write " POSTFSDATA " 1\n"
 "    start %s\n"
 "    wait " UNBLOCKFILE " 10\n"
+"    rm " POSTFSDATA "\n"
 "    rm " UNBLOCKFILE "\n"
 "\n"
 

--- a/native/jni/include/magisk.h
+++ b/native/jni/include/magisk.h
@@ -11,6 +11,7 @@
 #define JAVA_PACKAGE_NAME "com.topjohnwu.magisk"
 #define LOGFILE         "/cache/magisk.log"
 #define UNBLOCKFILE     "/dev/.magisk_unblock"
+#define POSTFSDATA      "/dev/.magisk_post_fs_data"
 #define EARLYINIT       "/dev/.magisk_early_init"
 #define EARLYINITDONE   "/dev/.magisk_early_init_done"
 #define DISABLEFILE     "/cache/.disable_magisk"


### PR DESCRIPTION
This is a fix of #1149 

The magisk UNBLOCKFILE doesn't get deleted because the module loading take more than 10 seconds (since it module dependent we can't make it faster) and the file was created after the **rm UNBLOCKFILE** was called in **init.rc** 

so to fix that I create a file **POSTFSDATA** (/dev/.magisk_post_fs_data) that is created before **/sbin/magisk --post-fs-data** and get deleted after the **wait UNBLOCKFILE 10**
And magisk create the **UNBLOCKFILE** only if the **POSTFSDATA** exists