### PR TITLE
fix parse_int

### DIFF
--- a/native/jni/core/db.cpp
+++ b/native/jni/core/db.cpp
@@ -43,7 +43,7 @@ int db_settings::getKeyIdx(string_view key) const {
 }
 
 static int ver_cb(void *ver, int, char **data, char **) {
-	*((int *) ver) = parse_int(data[0]);
+	*((int *) ver) = b_parse_int(data[0]);
 	return 0;
 }
 

--- a/native/jni/magiskhide/hide_utils.cpp
+++ b/native/jni/magiskhide/hide_utils.cpp
@@ -60,7 +60,7 @@ void crawl_procfs(const function<bool (int)> &fn) {
 	int pid;
 	rewinddir(procfp);
 	while ((dp = readdir(procfp))) {
-		pid = parse_int(dp->d_name);
+		pid = b_parse_int(dp->d_name);
 		if (pid > 0 && !fn(pid))
 			break;
 	}
@@ -327,4 +327,3 @@ void auto_start_magiskhide() {
 		});
 	}
 }
-

--- a/native/jni/magiskhide/proc_monitor.cpp
+++ b/native/jni/magiskhide/proc_monitor.cpp
@@ -104,7 +104,7 @@ static bool parse_packages_xml(string_view s) {
 			if (!pkg)
 				return true;
 		} else if (key_view == "userId" || key_view == "sharedUserId") {
-			int uid = parse_int(value);
+			int uid = b_parse_int(value);
 			for (auto &hide : hide_set) {
 				if (hide.first == pkg)
 					uid_proc_map[uid].emplace_back(hide.second);

--- a/native/jni/su/su.cpp
+++ b/native/jni/su/su.cpp
@@ -177,7 +177,7 @@ int su_client_main(int argc, char *argv[]) {
 		if (pw)
 			su_req.uid = pw->pw_uid;
 		else
-			su_req.uid = parse_int(argv[optind]);
+			su_req.uid = b_parse_int(argv[optind]);
 		optind++;
 	}
 

--- a/native/jni/utils/include/utils.h
+++ b/native/jni/utils/include/utils.h
@@ -83,7 +83,7 @@ int strend(const char *s1, const char *s2);
 char *rtrim(char *str);
 void init_argv0(int argc, char **argv);
 void set_nice_name(const char *name);
-int parse_int(const char *s);
+int b_parse_int(const char *s);
 
 #define getline __getline
 #define getdelim __getdelim
@@ -203,11 +203,8 @@ void mmap_rw(const char *filename, B &buf, L &sz) {
 }
 
 // misc.cpp
-
-template <class S>
-int parse_int(S __s) {
-	return parse_int(__s.data());
-}
+// our own parse_int shortcut for std::string_view::data()
+# define parse_int(s) b_parse_int(s.data())
 
 int new_daemon_thread(void *(*start_routine) (void *), void *arg = nullptr,
 		const pthread_attr_t *attr = nullptr);

--- a/native/jni/utils/misc.cpp
+++ b/native/jni/utils/misc.cpp
@@ -235,7 +235,7 @@ char *rtrim(char *str) {
  * Bionic's atoi runs through strtol().
  * Use our own implementation for faster conversion.
  */
-int parse_int(const char *s) {
+int b_parse_int(const char *s) {
 	int val = 0;
 	char c;
 	while ((c = *(s++))) {


### PR DESCRIPTION
errors from compiling:

```
In file included from jni/magiskhide/proc_monitor.cpp:24:
jni/utils/include/utils.h:209:22: error: member reference base type 'char *' is not a structure or union
        return parse_int(__s.data());
                         ~~~^~~~~
jni/magiskhide/proc_monitor.cpp:107:14: note: in instantiation of function template specialization 'parse_int<char *>' requested here
                        int uid = parse_int(value);
                                  ^
1 error generated.
```

our parse_int only takes `.data()` from `string_view`, it does not have to be a template