### PR TITLE
Fix error installing magiskinit64 binary

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/tasks/MagiskInstaller.java
+++ b/app/src/main/java/com/topjohnwu/magisk/tasks/MagiskInstaller.java
@@ -164,11 +164,10 @@ public abstract class MagiskInstaller {
             return false;
         }
 
-        SuFile init64 = new SuFile(installDir, "magiskinit64");
         if (Build.VERSION.SDK_INT >= 21 && Build.SUPPORTED_64_BIT_ABIS.length != 0) {
-            init64.renameTo(new SuFile(installDir, "magiskinit"));
+            Shell.sh("mv " + installDir + "/magiskinit64 " + installDir + "/magiskinit").exec();
         } else {
-            init64.delete();
+            Shell.sh("rm " + installDir + "/magiskinit64").exec();
         }
         Shell.sh("cd " + installDir, "chmod 755 *").exec();
         return true;


### PR DESCRIPTION
Somehow the File.renameTo() failed and the 32bit magiskinit is installed on boot.img and leads to issues like: ’Magisk not installed’ and ‘su hangs in command line’.

Signed-off-by: Shaka Huang <shakalaca@gmail.com>