### PR TITLE
Removing android app data backup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:name="a.e"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:allowBackup="false"
         android:name="a.e"
         android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         tools:ignore="UnusedAttribute,GoogleAppIndexingWarning">
 
         <!-- Activities -->


### PR DESCRIPTION
This commit will remove/turn off backup functionality for ADB to backup Magisk manager's private directory `/data/data/com.topjohnwu.magisk/<any file and folder>`.

That private directory is only accessible to that app only but setting `android:allowBackup="true"` in manifest will allow ADB(Android debug bridge) to take backup of private directory it means whole directory will get dumped.

This might affect security of user's device because that backup can also be restored any malicious code/file can be injected or any file can be manipulated or altered.

You can also allow backup of only some or specific file/folders.

Reference/Support material:-
https://developer.android.com/guide/topics/data/autobackup.html#EnablingAutoBackup
https://blog.devknox.io/what-is-android-allowbackup-how-it-affects-your-app/
