### PR TITLE
Properly mount system for A-only system-as-root devices

### DIFF
--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -78,7 +78,7 @@ chmod -R 755 $MAGISKBIN
 # addon.d
 if [ -d /system/addon.d ]; then
   ui_print "- Adding addon.d survival script"
-  mount -o rw,remount /system
+  mount -o rw,remount $SYSTEM
   ADDOND=/system/addon.d/99-magisk.sh
   echo '#!/sbin/sh' > $ADDOND
   echo '# ADDOND_VERSION=2' >> $ADDOND

--- a/scripts/magisk_uninstaller.sh
+++ b/scripts/magisk_uninstaller.sh
@@ -129,7 +129,7 @@ rm -rf  /cache/*magisk* /cache/unblock /data/*magisk* /data/cache/*magisk* /data
         /data/adb/post-fs-data.d /data/adb/service.d /data/adb/modules* 2>/dev/null
 
 if [ -f /system/addon.d/99-magisk.sh ]; then
-  mount -o rw,remount /system
+  mount -o rw,remount $SYSTEM
   rm -f /system/addon.d/99-magisk.sh
 fi
 


### PR DESCRIPTION
* A properly configured A-only system-as-root device in recovery should have system mounted to /system_root and /system being a symlink of /system_root/system
* A-only system-as-root devices don't need to be manually mounted to /system_root doing it as default

Signed-off-by: Davide Garberi <dade.garberi@gmail.com>