### PR TITLE
Fix uninstaller missing recent changes

### DIFF
--- a/app/src/main/res/raw/utils.sh
+++ b/app/src/main/res/raw/utils.sh
@@ -55,6 +55,7 @@ restore_imgs() {
   local STOCKDTBO=/data/stock_dtbo.img.gz
   [ -f $STOCKBOOT ] || return 1
 
+  get_flags
   find_boot_image
   find_dtbo_image
 

--- a/native/jni/magiskboot/main.cpp
+++ b/native/jni/magiskboot/main.cpp
@@ -74,7 +74,7 @@ static void usage(char *arg0) {
 		"      test\n"
 		"        Check if fstab has verity/avb flags\n"
 		"        Return values:\n"
-		"        0:no flags    1:flag exists\n"
+		"        0:flag exists    1:no flags\n"
 		"      patch\n"
 		"        Search for fstab and remove verity/avb\n"
 		"\n"


### PR DESCRIPTION
- group unsupported formats into the same code (https://github.com/topjohnwu/Magisk/commit/86f778c0aa21f1cc7a358331c102180488b3351b#diff-93690a8d9f50c177ef97416af3be8726)
- support A only system-as-root devices (https://github.com/topjohnwu/Magisk/commit/e72c6685edf81706617a3444575c4500b9b8fe6c#diff-93690a8d9f50c177ef97416af3be8726)
- remove unnecessary '--' from magiskboot actions (https://github.com/topjohnwu/Magisk/commit/7f08c0694392ede38ebbb6bd835757f2b3c3c477#diff-93690a8d9f50c177ef97416af3be8726)
- get_flags need to be before find_boot_image (https://github.com/topjohnwu/Magisk/commit/a4f5d47e72158a559bd4b47e70bf7ba1126b2dbd)

closes #1371, closes #1431, closes #1439