### PR TITLE
extend magiskhide with exec option

### DIFF
--- a/native/jni/magiskhide/magiskhide.h
+++ b/native/jni/magiskhide/magiskhide.h
@@ -35,6 +35,7 @@ void manage_selinux();
 void clean_magisk_props();
 void crawl_procfs(const std::function<bool (int)> &fn);
 void crawl_procfs(DIR *dir, const std::function<bool (int)> &fn);
+void do_hide_daemon(int pid);
 
 extern bool hide_enabled;
 extern pthread_mutex_t monitor_lock;

--- a/native/jni/magiskhide/proc_monitor.cpp
+++ b/native/jni/magiskhide/proc_monitor.cpp
@@ -211,6 +211,10 @@ static void hide_daemon(int pid) {
 	manage_selinux();
 	clean_magisk_props();
 
+	do_hide_daemon(pid);
+}
+
+void do_hide_daemon(int pid) {
 	vector<string> targets;
 
 	// Unmount dummy skeletons and /sbin links


### PR DESCRIPTION
this shall be used to start a process in "stock" environment
where magisk components are not visible

this is needed in very early boot phase to start special root
detection processes like sony xperia ric daemon

when ric daemon thinks bootloader is still locked and detects
presence of /sbin/su or other utilities, kernel is rebooted
in it's very early boot phase

this patch adds new --exec option which will create private
mount namespace and change all mount points sharing to MS_PRIVATE
so hide_daemon() can be used to unmount magisk mounts just before
exec() to target process