### PR TITLE
Fix early mount on Leagoo T8s

### DIFF
--- a/stub/src/main/res/values-ca/strings.xml
+++ b/stub/src/main/res/values-ca/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="upgrade_msg">Fes una actualització total de Magisk Manager  per finalitzar l'instalació. Descarregar i instalar?</string>
+    <string name="upgrade_msg">Fes una actualització total de Magisk Manager  per finalitzar l\'instalació. Descarregar i instalar?</string>
     <string name="no_internet_msg">Si us plau, connecta\'t a internet! Es necessari fer una actualització total de Magisk Manager.</string>
 </resources>


### PR DESCRIPTION
Problem I described [here](https://github.com/topjohnwu/Magisk/issues/844).
Early mount was too early, when mmcblk0 was still missing from /sys/dev/block.