### PR TITLE
Use the standard Android Reboot API to perform reboot

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/module/ModulesFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/module/ModulesFragment.kt
@@ -68,15 +68,15 @@ class ModulesFragment : MagiskFragment<ModuleViewModel, FragmentModulesBinding>(
                 return true
             }
             R.id.reboot_recovery -> {
-                Shell.su("/system/bin/reboot recovery").submit()
+                RootUtils.reboot("recovery")
                 return true
             }
             R.id.reboot_bootloader -> {
-                Shell.su("/system/bin/reboot bootloader").submit()
+                RootUtils.reboot("bootloader")
                 return true
             }
             R.id.reboot_download -> {
-                Shell.su("/system/bin/reboot download").submit()
+                RootUtils.reboot("download")
                 return true
             }
             else -> return false

--- a/app/src/main/java/com/topjohnwu/magisk/utils/RootUtils.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/RootUtils.kt
@@ -163,16 +163,7 @@ class RootUtils : Shell.Initializer() {
 
         @JvmStatic
         fun reboot(reason: String) {
-            Shell.su("service call power ${getRebootTransactionCode()} i32 0 s16 $reason i32 0").submit()
-        } 
-
-        private fun getRebootTransactionCode(): Int {
-            // Get the transaction code for the reboot method in PowerManager.
-            // Warning: Hidden-api usage.
-            val clz = java.lang.Class.forName("android.os.IPowerManager\$Stub")
-            val field = clz.getDeclaredField("TRANSACTION_reboot")
-            field.setAccessible(true)
-            return field.getInt(null)
+            Shell.su("svc power reboot $reason").submit()
         }
     }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/utils/RootUtils.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/RootUtils.kt
@@ -163,7 +163,7 @@ class RootUtils : Shell.Initializer() {
 
         @JvmStatic
         fun reboot(reason: String) {
-            Shell.su("svc power reboot $reason").submit()
+            Shell.su("/system/bin/svc power reboot $reason").submit()
         }
     }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/utils/RootUtils.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/RootUtils.kt
@@ -163,7 +163,7 @@ class RootUtils : Shell.Initializer() {
 
         @JvmStatic
         fun reboot(reason: String) {
-            Shell.su("service call power ${getRebootTransactionCode()} i32 1 s16 $reason i32 0").submit()
+            Shell.su("service call power ${getRebootTransactionCode()} i32 0 s16 $reason i32 0").submit()
         } 
 
         private fun getRebootTransactionCode(): Int {

--- a/app/src/main/java/com/topjohnwu/magisk/utils/RootUtils.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/RootUtils.kt
@@ -158,7 +158,21 @@ class RootUtils : Shell.Initializer() {
 
         @JvmStatic
         fun reboot() {
-            Shell.su("/system/bin/reboot ${if (Config.recovery) "recovery" else ""}").submit()
+            reboot(if (Config.recovery) "recovery" else "")
+        }
+
+        @JvmStatic
+        fun reboot(reason: String) {
+            Shell.su("service call power ${getRebootTransactionCode()} i32 1 s16 $reason i32 0").submit()
+        } 
+
+        private fun getRebootTransactionCode(): Int {
+            // Get the transaction code for the reboot method in PowerManager.
+            // Warning: Hidden-api usage.
+            val clz = java.lang.Class.forName("android.os.IPowerManager\$Stub")
+            val field = clz.getDeclaredField("TRANSACTION_reboot")
+            field.setAccessible(true)
+            return field.getInt(null)
         }
     }
 }


### PR DESCRIPTION
# Purpose
Magisk currently uses `reboot` command to perform hard-reboots which is not good for devices and developers, that's because:

* Android has its own shutdown/reboot procedure
* Some developers would like to receive the shutdown broadcasts
* Inside Android's own procedure, SystemServer shutdowns services gently so it's safe to perform the hard shutdown at last. Performing it without shutting down the services may cause errors.

# Is this PR tested?
I'm not sure if that the `svc power reboot` method works perfectly from Android L to P but I've taken a look about this part of the source of L and P and they look similar. The reboot API may be changed by OEM and may won't work normally, but on my Android Pie (AospExtended) device it works perfectly in debug mode. 

Another thing is that I've tested rebooting to normal, recovery and bootloader successfully but I cannot reboot into `download` and I have no idea about it. 

# How does it work?
I use `svc power reboot <reason>` instead, it should be more stable than the pervious commit which uses `service call`.

# Acknowledgement
Thanks to RikkaW and Kr328