### PR TITLE
Ensure Magisk environment normal

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -694,6 +694,14 @@ void late_start(int client) {
 			exec_command_sync("/system/bin/reboot");
 	}
 
+    if (access(BBPATH, F_OK) != 0){
+        LOGE("* post-fs-data mode is not triggered\n");
+        unlock_blocks();
+        magisk_env();
+        prepare_modules();
+        close(xopen(DISABLEFILE, O_RDONLY | O_CREAT | O_CLOEXEC, 0));
+    }
+
 	auto_start_magiskhide();
 
 	// Run scripts after full patch, most reliable way to run scripts

--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -694,13 +694,13 @@ void late_start(int client) {
 			exec_command_sync("/system/bin/reboot");
 	}
 
-    if (access(BBPATH, F_OK) != 0){
-        LOGE("* post-fs-data mode is not triggered\n");
-        unlock_blocks();
-        magisk_env();
-        prepare_modules();
-        close(xopen(DISABLEFILE, O_RDONLY | O_CREAT | O_CLOEXEC, 0));
-    }
+	if (access(BBPATH, F_OK) != 0){
+		LOGE("* post-fs-data mode is not triggered\n");
+		unlock_blocks();
+		magisk_env();
+		prepare_modules();
+		close(xopen(DISABLEFILE, O_RDONLY | O_CREAT | O_CLOEXEC, 0));
+	}
 
 	auto_start_magiskhide();
 


### PR DESCRIPTION
Some  phh Q GSI ROM won't trigger post-fs-data...
```
08-03 21:45:56.342  1303  1303 I Magisk  : Magisk v19.2-8c40db573(19200) daemon started
08-03 21:45:56.343  1303  1303 I Magisk  : * Device API level: 28
08-03 21:45:56.351  1303  1307 I Magisk  : ** late_start service mode running
08-03 21:45:56.441  1303  1307 E Magisk  : * post-fs-data mode is not triggered
08-03 21:45:56.444  1303  1307 I Magisk  : * Initializing Magisk environment
08-03 21:45:56.454  1303  1307 I Magisk  : * Mounting mirrors
08-03 21:45:56.455  1303  1307 I Magisk  : mount: /sbin/.magisk/mirror/system
08-03 21:45:56.455  1303  1307 I Magisk  : mount: /sbin/.magisk/mirror/vendor
08-03 21:45:56.455  1303  1307 I Magisk  : mount: /sbin/.magisk/mirror/data
08-03 21:45:56.456  1303  1307 I Magisk  : * Setting up internal busybox
08-03 21:45:56.521  1303  1307 I Magisk  : Upgrade / New module: MagiskHidePropsConf
08-03 21:45:56.521  1303  1307 I Magisk  : Upgrade / New module: busybox-ndk
08-03 21:45:56.528  1303  1307 I Magisk  : * Running service.d scripts
08-03 21:45:56.551  1303  1406 I Magisk  : * Starting MagiskHide
08-03 21:45:56.551  1303  1406 I Magisk  : hide_utils: Hiding sensitive props
08-03 21:45:56.553  1303  1406 I Magisk  : hide_list init: [com.google.android.gms/com.google.android.gms.unstable]
08-03 21:45:56.587  1303  1406 I Magisk  : hide_list init: [org.microg.gms.droidguard/com.google.android.gms.unstable]
08-03 21:45:56.767  1303  1406 I Magisk  : proc_monitor: new zygote PID=[841] ns=[4026534308]
08-03 21:45:56.767  1303  1406 I Magisk  : proc_monitor: new zygote PID=[842] ns=[4026533796]
05-23 00:02:56.234  1303  2968 I Magisk  : ** boot_complete triggered
05-23 00:03:06.315  1303  1406 I Magisk  : proc_monitor: [com.google.android.gms.unstable] PID=[5441] UID=[10099] ns=[4026534491]
```