### PR TITLE
Added warnings about flashing only an AP file and using MTP.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -69,8 +69,8 @@ Just when you think the bootloader is unlocked, surprise surprise, it is *actual
 4. In Magisk Manager: **Install → Install → Select and Patch a File** and select the AP tar file.
 5. Magisk Manager will patch the whole firmware file and store the output to
 `[Internal Storage]/Download/magisk_patched.tar`
-6. Copy the tar file to your PC, and boot your device to download mode.
-7. Flash `magisk_patched.tar` as AP in ODIN <br> **Important: Uncheck "Auto Reboot" in Options!!!!**
+6. Copy the tar file to your PC (using `adb`: some people report corruption using MTP), and boot your device to download mode.
+7. Flash `magisk_patched.tar` as AP in ODIN, together with the BL, CP and HOME_CSC files. Never flash only an AP file, as Odin can shrink your `/data` file-system if you do.<br> **Important: Uncheck "Auto Reboot" in Options!**
 8. Magisk is now successfully flashed to your device! But there are still several steps before you can properly use the device.
 9. We now want to boot into the stock recovery to factory reset our device. <br>
 **Full data wipe is mandatory! Do not skip this step.** <br>


### PR DESCRIPTION
MTP is now known to sometimes corrupt the AP file on transfer to the PC,
so we should warn users to prefer `adb`.

Furthermore, quite a few users are reporting a shrunken `/data`
file-system after flashing with Odin. This has been traced to the
flashing of only an AP file, which causes some versions of Odin to
shrink `/data`. The phenomenon is reproducable.