### PR TITLE
Use original file type when creating device nodes

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -311,7 +311,7 @@ static int bind_mount(const char *from, const char *to, bool log) {
 #define mount_mirror(part, flag) { \
 	sscanf(line.data(), "%s %*s %s", buf, buf2); \
 	xstat(buf, &st); \
-	mknod(PARTBLK(part), S_IFBLK | 0600, st.st_rdev); \
+	mknod(PARTBLK(part), (st.st_mode & S_IFMT) | 0600, st.st_rdev); \
 	xmkdir(MIRRMNT(part), 0755); \
 	xmount(PARTBLK(part), MIRRMNT(part), buf2, flag, nullptr); \
 	VLOGI("mount", PARTBLK(part), MIRRMNT(part)); \


### PR DESCRIPTION
Commit dab32e1599613e9c6e12de2d3c16cf9ede4b282b broke compatibility with my ubifs device again. :smiley: 
Since I know @topjohnwu doesn't have one, I figured that I would fix it myself and submit a pull request.

What happened this time is that when this line created the device node
https://github.com/topjohnwu/Magisk/blob/dab32e1599613e9c6e12de2d3c16cf9ede4b282b/native/jni/core/bootstages.cpp#L310
it would assume that the device was a block device. This is a pretty reasonable assumption, but as it turns out, on devices with raw flash (and filesystems like yaffs or ubifs), the device backing the filesystem is a _character_ device:
```
shell@mid713l_lp:/ # ls -l /dev/ubi0_0                                         
crw------- root     root     229,   1 2019-06-07 06:28 ubi0_0
```
rather than a block device like you would see normally:
```
A1_PRO:/ # ls -l /dev/block/mmcblk0p31
brw------- 1 root root 179,  31 2019-06-05 16:50 /dev/block/mmcblk0p31
```

The solution is to use the S_IFMT mask to extract the device file type from the stat call and use that value in place of S_IFBLK.