### PR TITLE
'magiskboot hexpatch' will exit with status 1 when nothing patched.

### DIFF
--- a/native/jni/magiskboot/hexpatch.cpp
+++ b/native/jni/magiskboot/hexpatch.cpp
@@ -16,8 +16,9 @@ static void hex2byte(uint8_t *hex, uint8_t *str) {
 	}
 }
 
-void hexpatch(const char *image, const char *from, const char *to) {
+int hexpatch(const char *image, const char *from, const char *to) {
 	int patternsize = strlen(from) / 2, patchsize = strlen(to) / 2;
+	int patched = 1;
 	size_t filesize;
 	uint8_t *file, *pattern, *patch;
 	mmap_rw(image, file, filesize);
@@ -31,9 +32,12 @@ void hexpatch(const char *image, const char *from, const char *to) {
 			memset(file + i, 0, patternsize);
 			memcpy(file + i, patch, patchsize);
 			i += patternsize - 1;
+			patched = 0;
 		}
 	}
 	munmap(file, filesize);
 	free(pattern);
 	free(patch);
+
+	return patched;
 }

--- a/native/jni/magiskboot/magiskboot.h
+++ b/native/jni/magiskboot/magiskboot.h
@@ -15,7 +15,7 @@
 // Main entries
 int unpack(const char *image, bool hdr = false);
 void repack(const char* orig_image, const char* out_image);
-void hexpatch(const char *image, const char *from, const char *to);
+int hexpatch(const char *image, const char *from, const char *to);
 int cpio_commands(int argc, char *argv[]);
 int dtb_commands(const char *cmd, int argc, char *argv[]);
 

--- a/native/jni/magiskboot/main.cpp
+++ b/native/jni/magiskboot/main.cpp
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
 	} else if (argc > 2 && strncmp(argv[1], "compress", 8) == 0) {
 		compress(argv[1][8] == '=' ? &argv[1][9] : "gzip", argv[2], argv[3]);
 	} else if (argc > 4 && strcmp(argv[1], "hexpatch") == 0) {
-		hexpatch(argv[2], argv[3], argv[4]);
+		return hexpatch(argv[2], argv[3], argv[4]);
 	} else if (argc > 2 && strcmp(argv[1], "cpio") == 0) {
 		if (cpio_commands(argc - 2, argv + 2)) usage(argv[0]);
 	} else if (argc > 2 && strncmp(argv[1], "dtb", 3) == 0) {


### PR DESCRIPTION
`magiskboot` has applications outside of Magisk, such as its handy ability to `hexpatch` files.

Unfortunately, `magiskboot` will exit with status **0** whether or not any byte sequences were successfully replaced.

This patch causes `magiskboot` to exit with status **1** when the `hexpatch` command fails to make any replacements.