### PR TITLE
Fix error using Magisk with bootup pin code enabled

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -731,7 +731,7 @@ void boot_complete(int client) {
 		rename(MANAGERAPK, "/data/magisk.apk");
 		install_apk("/data/magisk.apk");
 		installed = true;
-	} else {
+	} else if (access(MAGISKDB, F_OK) == 0) {
 		// Check whether we have a valid manager installed
 		db_strings str;
 		get_db_strings(str, SU_MANAGER);

--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -725,10 +725,12 @@ void boot_complete(int client) {
 	write_int(client, 0);
 	close(client);
 
+	bool installed = false;
 	if (access(MANAGERAPK, F_OK) == 0) {
 		// Install Magisk Manager if exists
 		rename(MANAGERAPK, "/data/magisk.apk");
 		install_apk("/data/magisk.apk");
+		installed = true;
 	} else {
 		// Check whether we have a valid manager installed
 		db_strings str;
@@ -737,9 +739,12 @@ void boot_complete(int client) {
 			// There is no manager installed, install the stub
 			exec_command_sync("/sbin/magiskinit", "-x", "manager", "/data/magisk.apk");
 			install_apk("/data/magisk.apk");
+			installed = true;
 		}
 	}
 
-	// Test whether broadcast can be used or not
-	broadcast_test();
+	if (installed) {
+		// Test whether broadcast can be used or not
+		broadcast_test();
+	}
 }


### PR DESCRIPTION
Magisk daemon creates new magiskdb before /data decryption and uses it afterwards, the status of hide and superuser requests will be out of sync because of using different magiskdb after /data decryption in Manager.

Signed-off-by: Shaka Huang <shakalaca@gmail.com>