### PR TITLE
Make /sepolicy unreadable by apps

### DIFF
--- a/native/jni/init/rootfs.cpp
+++ b/native/jni/init/rootfs.cpp
@@ -48,6 +48,9 @@ void MagiskInit::setup_rootfs() {
 		close(system_root);
 	}
 
+	// Some "security" mechanisms tries to read /sepolicy
+	chmod("/sepolicy", 0600);
+
 	if (patch_init) {
 		constexpr char SYSTEM_INIT[] = "/system/bin/init";
 		// If init is symlink, copy it to rootfs so we can patch


### PR DESCRIPTION
Some apps tries to read /sepolicy and see if it's patched for su.

Signed-off-by: Park Ju Hyung <qkrwngud825@gmail.com>