### PR TITLE
Manager: fix ModulesFragment reboot menu

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/module/ModulesFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/module/ModulesFragment.kt
@@ -68,16 +68,19 @@ class ModulesFragment : MagiskFragment<ModuleViewModel, FragmentModulesBinding>(
                 return true
             }
             R.id.reboot_recovery -> {
-                reboot("recovery")
+                Shell.su("/system/bin/reboot recovery").submit()
                 return true
             }
             R.id.reboot_bootloader -> {
-                reboot("booloader")
-                Shell.su("/system/bin/reboot bootloader").submit()
+                reboot("bootloader")
                 return true
             }
             R.id.reboot_download -> {
                 reboot("download")
+                return true
+            }
+            R.id.reboot_edl -> {
+                reboot("edl")
                 return true
             }
             else -> return false

--- a/app/src/main/res/menu/menu_reboot.xml
+++ b/app/src/main/res/menu/menu_reboot.xml
@@ -22,4 +22,9 @@
         android:title="@string/reboot_download"
         app:showAsAction="never" />
 
+    <item
+        android:id="@+id/reboot_edl"
+        android:title="@string/reboot_edl"
+        app:showAsAction="never" />
+
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="reboot_recovery">Reboot to Recovery</string>
     <string name="reboot_bootloader">Reboot to Bootloader</string>
     <string name="reboot_download">Reboot to Download</string>
+    <string name="reboot_edl">Reboot to EDL</string>
 
     <!--Repo Fragment-->
     <string name="update_available">Update Available</string>


### PR DESCRIPTION
- correct 'booloader' typo breaking bootloader entry
- remove extra bootloader entry Shell.su line which is unnecessary since it's covered by reboot()
- revert to using `reboot recovery` for recovery entry since `svc power reboot recovery` triggers a very disconcerting "Factory data reset" reboot dialog on many devices
- add Reboot to EDL mode option for good measure