### PR TITLE
magiskboot: don't clobber /overlay with cpio restore anymore

### DIFF
--- a/native/jni/magiskboot/ramdisk.cpp
+++ b/native/jni/magiskboot/ramdisk.cpp
@@ -130,8 +130,8 @@ void magisk_cpio::restore() {
 			} else {
 				mv(cur, &cur->first[8]);
 			}
-		} else if (str_starts(cur->first, "overlay") ||
-				str_starts(cur->first, "magisk") ||
+		} else if (str_starts(cur->first, "magisk") ||
+				cur->first == "overlay/init.magisk.rc" ||
 				cur->first == "sbin/magic_mask.sh" ||
 				cur->first == "init.magisk.rc") {
 			// Some known stuff we can remove


### PR DESCRIPTION
- Magisk "dirty" flashes would remove the /overlay directory which might have been put there by a custom kernel or other mod
- this is a leftover from when Magisk itself used /overlay for placing init.magisk.rc, so just remove this file specifically and leave the rest intact