### PR TITLE
magiskpolicy: rules: fix rootfs operations with SAR Magisk

### DIFF
--- a/native/jni/magiskpolicy/rules.cpp
+++ b/native/jni/magiskpolicy/rules.cpp
@@ -51,6 +51,9 @@ void sepol_magisk_rules() {
 	// Let everyone access tmpfs files (for SAR sbin overlay)
 	sepol_allow(ALL, "tmpfs", "file", ALL);
 
+	// For normal rootfs file/directory operations when rw (for SAR / overlay)
+	sepol_allow("rootfs", "labeledfs", "filesystem", "associate");
+
 	// Let init transit to SEPOL_PROC_DOMAIN
 	sepol_allow("kernel", "kernel", "process", "setcurrent");
 	sepol_allow("kernel", SEPOL_PROC_DOMAIN, "process", "dyntransition");


### PR DESCRIPTION
- while many newer devices cannot allow / (system partition) to be mounted rw due to compressed fs (e.g. erofs) or logical partitions, it should remain possible to alter rootfs files/directories on those that previously allowed it