### PR TITLE
magiskpolicy: rules: fix writing to loop devices using upstream sepolicy

### DIFF
--- a/native/jni/magiskpolicy/rules.cpp
+++ b/native/jni/magiskpolicy/rules.cpp
@@ -154,6 +154,7 @@ void sepol_magisk_rules() {
 	sepol_allow(SEPOL_PROC_DOMAIN, "tmpfs", "filesystem", "mount");
 	sepol_allow(SEPOL_PROC_DOMAIN, "tmpfs", "filesystem", "unmount");
 	sepol_allow("kernel", ALL, "file", "read");
+	sepol_allow("kernel", ALL, "file", "write");
 
 	// Allow us to do anything to any files/dir/links
 	sepol_allow(SEPOL_PROC_DOMAIN, ALL, "file", ALL);


### PR DESCRIPTION
- loop mounted ext4 .img would remount ro with OP7 Pro on OOS Stable, and Pixel 2 on Q Beta 5