### PR TITLE
recovery addon.d-v2 script update, and update-binary fix

### DIFF
--- a/scripts/update_binary.sh
+++ b/scripts/update_binary.sh
@@ -4,7 +4,7 @@ extract_bb() {
   touch "$BBBIN"
   chmod 755 "$BBBIN"
   dd if="$0" of="$BBBIN" bs=1024 skip=1 count=$X86_CNT
-  "$BBBIN" >/dev/null || dd if="$0" of="$BBBIN" bs=1024 skip=$(($X86_CNT + 1))
+  "$BBBIN" >/dev/null 2>&1 || dd if="$0" of="$BBBIN" bs=1024 skip=$(($X86_CNT + 1))
 }
 setup_bb() {
   export BBDIR=$TMPDIR/bin


### PR DESCRIPTION
scripts: hide expected x86 busybox error on arm
- Magisk Manager installs have busybox in the $PATH before extracting busybox from update-binary so an error from busybox ash (as sh) attempting to parse the x86 busybox like a shell script would be shown:
```./bin/busybox: line 1: syntax error: unexpected "("```
- this will only occur when ash tries to run a binary it can't handle, so basically only with x86 binary on an arm* device

scripts: prepare addon.d for recovery addon.d-v2 support
- naturally there's no `su` in recovery
- major refactor for common actions and simplicity