### PR TITLE
magiskboot: ignore recovery_dtbo_size and dtb_size if incorrect header_version

### DIFF
--- a/native/jni/magiskboot/bootimg.cpp
+++ b/native/jni/magiskboot/bootimg.cpp
@@ -331,11 +331,15 @@ int unpack(const char *image, bool hdr) {
 	// Dump extra
 	dump(boot.extra, boot.hdr.extra_size(), EXTRA_FILE);
 
-	// Dump recovery_dtbo
-	dump(boot.recov_dtbo, boot.hdr.recovery_dtbo_size(), RECV_DTBO_FILE);
-
-	// Dump dtb
-	dump(boot.dtb, boot.hdr.dtb_size(), DTB_FILE);
+	uint32_t hdr_ver = boot.hdr.header_version();
+	if (hdr_ver > 0) {
+		// Dump recovery_dtbo
+		dump(boot.recov_dtbo, boot.hdr.recovery_dtbo_size(), RECV_DTBO_FILE);
+	}
+	if (hdr_ver > 1) {
+		// Dump dtb
+		dump(boot.dtb, boot.hdr.dtb_size(), DTB_FILE);
+	}
 	return ret;
 }
 


### PR DESCRIPTION
- Huawei has header_version=0 boot.img "Cairo SIGN" at 1632, which would cause unpack to incorrectly dump dtb and recovery_dtbo trying to use this string data as sizes