### PR TITLE
magiskpolicy: rules: standardize update_engine sepolicy when rooted

### DIFF
--- a/native/jni/magiskpolicy/rules.cpp
+++ b/native/jni/magiskpolicy/rules.cpp
@@ -192,9 +192,9 @@ void sepol_magisk_rules() {
 	// Support deodexed ROM on Pie (Samsung)
 	sepol_allow("system_server", "dalvikcache_data_file", "file", "write");
 	sepol_allow("system_server", "dalvikcache_data_file", "file", "execute");
-	
-	// Allow update engine to source addon.d.sh
-	sepol_allow("update_engine", "adb_data_file", "dir", ALL);
+
+	// Allow update_engine/addon.d-v2 to run permissive on all ROMs
+	sepol_permissive("update_engine");
 
 #ifdef MAGISK_DEBUG
 	// Remove all dontaudit in debug mode


### PR DESCRIPTION
The state of ROM A/B OTA addon.d-v2 support is an inconsistent mess currently:
- LineageOS builds userdebug with permissive update_engine domain, OmniROM builds userdebug with a more restricted update_engine domain, and CarbonROM builds user with a hybrid closer to Omni's
- addon.d-v2 scripts cannot function to the full extent they should when there is a more restricted update_engine domain sepolicy in place, which is likely why Lineage made update_engine completely permissive

Evidence for the above:
- many addon.d-v2 scripts only work (or fully work) on Lineage, see below
- Magisk's addon.d-v2 script would work on Lineage without issue, but would work on Carbon and Omni only if further allow rules were added for basic things like "file read" and "dir search" suggesting these ROMs' addon.d-v2 is severely limited
- Omni includes a /system/addon.d/69-gapps.sh script with the ROM itself (despite shipping without GApps), and with Magisk's more permissive sepolicy and no GApps installed it will remove important ROM files during OTA, resulting in a bootloop; the issue with shipping this script was therefore masked by Omni's overly restrictive update_engine sepolicy not allowing the script to function as intended

The solution:
- guarantee a consistent addon.d-v2 experience for users across ROMs when rooted with Magisk by making update_engine permissive as Lineage has
- hopefully ROMs can work together to come up with something standard for unrooted addon.d-v2 function