### PR TITLE
dtb: support patching qcom dtbtool generated dt images

### DIFF
--- a/native/jni/magiskboot/bootimg.cpp
+++ b/native/jni/magiskboot/bootimg.cpp
@@ -289,7 +289,7 @@ int unpack(const char *image, bool hdr) {
 
 	if (hdr) {
 		FILE *fp = xfopen(HEADER_FILE, "w");
-		fprintf(fp, "pagesize=%u\n", boot.hdr->page_size());
+		fprintf(fp, "page_size=%u\n", boot.hdr->page_size());
 		fprintf(fp, "name=%s\n", boot.hdr->name());
 		fprintf(fp, "cmdline=%.512s%.1024s\n", boot.hdr->cmdline(), boot.hdr->extra_cmdline());
 		uint32_t ver = boot.hdr->os_version();

--- a/native/jni/magiskboot/format.h
+++ b/native/jni/magiskboot/format.h
@@ -39,6 +39,7 @@ typedef enum {
 #define LZ42_MAGIC      "\x04\x22\x4d\x18"
 #define MTK_MAGIC       "\x88\x16\x88\x58"
 #define DTB_MAGIC       "\xd0\x0d\xfe\xed"
+#define QCDT_MAGIC      "QCDT"
 #define LG_BUMP_MAGIC   "\x41\xa9\xe4\x67\x74\x4d\x1d\x1b\xa4\x29\xf2\xec\xea\x65\x52\x79"
 #define DHTB_MAGIC      "\x44\x48\x54\x42\x01\x00\x00\x00"
 #define SEANDROID_MAGIC "SEANDROIDENFORCE"

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -74,7 +74,7 @@ chmod -R 755 .
 CHROMEOS=false
 
 ui_print "- Unpacking boot image"
-./magiskboot unpack "$BOOTIMAGE"
+./magiskboot unpack -h "$BOOTIMAGE"
 
 case $? in
   1 )


### PR DESCRIPTION
Old qcom bootloaders for chips like msm8916, msm8974 load dt's from a dt.img appended to the end of the boot.img. This is already handled in the boot parsing section of magisk as what you call the "extra" section.
However, the new dtb patching to support A-only 2SI SAR did not take that into account.

The image has special formatting, consisting of
* A common header, which holds information like the header version and the number of dts in the image.
* A table of infos for each included dtb, which holds some chipset information and the size and offset in the image of the dtb
* Finally, each dtb is appended (with padding to align to page_size)

This patch makes sure to keep the appropriate dt.img format, with the necessary edits to account for size changes



References:
https://github.com/LineageOS/android_system_tools_dtbtool