### PR TITLE
Manager/Boot/Init: Create Core-Only Boot Images for self-rescue of devices lacking non-OEM recovery options

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/Info.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/Info.kt
@@ -22,6 +22,7 @@ object Info {
     var keepVerity = false
     var keepEnc = false
     var recovery = false
+    var coreOnly = false
 
     val isConnected by lazy {
         KObservableField(false).also { field ->

--- a/app/src/main/java/com/topjohnwu/magisk/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/tasks/MagiskInstaller.kt
@@ -253,6 +253,7 @@ abstract class MagiskInstaller {
         }
 
         if (!("KEEPFORCEENCRYPT=${Info.keepEnc} KEEPVERITY=${Info.keepVerity} " +
+                "COREONLYMODE=${Info.coreOnly} " +
                 "RECOVERYMODE=${Info.recovery} sh update-binary " +
                 "sh boot_patch.sh $srcBoot").sh().isSuccess) {
             return false

--- a/app/src/main/java/com/topjohnwu/magisk/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/home/HomeViewModel.kt
@@ -37,6 +37,7 @@ class HomeViewModel(
     val isForceEncryption = KObservableField(Info.keepEnc)
     val isKeepVerity = KObservableField(Info.keepVerity)
     val isRecovery = KObservableField(Info.recovery)
+    val isCoreOnly = KObservableField(Info.coreOnly)
 
     val magiskState = KObservableField(MagiskState.LOADING)
     val magiskStateText = Observer(magiskState) {
@@ -105,6 +106,9 @@ class HomeViewModel(
         }
         isRecovery.addOnPropertyChangedCallback {
             Info.recovery = it ?: return@addOnPropertyChangedCallback
+        }
+        isCoreOnly.addOnPropertyChangedCallback {
+            Info.coreOnly = it ?: return@addOnPropertyChangedCallback
         }
         isConnected.addOnPropertyChangedCallback {
             if (it == true) refresh(false)

--- a/app/src/main/java/com/topjohnwu/magisk/utils/RootInit.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/RootInit.kt
@@ -38,6 +38,7 @@ class RootInit : Shell.Initializer() {
         Info.keepVerity = ShellUtils.fastCmd("echo \$KEEPVERITY").toBoolean()
         Info.keepEnc = ShellUtils.fastCmd("echo \$KEEPFORCEENCRYPT").toBoolean()
         Info.recovery = ShellUtils.fastCmd("echo \$RECOVERYMODE").toBoolean()
+        Info.coreOnly = ShellUtils.fastCmd("echo \$COREONLYMODE").toBoolean()
 
         return true
     }

--- a/app/src/main/java/com/topjohnwu/magisk/view/dialogs/InstallMethodDialog.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/view/dialogs/InstallMethodDialog.kt
@@ -20,8 +20,8 @@ internal class InstallMethodDialog(activity: BaseActivity<*, *>, options: List<S
         setTitle(R.string.select_method)
         setItems(options.toTypedArray()) { _, idx ->
             when (idx) {
-                0 -> downloadOnly(activity)
-                1 -> patchBoot(activity)
+                0 -> patchBoot(activity)
+                1 -> downloadOnly(activity)
                 2 -> flash(activity)
                 3 -> installInactiveSlot(activity)
             }

--- a/app/src/main/java/com/topjohnwu/magisk/view/dialogs/MagiskInstallDialog.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/view/dialogs/MagiskInstallDialog.kt
@@ -19,13 +19,15 @@ class MagiskInstallDialog(a: BaseActivity<*, *>) : CustomAlertDialog(a) {
         setCancelable(true)
         setPositiveButton(R.string.install) { _, _ ->
             val options = ArrayList<String>()
-            options.add(a.getString(R.string.download_zip_only))
             options.add(a.getString(R.string.select_patch_file))
-            if (Shell.rootAccess()) {
-                options.add(a.getString(R.string.direct_install))
-                val s = ShellUtils.fastCmd("grep_prop ro.build.ab_update")
-                if (s.isNotEmpty() && s.toBoolean()) {
-                    options.add(a.getString(R.string.install_inactive_slot))
+            if (!Info.coreOnly){
+                options.add(a.getString(R.string.download_zip_only))
+                if (Shell.rootAccess()) {
+                    options.add(a.getString(R.string.direct_install))
+                    val s = ShellUtils.fastCmd("grep_prop ro.build.ab_update")
+                    if (s.isNotEmpty() && s.toBoolean()) {
+                        options.add(a.getString(R.string.install_inactive_slot))
+                    }
                 }
             }
             InstallMethodDialog(a, options).show()

--- a/app/src/main/res/layout/fragment_magisk.xml
+++ b/app/src/main/res/layout/fragment_magisk.xml
@@ -197,6 +197,18 @@
                             app:layout_constraintWidth_default="wrap"
                             app:layout_constraintWidth_min="300dp" />
 
+                        <CheckBox
+                            android:id="@+id/coreonly_mode"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:checked="@={viewModel.isCoreOnly}"
+                            android:text="@string/force_core_only_mode"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/recovery_mode"
+                            app:layout_constraintWidth_default="wrap"
+                            app:layout_constraintWidth_min="300dp" />
+
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
                 </LinearLayout>

--- a/app/src/main/res/raw/nonroot_utils.sh
+++ b/app/src/main/res/raw/nonroot_utils.sh
@@ -7,6 +7,7 @@ get_flags() {
   $SYSTEM_ROOT && KEEPVERITY=true || KEEPVERITY=false
   [ "`getprop ro.crypto.state`" = "encrypted" ] && KEEPFORCEENCRYPT=true || KEEPFORCEENCRYPT=false
   RECOVERYMODE=false
+  COREONLYMODE=false
 }
 
 run_migrations() { return; }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="keep_force_encryption">Preserve force encryption</string>
     <string name="keep_dm_verity">Preserve AVB 2.0/dm-verity</string>
     <string name="recovery_mode">Recovery Mode</string>
+    <string name="force_core_only_mode">Create Core-Only Mode Image</string>
     <string name="current_installed">Installed: %1$s</string>
     <string name="latest_version">Latest: %1$s</string>
     <string name="uninstall">Uninstall</string>

--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -404,6 +404,9 @@ static bool magisk_env() {
 		unlink("/sbin/resetprop");
 		unlink("/sbin/magiskhide");
 	}
+	// Trigger Forced Core-Only Mode if image configured as such
+	if (COREONLYMODE)
+		close(xopen(DISABLEFILE, O_RDONLY | O_CREAT | O_CLOEXEC, 0));
 
 	if (access(DATABIN "/busybox", X_OK) == -1)
 		return false;

--- a/native/jni/core/daemon.cpp
+++ b/native/jni/core/daemon.cpp
@@ -18,6 +18,7 @@
 
 int SDK_INT = -1;
 bool RECOVERY_MODE = false;
+bool COREONLYMODE = false;
 static struct stat self_st;
 
 static void verify_client(int client, pid_t pid) {
@@ -152,6 +153,8 @@ static void main_daemon() {
 
 	// Load config status
 	parse_prop_file(MAGISKTMP "/config", [](auto key, auto val) -> bool {
+		if (key == "COREONLYMODE" && val == "true")
+			COREONLYMODE = true;
 		if (key == "RECOVERYMODE" && val == "true")
 			RECOVERY_MODE = true;
 		return true;

--- a/native/jni/include/daemon.h
+++ b/native/jni/include/daemon.h
@@ -94,4 +94,5 @@ void broadcast_ack(int client);
 
 extern int SDK_INT;
 extern bool RECOVERY_MODE;
+extern bool COREONLYMODE;
 #define APP_DATA_DIR (SDK_INT >= 24 ? "/data/user_de" : "/data/user")

--- a/native/jni/init/getinfo.cpp
+++ b/native/jni/init/getinfo.cpp
@@ -103,6 +103,7 @@ void load_kernel_info(cmdline *cmd) {
 	bool enter_recovery = false;
 	bool kirin = false;
 	bool recovery_mode = false;
+	bool core_only_mode = false;
 
 	parse_cmdline([&](auto key, auto value) -> void {
 		LOGD("cmdline: [%s]=[%s]\n", key.data(), value);
@@ -125,6 +126,8 @@ void load_kernel_info(cmdline *cmd) {
 	});
 
 	parse_prop_file("/.backup/.magisk", [&](auto key, auto value) -> bool {
+		if (key == "COREONLYMODE" && value == "true")
+			core_only_mode = true;
 		if (key == "RECOVERYMODE" && value == "true")
 			recovery_mode = true;
 		return true;
@@ -140,6 +143,8 @@ void load_kernel_info(cmdline *cmd) {
 			recovery_mode = true;
 		}
 	}
+	if (core_only_mode)
+		LOGD("Running in Forced Core-Only mode, Modules will not be executed...\n");
 
 	if (recovery_mode) {
 		LOGD("Running in recovery mode, waiting for key...\n");

--- a/native/jni/magiskboot/ramdisk.cpp
+++ b/native/jni/magiskboot/ramdisk.cpp
@@ -41,8 +41,9 @@ bool check_env(const char *name) {
 void magisk_cpio::patch() {
 	bool keepverity = check_env("KEEPVERITY");
 	bool keepforceencrypt = check_env("KEEPFORCEENCRYPT");
-	fprintf(stderr, "Patch with flag KEEPVERITY=[%s] KEEPFORCEENCRYPT=[%s]\n",
-			keepverity ? "true" : "false", keepforceencrypt ? "true" : "false");
+	bool forcecoreonlymode = check_env("COREONLYMODE");
+	fprintf(stderr, "Patch with flag KEEPVERITY=[%s] KEEPFORCEENCRYPT=[%s] COREONLYMODE=[%s]\n",
+			keepverity ? "true" : "false", keepforceencrypt ? "true" : "false", forcecoreonlymode ? "true" : "false");
 
 	for (auto it = entries.begin(); it != entries.end();) {
 		auto cur = it++;

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -7,7 +7,7 @@
 # Usage: boot_patch.sh <bootimage>
 #
 # The following flags can be set in environment variables:
-# KEEPVERITY, KEEPFORCEENCRYPT, RECOVERYMODE
+# KEEPVERITY, KEEPFORCEENCRYPT, RECOVERYMODE, COREONLYMODE
 #
 # This script should be placed in a directory with the following files:
 #
@@ -59,8 +59,10 @@ BOOTIMAGE="$1"
 [ -z $KEEPVERITY ] && KEEPVERITY=false
 [ -z $KEEPFORCEENCRYPT ] && KEEPFORCEENCRYPT=false
 [ -z $RECOVERYMODE ] && RECOVERYMODE=false
+[ -z $COREONLYMODE ] && COREONLYMODE=false
 export KEEPVERITY
 export KEEPFORCEENCRYPT
+export COREONLYMODE
 
 chmod -R 755 .
 
@@ -137,6 +139,7 @@ ui_print "- Patching ramdisk"
 echo "KEEPVERITY=$KEEPVERITY" > config
 echo "KEEPFORCEENCRYPT=$KEEPFORCEENCRYPT" >> config
 echo "RECOVERYMODE=$RECOVERYMODE" >> config
+echo "COREONLYMODE=$COREONLYMODE" >> config
 [ ! -z $SHA1 ] && echo "SHA1=$SHA1" >> config
 
 ./magiskboot cpio ramdisk.cpio \

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -210,6 +210,7 @@ get_flags() {
   getvar KEEPVERITY
   getvar KEEPFORCEENCRYPT
   getvar RECOVERYMODE
+  getvar COREONLYMODE
   if [ -z $KEEPVERITY ]; then
     if $SYSTEM_ROOT; then
       KEEPVERITY=true
@@ -230,6 +231,7 @@ get_flags() {
     fi
   fi
   [ -z $RECOVERYMODE ] && RECOVERYMODE=false
+  [ -z $COREONLYMODE ] && COREONLYMODE=false
 }
 
 find_boot_image() {


### PR DESCRIPTION
Work on this was started independently of https://github.com/topjohnwu/Magisk/pull/1842
There is vast similarity between these two requests, with this one differing by:

* If creating a Core-Only image, offer only to patch a boot image, not flash in place or download the ZIP file, to prevent a user from accidentally making it their primary boot image or use the zip file in a Recovery that will not accept it.
* Have MagiskInit log the fact that a Core-Only image is booted, to assist troubleshooting
* Expose Core-Only Mode for utility functions