### PR TITLE
magiskboot: add unpack -n to help with repack validity tests

### DIFF
--- a/native/jni/magiskboot/bootimg.cpp
+++ b/native/jni/magiskboot/bootimg.cpp
@@ -319,7 +319,7 @@ int unpack(const char *image, bool nodecomp, bool hdr) {
 		boot.hdr->dump_hdr_file();
 
 	// Dump kernel
-	if (COMPRESSED(boot.k_fmt) && !nodecomp) {
+	if (!nodecomp && COMPRESSED(boot.k_fmt)) {
 		int fd = creat(KERNEL_FILE, 0644);
 		decompress(boot.k_fmt, fd, boot.kernel, boot.hdr->kernel_size());
 		close(fd);
@@ -331,7 +331,7 @@ int unpack(const char *image, bool nodecomp, bool hdr) {
 	dump(boot.kernel_dtb, boot.kernel_dt_size, KER_DTB_FILE);
 
 	// Dump ramdisk
-	if (COMPRESSED(boot.r_fmt) && !nodecomp) {
+	if (!nodecomp && COMPRESSED(boot.r_fmt)) {
 		int fd = creat(RAMDISK_FILE, 0644);
 		decompress(boot.r_fmt, fd, boot.ramdisk, boot.hdr->ramdisk_size());
 		close(fd);
@@ -436,7 +436,7 @@ void repack(const char* src_img, const char* out_img, bool nocomp) {
 		size_t raw_size;
 		void *raw_buf;
 		mmap_ro(RAMDISK_FILE, raw_buf, raw_size);
-		if (!COMPRESSED_ANY(check_fmt(raw_buf, raw_size)) && COMPRESSED(boot.r_fmt) && !nocomp) {
+		if (!nocomp && !COMPRESSED_ANY(check_fmt(raw_buf, raw_size)) && COMPRESSED(boot.r_fmt)) {
 			boot.hdr->ramdisk_size() = compress(boot.r_fmt, fd, raw_buf, raw_size);
 		} else {
 			boot.hdr->ramdisk_size() = xwrite(fd, raw_buf, raw_size);

--- a/native/jni/magiskboot/bootimg.cpp
+++ b/native/jni/magiskboot/bootimg.cpp
@@ -312,14 +312,14 @@ void boot_img::find_kernel_dtb() {
 	}
 }
 
-int unpack(const char *image, bool hdr) {
+int unpack(const char *image, bool nodecomp, bool hdr) {
 	boot_img boot(image);
 
 	if (hdr)
 		boot.hdr->dump_hdr_file();
 
 	// Dump kernel
-	if (COMPRESSED(boot.k_fmt)) {
+	if (COMPRESSED(boot.k_fmt) && !nodecomp) {
 		int fd = creat(KERNEL_FILE, 0644);
 		decompress(boot.k_fmt, fd, boot.kernel, boot.hdr->kernel_size());
 		close(fd);
@@ -331,7 +331,7 @@ int unpack(const char *image, bool hdr) {
 	dump(boot.kernel_dtb, boot.kernel_dt_size, KER_DTB_FILE);
 
 	// Dump ramdisk
-	if (COMPRESSED(boot.r_fmt)) {
+	if (COMPRESSED(boot.r_fmt) && !nodecomp) {
 		int fd = creat(RAMDISK_FILE, 0644);
 		decompress(boot.r_fmt, fd, boot.ramdisk, boot.hdr->ramdisk_size());
 		close(fd);

--- a/native/jni/magiskboot/magiskboot.h
+++ b/native/jni/magiskboot/magiskboot.h
@@ -12,7 +12,7 @@
 #define DTB_FILE        "dtb"
 #define NEW_BOOT        "new-boot.img"
 
-int unpack(const char *image, bool hdr = false);
+int unpack(const char *image, bool nodecomp = false, bool hdr = false);
 void repack(const char* src_img, const char* out_img, bool nocomp = false);
 int hexpatch(const char *image, const char *from, const char *to);
 int cpio_commands(int argc, char *argv[]);

--- a/native/jni/magiskboot/main.cpp
+++ b/native/jni/magiskboot/main.cpp
@@ -21,9 +21,11 @@ FULL_VER(MagiskBoot) R"EOF(  - Boot Image Modification Tool
 Usage: %s <action> [args...]
 
 Supported actions:
-  unpack [-h] <bootimg>
+  unpack [-n] [-h] <bootimg>
     Unpack <bootimg> to, if available, kernel, kernel_dtb, ramdisk.cpio,
     second, dtb, extra, and recovery_dtbo into current directory.
+    If '-n' is provided, it will not attempt to decompress kernel or
+    ramdisk.cpio from their original formats.
     If '-h' is provided, it will dump header info to 'header',
     which will be parsed when repacking.
     Return values:
@@ -146,10 +148,26 @@ int main(int argc, char *argv[]) {
 		printf("\n");
 		munmap(buf, size);
 	} else if (argc > 2 && action == "unpack") {
-		if (argv[2] == "-h"sv) {
-			if (argc == 3)
-				usage(argv[0]);
-			return unpack(argv[3], true);
+		if (argv[2] == "-n"sv) {
+			if (argv[3] == "-h"sv) {
+				if (argc == 4)
+					usage(argv[0]);
+				return unpack(argv[4], true, true);
+			} else {
+				if (argc == 3)
+					usage(argv[0]);
+				return unpack(argv[3], true);
+			}
+		} else if (argv[2] == "-h"sv) {
+			if (argv[3] == "-n"sv) {
+				if (argc == 4)
+					usage(argv[0]);
+				return unpack(argv[4], true, true);
+			} else {
+				if (argc == 3)
+					usage(argv[0]);
+				return unpack(argv[3], false, true);
+			}
 		} else {
 			return unpack(argv[2]);
 		}

--- a/native/jni/magiskboot/main.cpp
+++ b/native/jni/magiskboot/main.cpp
@@ -148,29 +148,25 @@ int main(int argc, char *argv[]) {
 		printf("\n");
 		munmap(buf, size);
 	} else if (argc > 2 && action == "unpack") {
-		if (argv[2] == "-n"sv) {
-			if (argv[3] == "-h"sv) {
-				if (argc == 4)
+		int idx = 2;
+		bool nodecomp = false;
+		bool hdr = false;
+		for (;;) {
+			if (idx >= argc)
+				usage(argv[0]);
+			if (argv[idx][0] != '-')
+				break;
+			for (char *flag = &argv[idx][1]; *flag; ++flag) {
+				if (*flag == 'n')
+					nodecomp = true;
+				else if (*flag == 'h')
+					hdr = true;
+				else
 					usage(argv[0]);
-				return unpack(argv[4], true, true);
-			} else {
-				if (argc == 3)
-					usage(argv[0]);
-				return unpack(argv[3], true);
 			}
-		} else if (argv[2] == "-h"sv) {
-			if (argv[3] == "-n"sv) {
-				if (argc == 4)
-					usage(argv[0]);
-				return unpack(argv[4], true, true);
-			} else {
-				if (argc == 3)
-					usage(argv[0]);
-				return unpack(argv[3], false, true);
-			}
-		} else {
-			return unpack(argv[2]);
+			++idx;
 		}
+		return unpack(argv[idx], nodecomp, hdr);
 	} else if (argc > 2 && action == "repack") {
 		if (argv[2] == "-n"sv) {
 			if (argc == 3)


### PR DESCRIPTION
- support unpack without decompression to allow easy testing of magiskboot's header, structure and hashing handling by comparing repack checksum versus origbootimg
- make -n first to match repack