### PR TITLE
Script refactor and major addon.d and signing fixes

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/tasks/MagiskInstaller.kt
@@ -266,7 +266,7 @@ abstract class MagiskInstaller {
 
         val patched = File(installDir, "new-boot.img")
         if (isSigned) {
-            console.add("- Signing boot image with test keys")
+            console.add("- Signing boot image with verity keys")
             val signed = File(installDir, "signed.img")
             try {
                 withStreams(SuFileInputStream(patched), signed.outputStream().buffered()) {

--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -20,9 +20,6 @@ else
 fi
 
 initialize() {
-  # This path should work in any cases
-  TMPDIR=/dev/tmp
-
   mount /data 2>/dev/null
 
   MAGISKBIN=/data/adb/magisk
@@ -43,71 +40,43 @@ initialize() {
   fi
 }
 
-show_logo() {
-  ui_print "************************"
-  ui_print "* Magisk v$MAGISK_VER addon.d"
-  ui_print "************************"
-}
-
-installation() {
-  find_manager_apk
-  get_flags
-  find_boot_image
-  find_dtbo_image
-  [ -z $BOOTIMAGE ] && abort "! Unable to detect target image"
-  ui_print "- Target image: $BOOTIMAGE"
-  [ -z $DTBOIMAGE ] || ui_print "- DTBO image: $DTBOIMAGE"
-
-  remove_system_su
-
-  [ -f $APK ] && eval $BOOTSIGNER -verify < $BOOTIMAGE && BOOTSIGNED=true
-  $BOOTSIGNED && ui_print "- Boot image is signed with AVB 1.0"
-
-  SOURCEDMODE=true
-  cd $MAGISKBIN
-
-  # Source the boot patcher
-  . ./boot_patch.sh "$BOOTIMAGE"
-
-  ui_print "- Flashing new boot image"
-  flash_image new-boot.img "$BOOTIMAGE" || abort "! Insufficient partition size"
-  rm -f new-boot.img
-
-  if [ -f stock_boot* ]; then
-    rm -f /data/stock_boot* 2>/dev/null
-    $DATA && mv stock_boot* /data
-  fi
-
-  $KEEPVERITY || patch_dtbo_image
-
-  if [ -f stock_dtbo* ]; then
-    rm -f /data/stock_dtbo* 2>/dev/null
-    $DATA && mv stock_dtbo* /data
-  fi
-
-  cd /
-}
-
-finalize() {
-  ui_print "- Done"
-  exit 0
-}
-
 main() {
   if ! $backuptool_ab; then
     # Wait for post addon.d-v1 processes to finish
     sleep 5
   fi
+
   $BOOTMODE || recovery_actions
-  show_logo
+
+  ui_print "************************"
+  ui_print "* Magisk v$MAGISK_VER addon.d"
+  ui_print "************************"
+
   mount_partitions
+  check_data
+  get_flags
+
   if $backuptool_ab; then
     # Swap the slot for addon.d-v2
     if [ ! -z $SLOT ]; then [ $SLOT = _a ] && SLOT=_b || SLOT=_a; fi
   fi
-  installation
+
+  find_boot_image
+
+  [ -z $BOOTIMAGE ] && abort "! Unable to detect target image"
+  ui_print "- Target image: $BOOTIMAGE"
+
+  remove_system_su
+  find_manager_apk
+  patch_boot_image
+
+  cd /
+  # Cleanups
   $BOOTMODE || recovery_cleanup
-  finalize
+  rm -rf $TMPDIR
+
+  ui_print "- Done"
+  exit 0
 }
 
 case "$1" in

--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -1,7 +1,7 @@
 #MAGISK
 ##########################################################################################
 #
-# Magisk Flash Script
+# Magisk Flash Script (updater-script)
 # by topjohnwu
 #
 # This script will detect, construct the environment for Magisk
@@ -103,43 +103,10 @@ fi
 $BOOTMODE || recovery_actions
 
 ##########################################################################################
-# Boot patching
+# Boot/DTBO Patching
 ##########################################################################################
 
-eval $BOOTSIGNER -verify < $BOOTIMAGE && BOOTSIGNED=true
-$BOOTSIGNED && ui_print "- Boot image is signed with AVB 1.0"
-
-SOURCEDMODE=true
-cd $MAGISKBIN
-
-$IS64BIT && mv -f magiskinit64 magiskinit || rm -f magiskinit64
-
-# Source the boot patcher
-. ./boot_patch.sh "$BOOTIMAGE"
-
-ui_print "- Flashing new boot image"
-
-if ! flash_image new-boot.img "$BOOTIMAGE"; then
-  ui_print "- Compressing ramdisk to fit in partition"
-  ./magiskboot cpio ramdisk.cpio compress
-  ./magiskboot repack "$BOOTIMAGE"
-  flash_image new-boot.img "$BOOTIMAGE" || abort "! Insufficient partition size"
-fi
-
-./magiskboot cleanup
-rm -f new-boot.img
-
-if [ -f stock_boot* ]; then
-  rm -f /data/stock_boot* 2>/dev/null
-  $DATA && mv stock_boot* /data
-fi
-
-$KEEPVERITY || patch_dtbo_image
-
-if [ -f stock_dtbo* ]; then
-  rm -f /data/stock_dtbo* 2>/dev/null
-  $DATA && mv stock_dtbo* /data
-fi
+patch_boot_image
 
 cd /
 # Cleanups

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -256,7 +256,7 @@ flash_image() {
   esac
   if $BOOTSIGNED; then
     CMD2="$BOOTSIGNER -sign"
-    ui_print "- Sign image with test keys"
+    ui_print "- Sign image with verity keys"
   else
     CMD2="cat -"
   fi

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -293,6 +293,45 @@ patch_dtbo_image() {
   return 1
 }
 
+patch_boot_image() {
+  # Common installation script for flash_script.sh (updater-script) and addon.d.sh
+  eval $BOOTSIGNER -verify < $BOOTIMAGE && BOOTSIGNED=true
+  $BOOTSIGNED && ui_print "- Boot image is signed with AVB 1.0"
+
+  SOURCEDMODE=true
+  cd $MAGISKBIN
+
+  $IS64BIT && mv -f magiskinit64 magiskinit 2>/dev/null || rm -f magiskinit64
+
+  # Source the boot patcher
+  . ./boot_patch.sh "$BOOTIMAGE"
+
+  ui_print "- Flashing new boot image"
+
+  if ! flash_image new-boot.img "$BOOTIMAGE"; then
+    ui_print "- Compressing ramdisk to fit in partition"
+    ./magiskboot cpio ramdisk.cpio compress
+    ./magiskboot repack "$BOOTIMAGE"
+    flash_image new-boot.img "$BOOTIMAGE" || abort "! Insufficient partition size"
+  fi
+
+  ./magiskboot cleanup
+  rm -f new-boot.img
+
+  if [ -f stock_boot* ]; then
+    rm -f /data/stock_boot* 2>/dev/null
+    $DATA && mv stock_boot* /data
+  fi
+
+  # Patch DTBO together with boot image
+  $KEEPVERITY || patch_dtbo_image
+
+  if [ -f stock_dtbo* ]; then
+    rm -f /data/stock_dtbo* 2>/dev/null
+    $DATA && mv stock_dtbo* /data
+  fi
+}
+
 sign_chromeos() {
   ui_print "- Signing ChromeOS boot image"
 
@@ -360,13 +399,16 @@ check_data() {
 }
 
 find_manager_apk() {
-  APK=/data/adb/magisk.apk
+  [ -z $APK ] && APK=/data/adb/magisk.apk
   [ -f $APK ] || APK=/data/magisk/magisk.apk
   [ -f $APK ] || APK=/data/app/com.topjohnwu.magisk*/*.apk
   if [ ! -f $APK ]; then
-    DBAPK=`magisk --sqlite "SELECT value FROM strings WHERE key='requester'" | cut -d= -f2`
-    [ -z "$DBAPK" ] || APK=/data/app/$DBAPK*/*.apk
+    DBAPK=`magisk --sqlite "SELECT value FROM strings WHERE key='requester'" 2>/dev/null | cut -d= -f2`
+    [ -z $DBAPK ] && DBAPK=`strings /data/adb/magisk.db | grep 5requester | cut -c11-`
+    [ -z $DBAPK ] || APK=/data/user_de/*/$DBAPK/dyn/*.apk
+    [ -f $APK ] || APK=/data/app/$DBAPK*/*.apk
   fi
+  [ -f $APK ] || ui_print "! Unable to detect Magisk Manager APK for BootSigner"
 }
 
 #################

--- a/signing/src/main/java/com/topjohnwu/signing/SignBoot.java
+++ b/signing/src/main/java/com/topjohnwu/signing/SignBoot.java
@@ -33,6 +33,12 @@ public class SignBoot {
     private static final int BOOT_IMAGE_HEADER_V1_RECOVERY_DTBO_SIZE_OFFSET = 1632;
     private static final int BOOT_IMAGE_HEADER_V2_DTB_SIZE_OFFSET = 1648;
 
+    /* Arbitrary maximum header version value; when greater assume the field is dt/extra size */
+    private static final int BOOT_IMAGE_HEADER_VERSION_MAXIMUM = 8;
+
+    /* Maximum header size byte value to read (bootimg minimum page size) */
+    private static final int BOOT_IMAGE_HEADER_SIZE_MAXIMUM = 2048;
+
     private static class PushBackRWStream extends FilterInputStream {
         private OutputStream out;
         private int pos = 0;
@@ -82,7 +88,7 @@ public class SignBoot {
                                       InputStream cert, InputStream key) {
         try {
             PushBackRWStream in = new PushBackRWStream(imgIn, imgOut);
-            byte[] hdr = new byte[1024];
+            byte[] hdr = new byte[BOOT_IMAGE_HEADER_SIZE_MAXIMUM];
             // First read the header
             in.read(hdr);
             int signableSize = getSignableImageSize(hdr);
@@ -113,7 +119,7 @@ public class SignBoot {
     public static boolean verifySignature(InputStream imgIn, InputStream certIn) {
         try {
             // Read the header for size
-            byte[] hdr = new byte[1024];
+            byte[] hdr = new byte[BOOT_IMAGE_HEADER_SIZE_MAXIMUM];
             if (imgIn.read(hdr) != hdr.length)
                 return false;
             int signableSize = getSignableImageSize(hdr);
@@ -141,7 +147,8 @@ public class SignBoot {
                 System.err.println("Signature is INVALID");
             }
         } catch (Exception e) {
-            System.err.println("Invalid image: not signed");
+            e.printStackTrace();
+            return false;
         }
         return false;
     }
@@ -165,8 +172,8 @@ public class SignBoot {
                 + ((kernelSize + pageSize - 1) / pageSize) * pageSize
                 + ((ramdskSize + pageSize - 1) / pageSize) * pageSize
                 + ((secondSize + pageSize - 1) / pageSize) * pageSize;
-        int headerVersion = image.getInt(); // boot image header version or extra size
-        if (headerVersion > 0 && headerVersion < 4) {
+        int headerVersion = image.getInt(); // boot image header version or dt/extra size
+        if (headerVersion > 0 && headerVersion < BOOT_IMAGE_HEADER_VERSION_MAXIMUM) {
             image.position(BOOT_IMAGE_HEADER_V1_RECOVERY_DTBO_SIZE_OFFSET);
             int recoveryDtboLength = image.getInt();
             length += ((recoveryDtboLength + pageSize - 1) / pageSize) * pageSize;
@@ -183,7 +190,7 @@ public class SignBoot {
                         "Invalid image header: invalid header length");
             }
         } else {
-            // headerVersion is 0 or actually extra size in this case
+            // headerVersion is 0 or actually dt/extra size in this case
             length += ((headerVersion + pageSize - 1) / pageSize) * pageSize;
         }
         length = ((length + pageSize - 1) / pageSize) * pageSize;


### PR DESCRIPTION
scripts: refactor and major addon.d fixes
- remove redundant addon.d.sh script bits that were covered elsewhere ($TMPDIR in util_functions.sh, find_dtbo_image in patch_dtbo_image)
- refactor addon.d.sh and flash_script.sh for simplicity and readability, and put common flashing script in util_functions.sh (as patch_boot_image), which should greatly help avoid them getting out of sync going forward and fixes compressing ramdisk support and post-patch cleanup for addon.d
- add check_data to addon.d.sh since moving stock_boot* and stock_dtbo* backups depend on it and so weren't occuring with addon.d
- fix find_manager_apk with working fallback for recovery addon.d execution (where `magisk --sqlite` will not work for hidden Manager), Manager DynAPK hiding, and print a useful log warning if an APK can't be found

signing: fixes for bootimg hdr_v1 and hdr_v2
- increase SignBoot bootimg header version maximum from 4 to 8 (upstream AOSP is already at 3) and make a variable for future ease
- hdr read size of 1024 bytes was too small as hdr_v1 and hdr_v2 have increased the used header page areas to 1632 and 1648 bytes, respectively, so raise this to the minimum page size of 2048 and also make a variable for future ease
- do not return "not signed" for all caught exceptions, show StackTrace for future debugging then still return false for script purposes
- correct "test keys" boot image signing strings (scripts and app) to "verity keys"

May fix boot image signing issues identified in https://github.com/topjohnwu/Magisk/issues/2013