### PR TITLE
Fixes for recovery addon.d-v1 AVBv1 signing + SignBoot

### DIFF
--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -20,9 +20,8 @@ else
 fi
 
 initialize() {
-  mount /data 2>/dev/null
-
   MAGISKBIN=/data/adb/magisk
+
   if [ ! -d $MAGISKBIN ]; then
     echo "! Cannot find Magisk binaries!"
     exit 1
@@ -45,6 +44,9 @@ main() {
     # Wait for post addon.d-v1 processes to finish
     sleep 5
   fi
+
+  # Ensure we aren't in /tmp/addon.d anymore (since it's been deleted by addon.d)
+  cd $TMPDIR
 
   $BOOTMODE || recovery_actions
 

--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -84,6 +84,8 @@ if [ -d /system/addon.d ]; then
 #!/sbin/sh
 # ADDOND_VERSION=2
 
+mount /data 2>/dev/null
+
 if [ -f /data/adb/magisk/addon.d.sh ]; then
   exec sh /data/adb/magisk/addon.d.sh "\$@"
 else

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -295,11 +295,11 @@ patch_dtbo_image() {
 
 patch_boot_image() {
   # Common installation script for flash_script.sh (updater-script) and addon.d.sh
-  eval $BOOTSIGNER -verify < $BOOTIMAGE && BOOTSIGNED=true
-  $BOOTSIGNED && ui_print "- Boot image is signed with AVB 1.0"
-
   SOURCEDMODE=true
   cd $MAGISKBIN
+
+  eval $BOOTSIGNER -verify < $BOOTIMAGE && BOOTSIGNED=true
+  $BOOTSIGNED && ui_print "- Boot image is signed with AVB 1.0"
 
   $IS64BIT && mv -f magiskinit64 magiskinit 2>/dev/null || rm -f magiskinit64
 


### PR DESCRIPTION
scripts: fix signing in recovery with addon.d-v1
- change to $TMPDIR in addon.d.sh since recovery addon.d-v1 backup + restore leaves you in /tmp/addon.d which the restore then deletes, which would break $BOOTSIGNER execution with the following:
```
    libc: Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0 in tid 1078 (main), pid 1078 (main)
    Segmentation fault
```
- also move $BOOTSIGNER execution to after `cd $MAGISKBIN` to ensure it's in a working directory in all cases
- addon.d.sh data mount wasn't doing anything since /data has to already be mounted for the script to be running, so move it into /system/addon.d/99-magisk.sh stub script where it might be useful on recoveries that don't mount /data initially

Fixes #2013

SignBoot: improve error catching/reporting
- `!= remain` shouldn't indicate "not signed", it should indicate a read error as with `!= hdr.length`
- attempt to catch unsigned images at signature read, before they make it to `BootSignature bootsig = new BootSignature(signature);` and result in the following:
```
    java.io.IOException: unexpected end-of-contents marker
            at org.bouncycastle.asn1.ASN1InputStream.readObject(Unknown Source:14)
            at com.topjohnwu.signing.SignBoot$BootSignature.<init>(SignBoot.java:230)
            at com.topjohnwu.signing.SignBoot.verifySignature(SignBoot.java:139)
            at com.topjohnwu.signing.BootSigner.main(BootSigner.java:15)
            at a.a.main(a.java:20)
```