### PR TITLE
SignBoot: also catch empty streamed signature as indicating not signed

### DIFF
--- a/signing/src/main/java/com/topjohnwu/signing/SignBoot.java
+++ b/signing/src/main/java/com/topjohnwu/signing/SignBoot.java
@@ -136,7 +136,7 @@ public class SignBoot {
 
             // Read footer, which contains the signature
             byte[] signature = new byte[4096];
-            if (imgIn.read(signature) == -1) {
+            if (imgIn.read(signature) == -1 || Arrays.equals(signature, new byte [signature.length])) {
                 System.err.println("Invalid image: not signed");
                 return false;
             }


### PR DESCRIPTION
- compare against new byte[] array as a quick tell, since when streaming from a partition with an unsigned image the "signature" would of course read without issue but then remain filled by zero padding, resulting in the following:
    java.io.IOException: unexpected end-of-contents marker
        at org.bouncycastle.asn1.ASN1InputStream.readObject(Unknown Source:14)
        at com.topjohnwu.signing.SignBoot$BootSignature.<init>(SignBoot.java:235)
        at com.topjohnwu.signing.SignBoot.verifySignature(SignBoot.java:144)
        at com.topjohnwu.signing.BootSigner.main(BootSigner.java:15)
        at a.a.main(a.java:20)