### PR TITLE
magiskboot: add simple workaround for Samsung offset header variant

### DIFF
--- a/native/jni/magiskboot/bootimg.cpp
+++ b/native/jni/magiskboot/bootimg.cpp
@@ -221,7 +221,7 @@ void boot_img::parse_image(uint8_t *addr) {
 			hdr = new dyn_img_v0(addr);
 	}
 
-	for (int i = SHA_DIGEST_SIZE; i < SHA256_DIGEST_SIZE; ++i) {
+	for (int i = SHA_DIGEST_SIZE + 4; i < SHA256_DIGEST_SIZE; ++i) {
 		if (hdr->id()[i]) {
 			flags |= SHA256_FLAG;
 			break;


### PR DESCRIPTION
- some Samsung devices (e.g. Galaxy S5 SMG-900H) use a slightly different AOSP bootimg.h variant with `#define BOOT_NAME_SIZE 20` instead of 16
- since all known examples of these device images do not have anything in the NAME or CMDLINE fields, and the bootloader also accepts standard AOSP images, simply offset the SHA1/SHA256 detection by 4 bytes to avoid false positives from these images, remain a equally effective detection shortcut, and ensure a proper SHA1 checksum on repack

```
aosp-dtbhdt2-4offhash-seandroid-256sig-samsung_gs5-smg900h-boot.img:
UNPACK CHECKSUM [00000000b11580f7d20f70297cdc31e02626def0356c82b90000000000000000]
REPACK CHECKSUM [73b18751202e56c433f89dfd1902c290eaf4eef3e167fcf03b814b59a5e984b6]
AIK CHECKSUM    [b11580f7d20f70297cdc31e02626def0356c82b9000000000000000000000000]
```

This patch should result in a `magiskboot unpack -n boot.img; magiskboot repack boot.img` new-boot.img matching the AIK CHECKSUM above.