### PR TITLE
Exclude recovery DTBO from patching.

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/tasks/MagiskInstaller.kt
@@ -287,8 +287,6 @@ abstract class MagiskInstaller {
     protected fun flashBoot(): Boolean {
         if (!"direct_install $installDir $srcBoot".sh().isSuccess)
             return false
-        if (!Info.keepVerity)
-            "patch_dtbo_image".sh()
         return true
     }
 

--- a/app/src/main/res/raw/utils.sh
+++ b/app/src/main/res/raw/utils.sh
@@ -44,7 +44,7 @@ direct_install() {
 }
 
 mm_patch_dtbo() {
-  $KEEPVERITY && return 1 || patch_dtbo_image
+  $KEEPVERITY && return 1
 }
 
 restore_imgs() {

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -157,7 +157,7 @@ rm -f ramdisk.cpio.orig config
 # Binary patches
 ##########################################################################################
 
-for dt in dtb kernel_dtb extra recovery_dtbo; do
+for dt in dtb kernel_dtb extra; do
   [ -f $dt ] && ./magiskboot dtb $dt patch && ui_print "- Patching fstab in $dt"
 done
 

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -323,9 +323,6 @@ patch_boot_image() {
     $DATA && mv stock_boot* /data
   fi
 
-  # Patch DTBO together with boot image
-  $KEEPVERITY || patch_dtbo_image
-
   if [ -f stock_dtbo* ]; then
     rm -f /data/stock_dtbo* 2>/dev/null
     $DATA && mv stock_dtbo* /data


### PR DESCRIPTION
See the DTBO mangling issue at https://github.com/topjohnwu/Magisk/issues/2073 for the background to this PR.

I'm submitting this just in case it will work for the generic case, i.e. not only Qualcomm-based Samsung devices. It does, at least, work for those devices, but I have no idea if all hell will break loose on other makes and models.
