### PR TITLE
Android Q Apex Fix

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -118,7 +118,7 @@ recovery_actions() {
     [ -L /apex ] && rm -f /apex
     # Apex files present - needs to extract and mount the payload imgs
     if [ -f "/system/apex/com.android.runtime.release.apex" ]; then
-      local j=0
+      local j=0 k=0
       for i in /system/apex/*.apex; do
         local DEST="/apex/$(basename $i | sed 's/.apex$//')"
         [ "$DEST" == "/apex/com.android.runtime.release" ] && DEST="/apex/com.android.runtime"
@@ -127,9 +127,10 @@ recovery_actions() {
         mv -f /apex/apex_payload.img $DEST.img
         while [ $j -lt 50 ]; do
           local loop=/dev/loop$j
-          mknod $loop b 7 $j 2>/dev/null
+          mknod $loop b 7 $k 2>/dev/null
           losetup $loop $DEST.img 2>/dev/null
           j=$((j + 1))
+          k=$((k + 8))
           losetup $loop | grep -q $DEST.img && break
         done;
         [ -z $floop ] && floop=$((j - 1))

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -118,7 +118,8 @@ recovery_actions() {
     [ -L /apex ] && rm -f /apex
     # Apex files present - needs to extract and mount the payload imgs
     if [ -f "/system/apex/com.android.runtime.release.apex" ]; then
-      local j=0 k=0
+      local j=0
+      [ -e /dev/block/loop1 ] && local minorx=$(ls -l /dev/block/loop1 | awk '{print $6}') || local minorx=1
       for i in /system/apex/*.apex; do
         local DEST="/apex/$(basename $i | sed 's/.apex$//')"
         [ "$DEST" == "/apex/com.android.runtime.release" ] && DEST="/apex/com.android.runtime"
@@ -127,10 +128,9 @@ recovery_actions() {
         mv -f /apex/apex_payload.img $DEST.img
         while [ $j -lt 50 ]; do
           local loop=/dev/loop$j
-          mknod $loop b 7 $k 2>/dev/null
+          mknod $loop b 7 $((j * minorx)) 2>/dev/null
           losetup $loop $DEST.img 2>/dev/null
           j=$((j + 1))
-          k=$((k + 8))
           losetup $loop | grep -q $DEST.img && break
         done;
         [ -z $floop ] && floop=$((j - 1))


### PR DESCRIPTION
Fix for android Q devices in twrp based recoveries. [See issue for more details](https://github.com/topjohnwu/Magisk/issues/2109)

Mounts /system/apex modules to /apex location, renaming them as required. Doesn't touch system and enables dynamically linked binaries to work as expected in recovery