### PR TITLE
magiskhide: hide /proc/net/unix from the world

### DIFF
--- a/native/jni/include/magisk.h
+++ b/native/jni/include/magisk.h
@@ -21,6 +21,7 @@
 #define MAGISKDB        SECURE_DIR "/magisk.db"
 #define BOOTCOUNT       SECURE_DIR "/.boot_count"
 #define MANAGERAPK      DATABIN "/magisk.apk"
+#define PROC_NET_UNIX   "/proc/net/unix"
 
 // Legacy crap
 #define LEGACYCORE      MODULEROOT "/.core"

--- a/native/jni/magiskhide/hide_policy.cpp
+++ b/native/jni/magiskhide/hide_policy.cpp
@@ -36,6 +36,10 @@ static inline void lazy_unmount(const char* mountpoint) {
 }
 
 void hide_daemon(int pid) {
+	// Make the file /proc/net/unix unreadable because it
+	// would otherwise allow apps to find out about Magisk,
+	// even if hidden
+	chmod(PROC_NET_UNIX, 0440);
 	run_finally fin([=]() -> void {
 		// Send resume signal
 		kill(pid, SIGCONT);


### PR DESCRIPTION
Some apps (especially banking apps) use the file
/proc/net/unix to check whether tools like Magisk
are installed/running. From my own experience I can
tell that chmod'ing that file 440 is really a oneliner
fix for such banking apps.

Test: manual, > 4 months on Android 9.0 and 10.0

I've read that from Magisk 19.4 this is already fixed but for me it never really worked and this fixed it once and for all.

I'm not sure whether this needs sepolicy rules. I'm not familiar enough with sepolicy to write proper rules for this so I'm kindly asking for your expertise regarding this.
I also haven't been able to compile the binary using your FrankeNDK. Please verify the code before merging.

References:
https://twitter.com/arter97/status/1140717230054760448
https://github.com/topjohnwu/Magisk/issues/1226#issuecomment-474425647
https://forum.xda-developers.com/showpost.php?p=79769269&postcount=5
https://www.didgeridoohan.com/magisk/MagiskHide#hn_UDS_detection
https://github.com/halogenOS/android_vendor_aosp/commit/8ee1cf7518aa779a38f14f81e63caf4701e50373
https://github.com/halogenOS/android_vendor_aosp/commit/12db4f79b378c07d59fcbf4e7a9a425e49f4664e
https://gerrit.pixelexperience.org/c/vendor_aosp/+/1230
https://github.com/DerpLab/platform_vendor_aosip/commit/a3a479797b75ce3c00bb9e3e5dcf9f02e3bea49b