### PR TITLE
Fix Magisk detection by parsing ro.bootmode

### DIFF
--- a/native/jni/magiskhide/hide_policy.cpp
+++ b/native/jni/magiskhide/hide_policy.cpp
@@ -12,12 +12,12 @@ using namespace std;
 static const char *prop_key[] =
 		{ "ro.boot.vbmeta.device_state", "ro.boot.verifiedbootstate", "ro.boot.flash.locked",
 		  "ro.boot.veritymode", "ro.boot.warranty_bit", "ro.warranty_bit", "ro.debuggable",
-		  "ro.secure", "ro.build.type", "ro.build.tags", "ro.build.selinux", "ro.bootmode", nullptr };
+		  "ro.secure", "ro.build.type", "ro.build.tags", "ro.build.selinux", "ro.bootmode", "ro.boot.mode", nullptr };
 
 static const char *prop_value[] =
 		{ "locked", "green", "1",
 		  "enforcing", "0", "0", "0",
-		  "1", "user", "release-keys", "0", "unknown", nullptr };
+		  "1", "user", "release-keys", "0", "unknown", "unknown", nullptr };
 
 void hide_sensitive_props() {
 	LOGI("hide_policy: Hiding sensitive props\n");

--- a/native/jni/magiskhide/hide_policy.cpp
+++ b/native/jni/magiskhide/hide_policy.cpp
@@ -12,12 +12,12 @@ using namespace std;
 static const char *prop_key[] =
 		{ "ro.boot.vbmeta.device_state", "ro.boot.verifiedbootstate", "ro.boot.flash.locked",
 		  "ro.boot.veritymode", "ro.boot.warranty_bit", "ro.warranty_bit", "ro.debuggable",
-		  "ro.secure", "ro.build.type", "ro.build.tags", "ro.build.selinux", nullptr };
+		  "ro.secure", "ro.build.type", "ro.build.tags", "ro.build.selinux", "ro.bootmode", nullptr };
 
 static const char *prop_value[] =
 		{ "locked", "green", "1",
 		  "enforcing", "0", "0", "0",
-		  "1", "user", "release-keys", "0", nullptr };
+		  "1", "user", "release-keys", "0", "unknown", nullptr };
 
 void hide_sensitive_props() {
 	LOGI("hide_policy: Hiding sensitive props\n");


### PR DESCRIPTION
This prevents apps from detecting Magisk when Magisk is installed to the recovery partition. In this configuration, ro.bootmode is set to recovery, meanwhile booting normally produces "unknown" in this field.