### PR TITLE
Add missing verity and encryption flags

### DIFF
--- a/native/jni/magiskboot/pattern.cpp
+++ b/native/jni/magiskboot/pattern.cpp
@@ -8,7 +8,13 @@
 static int check_verity_pattern(const char *s) {
 	int skip = 0;
 	if (s[0] == ',') ++skip;
-	if (strncmp(s + skip, "verify", 6) == 0)
+	if (strncmp(s + skip, "support_scfs,verify", 19) == 0)
+			skip += 19;
+	else if (strncmp(s + skip, "verify,support_scfs", 19) == 0)
+			skip += 19;
+	else if (strncmp(s + skip, "support_scfs", 12) == 0)
+		skip += 12;
+	else if (strncmp(s + skip, "verify", 6) == 0)
 		skip += 6;
 	else if (strncmp(s + skip, "avb", 3) == 0)
 		skip += 3;
@@ -22,7 +28,7 @@ static int check_verity_pattern(const char *s) {
 }
 
 static int check_encryption_pattern(const char *s) {
-	static const char *encrypt_list[] = { "forceencrypt", "forcefdeorfbe" };
+	static const char *encrypt_list[] = { "forceencrypt", "forcefdeorfbe", "fileencryption" };
 	for (auto enc : encrypt_list) {
 		int len = strlen(enc);
 		if (strncmp(s, enc, len) == 0)


### PR DESCRIPTION
Add missing strings for verity and forceencrypt.
fileencryption is used on oneplus devices (and probably others) (I've verified this on my OP5T)
support_scfs,verify is used on some samsungs (see https://twitter.com/arter97/status/614118117719932928 and https://forum.xda-developers.com/note5/orig-development/kernel-discussion-root-recompiling-t3219990
The reason I have them all as separate entries rather than just one for support_scfs is because
if there's multiple matches together like `support_scfs,verify`, then the comma will only get removed for the first match which would leave an extra comma on the line. Still looking into why that occurs.
Seems to be this way in any event where there's multiple matches on the same line next to each other.
So if it's something like: `wait,support_scfs,verify`
It becomes: `wait,`
And the output is:
```
Remove pattern [,support_scfs]
Remove pattern [verify]
```

So the current solution works fine but isn't most ideal