### PR TITLE
Ignore twrp fstabs

### DIFF
--- a/native/jni/magiskboot/ramdisk.cpp
+++ b/native/jni/magiskboot/ramdisk.cpp
@@ -47,8 +47,11 @@ void magisk_cpio::patch() {
 	for (auto it = entries.begin(); it != entries.end();) {
 		auto cur = it++;
 		bool fstab = (!keepverity || !keepforceencrypt) &&
-					 !str_starts(cur->first, ".backup") && !str_contains(cur->first, "twrp") && !str_contains(cur->first, "recovery") &&
-					 str_contains(cur->first, "fstab") && S_ISREG(cur->second->mode);
+					 S_ISREG(cur->second->mode) &&
+					 !str_starts(cur->first, ".backup") && 
+					 !str_contains(cur->first, "twrp") && 
+					 !str_contains(cur->first, "recovery") &&
+					 str_contains(cur->first, "fstab");
 		if (!keepverity) {
 			if (fstab) {
 				fprintf(stderr, "Found fstab file [%s]\n", cur->first.data());

--- a/native/jni/magiskboot/ramdisk.cpp
+++ b/native/jni/magiskboot/ramdisk.cpp
@@ -47,7 +47,7 @@ void magisk_cpio::patch() {
 	for (auto it = entries.begin(); it != entries.end();) {
 		auto cur = it++;
 		bool fstab = (!keepverity || !keepforceencrypt) &&
-					 !str_starts(cur->first, ".backup") &&
+					 !str_starts(cur->first, ".backup") && !str_contains(cur->first, "twrp") && !str_contains(cur->first, "recovery") &&
 					 str_contains(cur->first, "fstab") && S_ISREG(cur->second->mode);
 		if (!keepverity) {
 			if (fstab) {


### PR DESCRIPTION
In system as root devices or any other device that has twrp in the boot img, magiskboot will patch the twrp fstabs which can cause errors in twrp. This pull should fix that assuming they're not named anything else by other maintainers 