### PR TITLE
Script fixes for Android 10 + Tegra, magiskboot improvement

### DIFF
--- a/native/jni/init/mount.cpp
+++ b/native/jni/init/mount.cpp
@@ -211,7 +211,7 @@ void SARInit::early_mount() {
 	if (dev < 0) {
 		// Try NVIDIA naming scheme
 		strcpy(partname, "APP");
-		dev = setup_block();
+		dev = setup_block(false);
 		if (dev < 0) {
 			// We don't really know what to do at this point...
 			LOGE("Cannot find root partition, abort\n");

--- a/native/jni/magiskboot/compress.cpp
+++ b/native/jni/magiskboot/compress.cpp
@@ -563,10 +563,10 @@ void decompress(char *infile, const char *outfile) {
 		if (!strm) {
 			format_t type = check_fmt(buf, len);
 
+			fprintf(stderr, "Detected format: [%s]\n", fmt2name[type]);
+
 			if (!COMPRESSED(type))
 				LOGE("Input file is not a supported compressed type!\n");
-
-			fprintf(stderr, "Detected format: [%s]\n", fmt2name[type]);
 
 			/* If user does not provide outfile, infile has to be either
 	 		* <path>.[ext], or '-'. Outfile will be either <path> or '-'.


### PR DESCRIPTION
* fix Tegra-named "APP" block /system partition mounting
* fix lzop detection use-case of `magiskboot decompress` which was broken in the generic stream refactor
* adjust mount scripts to support SOS, APP and CAC Tegra partition naming (vendor is still vendor, oddly)
* -Xnodex2oat is removed on Android 10 in AOSP (despite it still erroneously showing in `dalvikvm --help`), older devices will still run safely without it
* Android 10 dynamically linked binaries need APEX mounts and variables so add this to recovery_actions/cleanup (thanks @Zackptg5)