### PR TITLE
Add null terminator

### DIFF
--- a/native/jni/init/rootdir.cpp
+++ b/native/jni/init/rootdir.cpp
@@ -218,6 +218,7 @@ static void recreate_sbin(const char *mirror, bool use_bind_mount) {
 		fstatat(src, entry->d_name, &st, AT_SYMLINK_NOFOLLOW);
 		if (S_ISLNK(st.st_mode)) {
 			xreadlinkat(src, entry->d_name, buf, sizeof(buf));
+			buf[st.st_size] = '\0';
 			xsymlink(buf, sbin_path.data());
 		} else {
 			sprintf(buf, "%s/%s", mirror, entry->d_name);


### PR DESCRIPTION
readlinkat() does not append a null terminator to buf and may produce wrong link path for newly created symbolic links.

may closes #2247

Signed-off-by: Shaka Huang <shakalaca@gmail.com>