### PR TITLE
Add ianmacd theme to Magisk Manager for better contrast.

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/theme/Theme.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/theme/Theme.kt
@@ -35,6 +35,10 @@ enum class Theme(
     Salamence(
         themeName = "Salamence",
         themeRes = R.style.ThemeFoundationMD2_Salamence
+    ),
+    Ianmacd(
+        themeName = "ianmacd",
+        themeRes = R.style.ThemeFoundationMD2_Ianmacd
     );
 
     val isSelected get() = Config.themeOrdinal == ordinal

--- a/app/src/main/res/layout/fragment_theme_md2.xml
+++ b/app/src/main/res/layout/fragment_theme_md2.xml
@@ -155,6 +155,23 @@
 
             </FrameLayout>
 
+            <FrameLayout
+                android:id="@+id/theme_ianmacd"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/l1"
+                android:theme="@style/ThemeFoundationMD2.Ianmacd"
+                app:layout_constraintEnd_toEndOf="@+id/theme_mew"
+                app:layout_constraintStart_toStartOf="@+id/theme_mew"
+                app:layout_constraintTop_toBottomOf="@+id/theme_mew">
+
+                <include
+                    layout="@layout/item_theme"
+                    theme="@{Theme.Ianmacd}"
+                    viewModel="@{viewModel}" />
+
+            </FrameLayout>
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values-night/themes_md2.xml
+++ b/app/src/main/res/values-night/themes_md2.xml
@@ -33,4 +33,12 @@
 
     <!--3rd party themes-->
 
+    <style name="ThemeFoundationMD2.Ianmacd" parent="ThemeFoundationMD2.Amoled">
+        <item name="colorPrimary">#47AE84</item>
+        <item name="colorPrimaryVariant">#8047AE84</item>
+        <item name="colorSecondary">#47AE84</item>
+        <item name="colorSecondaryVariant">#8047AE84</item>
+        <item name="colorOnSurfaceVariant">#B0FFFFFF</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/themes_md2.xml
+++ b/app/src/main/res/values/themes_md2.xml
@@ -115,4 +115,12 @@
 
     <!--3rd party themes-->
 
+    <style name="ThemeFoundationMD2.Ianmacd" parent="ThemeFoundationMD2.Amoled">
+        <item name="colorPrimary">#47AE84</item>
+        <item name="colorPrimaryVariant">#8047AE84</item>
+        <item name="colorSecondary">#47AE84</item>
+        <item name="colorSecondaryVariant">#8047AE84</item>
+        <item name="colorOnSurfaceVariant">#B0FFFFFF</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
This theme provides higher contrast caption text, as well as a soothing green primary colour.