### PR TITLE
Fix crash during boot in x86 platform

### DIFF
--- a/native/jni/init/rootdir.cpp
+++ b/native/jni/init/rootdir.cpp
@@ -217,7 +217,14 @@ static void recreate_sbin(const char *mirror, bool use_bind_mount) {
 		struct stat st;
 		fstatat(src, entry->d_name, &st, AT_SYMLINK_NOFOLLOW);
 		if (S_ISLNK(st.st_mode)) {
+#if defined(__i386__)
+			// readlinkat() may failed on x86 platform, returning random value 
+			// instead of  number of bytes placed in buf (length of link)
+			memset(buf, 0, sizeof(buf));
+			readlinkat(src, entry->d_name, buf, sizeof(buf));
+#else
 			xreadlinkat(src, entry->d_name, buf, sizeof(buf));
+#endif
 			xsymlink(buf, sbin_path.data());
 		} else {
 			sprintf(buf, "%s/%s", mirror, entry->d_name);


### PR DESCRIPTION
readlinkat() in may return random value instead of the number of bytes placed in buf and crashing the system in two ways:
1. segmentation fault (buf[-7633350] = ‘\0’)
2. wrong link of watchdogd, resulting dog timeout

Confirmed working in ZenFone 2 x86 series, may fix #2247 and #2356

Signed-off-by: Shaka Huang <shakalaca@gmail.com>