### PR TITLE
fix ndk21 compilation

### DIFF
--- a/native/jni/init/init.cpp
+++ b/native/jni/init/init.cpp
@@ -102,7 +102,7 @@ static void decompress_ramdisk() {
 	uint8_t *buf;
 	size_t sz;
 	mmap_ro(ramdisk_xz, buf, sz);
-	int fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC);
+	int fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 700);
 	unxz(fd, buf, sz);
 	munmap(buf, sz);
 	close(fd);

--- a/native/jni/systemproperties/prop_info.cpp
+++ b/native/jni/systemproperties/prop_info.cpp
@@ -47,7 +47,7 @@ prop_info::prop_info(const char* name, uint32_t namelen, uint32_t long_offset) {
   memcpy(this->name, name, namelen);
   this->name[namelen] = '\0';
 
-  auto error_value_len = sizeof(kLongLegacyError) - 1;
+  const uint32_t error_value_len =  static_cast<uint32_t>(sizeof(kLongLegacyError) - 1);
   atomic_init(&this->serial, error_value_len << 24 | kLongFlag);
   memcpy(this->long_property.error_message, kLongLegacyError, sizeof(kLongLegacyError));
 


### PR DESCRIPTION
encountered the following issues building Magisk with ndk version 21
`
[arm64-v8a] Compile++      : systemproperties <= prop_info.cpp
jni/systemproperties/prop_info.cpp:51:3: error: no matching function for call to 'atomic_init'
  atomic_init(&this->serial, error_value_len << 24 | kLongFlag)
android-ndk-r21/sources/cxx-stl/llvm-libc++/include/atomic:1742:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('unsigned int' vs. 'unsigned long')
atomic_init(volatile atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
^
android-ndk-r21/sources/cxx-stl/llvm-libc++/include/atomic:1750:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('unsigned int' vs. 'unsigned long')
atomic_init(atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
^
` 
and
`
[armeabi-v7a] Compile++ thumb: magiskinit <= init.cpp
jni/init/init.cpp:105:61: error: 'open' called with O_CREAT or O_TMPFILE, but missing mode
        int fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC);
                                                                   ^
android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/fcntl.h:65:9: note: from 'diagnose_if' attribute on 'open':
        __clang_error_if(__open_modes_useful(flags), "'open' " __open_too_few_args_error) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/sys/cdefs.h:134:52: note: expanded from macro '__clang_error_if'
#define __clang_error_if(cond, msg) __attribute__((diagnose_if(cond, msg, "error")))
`