### PR TITLE
Disable Grant Button for 1 seconds after popup display

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/legacy/surequest/SuRequestViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/legacy/surequest/SuRequestViewModel.kt
@@ -39,6 +39,8 @@ class SuRequestViewModel(
 
     val selectedItemPosition = KObservableField(0)
 
+    val grantEnabled = KObservableField(false)
+
     private val items = DiffObservableList(ComparableRvItem.callback)
     private val itemBinding = ItemBinding.of<ComparableRvItem<*>> { binding, _, item ->
         item.bind(binding)
@@ -100,10 +102,13 @@ class SuRequestViewModel(
             packageName.value = policy.packageName
             selectedItemPosition.value = timeoutPrefs.getInt(policy.packageName, 0)
 
-            // Override timer
-            val millis = SECONDS.toMillis(Config.suDefaultTimeout.toLong())
+            // Override timer (+1 second because the popup need one second to appear)
+            val millis = SECONDS.toMillis(Config.suDefaultTimeout.toLong()+1)
             timer = object : CountDownTimer(millis, 1000) {
                 override fun onTick(remains: Long) {
+                    if (remains <= millis - 1000) {
+                        grantEnabled.value = true
+                    }
                     denyText.value = "${res.getString(R.string.deny)} (${remains / 1000})"
                 }
 

--- a/app/src/main/java/com/topjohnwu/magisk/legacy/surequest/SuRequestViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/legacy/surequest/SuRequestViewModel.kt
@@ -102,14 +102,14 @@ class SuRequestViewModel(
             packageName.value = policy.packageName
             selectedItemPosition.value = timeoutPrefs.getInt(policy.packageName, 0)
 
-            // Override timer (+1 second because the popup need one second to appear)
-            val millis = SECONDS.toMillis(Config.suDefaultTimeout.toLong()+1)
+            // Override timer
+            val millis = SECONDS.toMillis(Config.suDefaultTimeout.toLong())
             timer = object : CountDownTimer(millis, 1000) {
                 override fun onTick(remains: Long) {
                     if (remains <= millis - 1000) {
                         grantEnabled.value = true
                     }
-                    denyText.value = "${res.getString(R.string.deny)} (${remains / 1000})"
+                    denyText.value = "${res.getString(R.string.deny)} (${(remains / 1000) + 1})"
                 }
 
                 override fun onFinish() {

--- a/app/src/main/res/layout/activity_request.xml
+++ b/app/src/main/res/layout/activity_request.xml
@@ -141,6 +141,7 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:onClick="@{() -> viewModel.grantPressed()}"
+                    android:enabled="@{viewModel.grantEnabled}"
                     android:text="@string/grant" />
 
             </LinearLayout>


### PR DESCRIPTION
After reading #2441 I think of adding a 1second delay between the display and the ability to click the allow button to prevent miss clicking on "Grant" for unwanted applications

And I also fixed the visual countdown for being 1 lower than it should be displayed since I was modifying the `SuRequestViewModel` I fixed this bug