### PR TITLE
Add specific strings for Home + minor changes for Modules

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/module/ModuleViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/module/ModuleViewModel.kt
@@ -106,14 +106,14 @@ class ModuleViewModel(
         )
 
         private val sectionUpdate = SectionTitle(
-            R.string.module_section_pending,
-            R.string.module_section_pending_action,
+            R.string.module_section_updates,
+            R.string.module_section_action_update_all,
             R.drawable.ic_update_md2
             // enable with implementation of https://github.com/topjohnwu/Magisk/issues/2036
         ).also { it.hasButton = false }
 
         private val sectionActive = SectionTitle(
-            R.string.installed,
+            R.string.module_section_installed,
             R.string.reboot,
             R.drawable.ic_restart
         ).also { it.hasButton = false }

--- a/app/src/main/res/layout/include_home_magisk.xml
+++ b/app/src/main/res/layout/include_home_magisk.xml
@@ -142,7 +142,7 @@
 
                                 <TextView
                                     style="@style/W.Home.ItemContent"
-                                    android:text="@string/module_section_remote" />
+                                    android:text="@string/current_remote_version" />
 
                                 <TextView
                                     style="@style/W.Home.ItemContent.Right"
@@ -159,7 +159,7 @@
 
                                 <TextView
                                     style="@style/W.Home.ItemContent"
-                                    android:text="@string/installed" />
+                                    android:text="@string/current_installed_version" />
 
                                 <TextView
                                     style="@style/W.Home.ItemContent.Right"

--- a/app/src/main/res/layout/include_home_manager.xml
+++ b/app/src/main/res/layout/include_home_manager.xml
@@ -129,7 +129,7 @@
 
                                 <TextView
                                     style="@style/W.Home.ItemContent"
-                                    android:text="@string/module_section_remote" />
+                                    android:text="@string/current_remote_version" />
 
                                 <TextView
                                     style="@style/W.Home.ItemContent.Right"
@@ -146,7 +146,7 @@
 
                                 <TextView
                                     style="@style/W.Home.ItemContent"
-                                    android:text="@string/installed" />
+                                    android:text="@string/current_installed_version" />
 
                                 <TextView
                                     style="@style/W.Home.ItemContent.Right"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -31,7 +31,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">يتوفر على تحديث</string>
-    <string name="installed">مثبت</string>
+    <string name="module_section_installed">مثبت</string>
     <string name="sorting_order">ترتيب الفرز</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -29,7 +29,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Yeniləmə Var</string>
-    <string name="installed">Yüklənib</string>
+    <string name="module_section_installed">Yüklənib</string>
     <string name="sorting_order">Nizamlama Qaydası</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -29,7 +29,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Налице е актуализация.</string>
-    <string name="installed">Инсталирани</string>
+    <string name="module_section_installed">Инсталирани</string>
     <string name="sorting_order">Сортиране</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -117,15 +117,15 @@
     <string name="reboot_edl">Reiniciar a EDL</string>
     <string name="module_safe_mode_message">Està en mode segur. Cap dels mòduls instal·lats funcionarà.\nAquest missatge desapareixerà quan el mode segur es desactivi.</string>
     <string name="module_version_author">%1$s per %2$s</string>
-    <string name="module_section_pending">Actualitzacions</string>
-    <string name="module_section_pending_action">Actualitza tot</string>
+    <string name="module_section_installed">Instal·lat</string>
+    <string name="module_section_updates">Actualitzacions</string>
+    <string name="module_section_action_update_all">Actualitza tot</string>
     <string name="module_section_remote">Remot</string>
     <string name="module_state_remove">Eliminar</string>
     <string name="module_state_restore">Recuperar</string>
     <string name="module_action_install_external">Instal·lar des de l\'emmagatzematge</string>
     <string name="module_update_none">Els seus mòduls estan actualitzats!</string>
     <string name="update_available">Actualització Disponible</string>
-    <string name="installed">Instal·lat</string>
     <string name="sorting_order">Ordre de Classificació</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -28,7 +28,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Dostupná aktualizace</string>
-    <string name="installed">Nainstalováno</string>
+    <string name="module_section_installed">Nainstalováno</string>
     <string name="sorting_order">Pořadí řazení</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -106,15 +106,15 @@
     <string name="reboot_edl">Neustart im EDL-Modus</string>
     <string name="module_safe_mode_message">Sie sind im sicheren Modus. Keines der Benutzermodule wird funktionieren.\nDiese Meldung verschwindet, sobald der abgesicherte Modus deaktiviert wird.</string>
     <string name="module_version_author">%1$s von %2$s</string>
-    <string name="module_section_pending">Aktualisierungen</string>
-    <string name="module_section_pending_action">Alle aktualisieren</string>
+    <string name="module_section_installed">Installiert</string>
+    <string name="module_section_updates">Aktualisierungen</string>
+    <string name="module_section_action_update_all">Alle aktualisieren</string>
     <string name="module_section_remote">Remote</string>
     <string name="module_state_remove">Entfernen</string>
     <string name="module_state_restore">Wiederherstellen</string>
     <string name="module_action_install_external">Aus dem Speicher installieren</string>
     <string name="module_update_none">Ihre Module sind auf dem neuesten Stand!</string>
     <string name="update_available">Update verfügbar</string>
-    <string name="installed">Installiert</string>
     <string name="sorting_order">Sortierreihenfolge</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -30,7 +30,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Διαθέσιμη Ενημέρωση</string>
-    <string name="installed">Εγκαταστάθηκε</string>
+    <string name="module_section_installed">Εγκαταστάθηκε</string>
     <string name="sorting_order">Ταξινόμηση κατά</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -123,15 +123,15 @@
     <string name="reboot_edl">Reiniciar en Modo EDL</string>
     <string name="module_safe_mode_message">Estás en modo seguro. Ninguno de los módulos de usuario funcionará.\nEste mensaje desaparecerá una vez que se desactive el modo seguro.</string>
     <string name="module_version_author">%1$s por %2$s</string>
-    <string name="module_section_pending">Actualizaciones</string>
-    <string name="module_section_pending_action">¡Actualizar todo!</string>
+    <string name="module_section_installed">Instalado</string>
+    <string name="module_section_updates">Actualizaciones</string>
+    <string name="module_section_action_update_all">¡Actualizar todo!</string>
     <string name="module_section_remote">Disponible</string>
     <string name="module_state_remove">Eliminar</string>
     <string name="module_state_restore">Restaurar</string>
     <string name="module_action_install_external">Instalar desde almacenamiento</string>
     <string name="module_update_none">¡Sus módulos están actualizados!</string>
     <string name="update_available">Actualización disponible</string>
-    <string name="installed">Instalado</string>
     <string name="sorting_order">Clasificar por</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -30,7 +30,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Uuendus saadaval</string>
-    <string name="installed">Installitud</string>
+    <string name="module_section_installed">Installitud</string>
     <string name="sorting_order">Sorteerimisjärjekord</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -116,15 +116,15 @@
     <string name="reboot_edl">Redémarrer en mode secours (EDL)</string>
     <string name="module_safe_mode_message">Vous êtes en mode sans échec. Aucun des modules utilisateur ne fonctionnera. Ce message disparaîtra après désactivation du mode sans échec.</string>
     <string name="module_version_author">%1$s, par %2$s</string>
-    <string name="module_section_pending">Mises à jour</string>
-    <string name="module_section_pending_action">Tout mettre à jour</string>
+    <string name="module_section_installed">Installée</string>
+    <string name="module_section_updates">Mises à jour</string>
+    <string name="module_section_action_update_all">Tout mettre à jour</string>
     <string name="module_section_remote">À distance</string>
     <string name="module_state_remove">Supprimer</string>
     <string name="module_state_restore">Restorer</string>
     <string name="module_action_install_external">Installer depuis le stockage</string>
     <string name="module_update_none">Vos modules sont à jour !</string>
     <string name="update_available">Mise à jour disponible</string>
-    <string name="installed">Installée</string>
     <string name="sorting_order">Classement</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -30,7 +30,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">अपडेट उपलब्ध है</string>
-    <string name="installed">स्थापित</string>
+    <string name="module_section_installed">स्थापित</string>
     <string name="sorting_order">छँटाई क्रम </string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -27,7 +27,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Ažuriranje dostupno</string>
-    <string name="installed">Instalirano</string>
+    <string name="module_section_installed">Instalirano</string>
 
     <!--Log Fragment-->
     <string name="menuSaveLog">"Spremi zapisnik "</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -30,7 +30,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Pembaruan Tersedia</string>
-    <string name="installed">Terpasang</string>
+    <string name="module_section_installed">Terpasang</string>
     <string name="sorting_order">Urutkan Susunan</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -117,15 +117,15 @@
     <string name="reboot_edl">Riavvia in EDL</string>
     <string name="module_safe_mode_message">È stata attivata la modalità sicura. I moduli dell\'utente non funzioneranno.\nQuesto messaggio scomprarirà quando la modalità verrà disabilitata.</string>
     <string name="module_version_author">%1$s di %2$s</string>
-    <string name="module_section_pending">Aggiornamenti</string>
-    <string name="module_section_pending_action">Aggiorna tutto</string>
+    <string name="module_section_installed">Installato</string>
+    <string name="module_section_updates">Aggiornamenti</string>
+    <string name="module_section_action_update_all">Aggiorna tutto</string>
     <string name="module_section_remote">Remoto</string>
     <string name="module_state_remove">Rimuovi</string>
     <string name="module_state_restore">Ripristina</string>
     <string name="module_action_install_external">Installa dalla memoria</string>
     <string name="module_update_none">I tuoi moduli sono aggiornati!</string>
     <string name="update_available">Aggiornamento disponibile</string>
-    <string name="installed">Installato</string>
     <string name="sorting_order">Ordina per</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -28,7 +28,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">更新あり</string>
-    <string name="installed">インストール済</string>
+    <string name="module_section_installed">インストール済</string>
     <string name="sorting_order">並び順</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -117,15 +117,15 @@
     <string name="reboot_edl">EDL-ში გადატვირთვა</string>
     <string name="module_safe_mode_message">თქვენ ბრძანდებით უსაფრთხო რეჟიმში, მოდულები გამორთული იქნება.\nეს შეტყობინება უსაფრთხო რეჟიმიდან გამოსვლის შემდეგ გაქრება.</string>
     <string name="module_version_author">%1$s %2$s-სგან</string>
-    <string name="module_section_pending">განახლებები</string>
-    <string name="module_section_pending_action">ყველას განახლება</string>
+    <string name="module_section_installed">დაინსტალირებული</string>
+    <string name="module_section_updates">განახლებები</string>
+    <string name="module_section_action_update_all">ყველას განახლება</string>
     <string name="module_section_remote">გადმოწერა</string>
     <string name="module_state_remove">წაშლა</string>
     <string name="module_state_restore">აღდგენა</string>
     <string name="module_action_install_external">მახსოვრობიდან დაინსტალირება</string>
     <string name="module_update_none">თქვენი მოდულები განახლებულია!</string>
     <string name="update_available">ხელმისაწვდომია განახლება</string>
-    <string name="installed">დაინსტალირებული</string>
     <string name="sorting_order">სორტირება</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -31,7 +31,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">업데이트 가능</string>
-    <string name="installed">설치됨</string>
+    <string name="module_section_installed">설치됨</string>
     <string name="sorting_order">정렬 방식</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -29,7 +29,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Galimas atnaujinimas</string>
-    <string name="installed">Instaliuota</string>
+    <string name="module_section_installed">Instaliuota</string>
     <string name="sorting_order">Išdėliojimo tvarka</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -28,7 +28,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Достапно е ажурирање</string>
-    <string name="installed">Инсталирано</string>
+    <string name="module_section_installed">Инсталирано</string>
     <string name="sorting_order">Начин на подредување</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -29,7 +29,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Oppdatering tilgjengelig</string>
-    <string name="installed">Installert</string>
+    <string name="module_section_installed">Installert</string>
     <string name="sorting_order">Sorteringsrekkefølge</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -30,7 +30,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Update beschikbaar</string>
-    <string name="installed">Geïnstalleerd</string>
+    <string name="module_section_installed">Geïnstalleerd</string>
     <string name="sorting_order">Sorteervolgorde</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -127,15 +127,15 @@
     <string name="reboot_edl">Restart do EDL</string>
     <string name="module_safe_mode_message">Jesteś w trybie awaryjnym. Żaden moduł użytkownika nie będzie działał.\nTen komunikat zniknie po wyłączeniu trybu awaryjnego.</string>
     <string name="module_version_author">%1$s by %2$s</string>
-    <string name="module_section_pending">Aktualizacje</string>
-    <string name="module_section_pending_action">Zaktualizuj wszystkie</string>
+    <string name="module_section_installed">Zainstalowane</string>
+    <string name="module_section_updates">Aktualizacje</string>
+    <string name="module_section_action_update_all">Zaktualizuj wszystkie</string>
     <string name="module_section_remote">Dostępne</string>
     <string name="module_state_remove">Usuń</string>
     <string name="module_state_restore">Przywróć</string>
     <string name="module_action_install_external">Zainstaluj z pamięci</string>
     <string name="module_update_none">Twoje moduły są aktualne!</string>
     <string name="update_available">Dostępna aktualizacja</string>
-    <string name="installed">Zainstalowane</string>
     <string name="sorting_order">Kolejność sortowania</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -112,15 +112,15 @@
     <string name="reboot_edl">Reiniciar para EDL</string>
     <string name="module_safe_mode_message">Você está em modo seguro. Nenhum dos módulos de usuário funcionará.\nEsta mensagem desaparecerá assim que o modo seguro estiver desativado.</string>
     <string name="module_version_author">%1$s por %2$s</string>
-    <string name="module_section_pending">Atualizações</string>
-    <string name="module_section_pending_action">Atualizar tudo</string>
+    <string name="module_section_installed">Instalado</string>
+    <string name="module_section_updates">Atualizações</string>
+    <string name="module_section_action_update_all">Atualizar tudo</string>
     <string name="module_section_remote">Remoto</string>
     <string name="module_state_remove">Remover</string>
     <string name="module_state_restore">Restaurar</string>
     <string name="module_action_install_external">Instale a partir do armazenamento</string>
     <string name="module_update_none">Seus módulos estão atualizados!</string>
     <string name="update_available">Atualização disponível</string>
-    <string name="installed">Instalado</string>
     <string name="sorting_order">Ordem de classificação</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -25,7 +25,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Atualização disponível</string>
-    <string name="installed">Instalado</string>
+    <string name="module_section_installed">Instalado</string>
 
     <!--Log Fragment-->
     <string name="menuSaveLog">Gravar registo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -117,15 +117,15 @@
     <string name="reboot_edl">Repornește în EDL</string>
     <string name="module_safe_mode_message">Ești în modul sigur. Niciunul dintre modulele de utilizator nu va funcționa.\nAcest mesaj va dispărea odată cu dezactivarea modului sigur.</string>
     <string name="module_version_author">%1$s de %2$s</string>
-    <string name="module_section_pending">Actualizări</string>
-    <string name="module_section_pending_action">Actualizează-le pe toate</string>
+    <string name="module_section_installed">Instalate</string>
+    <string name="module_section_updates">Actualizări</string>
+    <string name="module_section_action_update_all">Actualizează-le pe toate</string>
     <string name="module_section_remote">La distanță</string>
     <string name="module_state_remove">Elimină</string>
     <string name="module_state_restore">Restaurează</string>
     <string name="module_action_install_external">Instalează din stocare</string>
     <string name="module_update_none">Modulele tale sunt la zi!</string>
     <string name="update_available">Actualizare disponibilă</string>
-    <string name="installed">Instalate</string>
     <string name="sorting_order">Ordine de sortare</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -124,15 +124,15 @@
     <string name="reboot_edl">Перезагрузка в EDL</string>
     <string name="module_safe_mode_message">Активирован безопасный режим. Все модули отключены.\nЭто предупреждение исчезнет при отключении безопасного режима.</string>
     <string name="module_version_author">%1$s от %2$s</string>
-    <string name="module_section_pending">Обновления</string>
-    <string name="module_section_pending_action">Обновить все</string>
+    <string name="module_section_installed">Установлены</string>
+    <string name="module_section_updates">Обновления</string>
+    <string name="module_section_action_update_all">Обновить все</string>
     <string name="module_section_remote">Подробно</string>
     <string name="module_state_remove">Удалить</string>
     <string name="module_state_restore">Восстановить</string>
     <string name="module_action_install_external">Установить из хранилища</string>
     <string name="module_update_none">Ваши модули обновлены!</string>
     <string name="update_available">Доступно обновление</string>
-    <string name="installed">Установлены</string>
     <string name="sorting_order">Сортировка</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -122,15 +122,15 @@
     <string name="reboot_edl">Reštartovať do EDL</string>
     <string name="module_safe_mode_message">Nachádzate sa v núdzovom režime. Žiadny z používateľských modulov nebude fungovať.\nTáto správa zmizne po vypnutí núdzového režimu.</string>
     <string name="module_version_author">%1$s by %2$s</string>
-    <string name="module_section_pending">Aktualizácie</string>
-    <string name="module_section_pending_action">Aktualizovať všetko</string>
+    <string name="module_section_installed">Nainštalované</string>
+    <string name="module_section_updates">Aktualizácie</string>
+    <string name="module_section_action_update_all">Aktualizovať všetko</string>
     <string name="module_section_remote">Vzdialené</string>
     <string name="module_state_remove">Odstrániť</string>
     <string name="module_state_restore">Obnoviť</string>
     <string name="module_action_install_external">Inštalácia z úložiska</string>
     <string name="module_update_none">Vaše moduly sú aktuálne!</string>
     <string name="update_available">Dostupná aktualizácia</string>
-    <string name="installed">Nainštalované</string>
     <string name="sorting_order">Zoradenie</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -27,7 +27,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Ажурирање доступно</string>
-    <string name="installed">Инсталирано</string>
+    <string name="module_section_installed">Инсталирано</string>
 
     <!--Log Fragment-->
     <string name="menuSaveLog">Сачувај дневник</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -25,7 +25,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Uppdatering tillgänglig</string>
-    <string name="installed">Installerad</string>
+    <string name="module_section_installed">Installerad</string>
 
     <!--Log Fragment-->
     <string name="menuSaveLog">Spara loggen</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -27,7 +27,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">มีการอัพเดต</string>
-    <string name="installed">ติดตั้งแล้ว</string>
+    <string name="module_section_installed">ติดตั้งแล้ว</string>
     <string name="sorting_order">การเรียง</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -124,15 +124,15 @@
     <string name="reboot_edl">EDL moduna yeniden başlat</string>
     <string name="module_safe_mode_message">Güvenli moddasınız. Hiçbir kullanıcı modülü çalışmaz.\nGüvenli mod devre dışı bırakıldığında bu mesaj kaybolacaktır.</string>
     <string name="module_version_author">%1$s - %2$s</string>
-    <string name="module_section_pending">Güncellemeler</string>
-    <string name="module_section_pending_action">Tümünü güncelle</string>
+    <string name="module_section_installed">Yüklendi</string>
+    <string name="module_section_updates">Güncellemeler</string>
+    <string name="module_section_action_update_all">Tümünü güncelle</string>
     <string name="module_section_remote">İndirilebilir</string>
     <string name="module_state_remove">Kaldır</string>
     <string name="module_state_restore">Geri yükle</string>
     <string name="module_action_install_external">Depolama alanından yükle</string>
     <string name="module_update_none">Modülleriniz güncel!</string>
     <string name="update_available">Güncelleme mevcut</string>
-    <string name="installed">Yüklendi</string>
     <string name="sorting_order">Sıralama Düzeni</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -124,15 +124,15 @@
     <string name="reboot_edl">Перезавантажити в EDL</string>
     <string name="module_safe_mode_message">Ви в безпечному режимі. В цьому режимі модулі не працюватимуть.\nПовідомлення зникне, після вимкнення безпечного режиму.</string>
     <string name="module_version_author">%1$s, розробник %2$s</string>
-    <string name="module_section_pending">Оновлення</string>
-    <string name="module_section_pending_action">Оновити всі</string>
+    <string name="module_section_installed">Встановлені</string>
+    <string name="module_section_updates">Оновлення</string>
+    <string name="module_section_action_update_all">Оновити всі</string>
     <string name="module_section_remote">Можна завантажити</string>
     <string name="module_state_remove">Видалити</string>
     <string name="module_state_restore">Відновити</string>
     <string name="module_action_install_external">Встановити зі сховища</string>
     <string name="module_update_none">Ваші модулі оновлені!</string>
     <string name="update_available">Доступне оновлення</string>
-    <string name="installed">Встановлені</string>
     <string name="sorting_order">Порядок сортування</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -29,7 +29,7 @@
 
     <!--Repo Fragment-->
     <string name="update_available">Có cập nhật mới</string>
-    <string name="installed">Đã được cài đặt</string>
+    <string name="module_section_installed">Đã được cài đặt</string>
     <string name="sorting_order">Thứ tự sắp xếp</string>
 
     <!--Log Fragment-->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -124,15 +124,15 @@
     <string name="reboot_edl">重启到 EDL</string>
     <string name="module_safe_mode_message">您正处于安全模式。用户模块不会生效\n退出安全模式时此消息将消失。</string>
     <string name="module_version_author">%1$s by %2$s</string>
-    <string name="module_section_pending">更新</string>
-    <string name="module_section_pending_action">全部更新</string>
+    <string name="module_section_installed">已安装</string>
+    <string name="module_section_updates">更新</string>
+    <string name="module_section_action_update_all">全部更新</string>
     <string name="module_section_remote">云端</string>
     <string name="module_state_remove">移除</string>
     <string name="module_state_restore">还原</string>
     <string name="module_action_install_external">从本地文件安装</string>
     <string name="module_update_none">您的模块是最新的！</string>
     <string name="update_available">可更新</string>
-    <string name="installed">已安装</string>
     <string name="sorting_order">排序方式</string>
 
     <!--Settings -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -123,15 +123,15 @@
     <string name="reboot_edl">重新啟動至 EDL</string>
     <string name="module_safe_mode_message">您正在安全模式。任何使用者的模組將不會運作。\n此訊息將會在安全模式停用後消失。</string>
     <string name="module_version_author">%1$s 來自 %2$s</string>
-    <string name="module_section_pending">更新</string>
-    <string name="module_section_pending_action">全部更新</string>
+    <string name="module_section_installed">已安裝</string>
+    <string name="module_section_updates">更新</string>
+    <string name="module_section_action_update_all">全部更新</string>
     <string name="module_section_remote">遠端</string>
     <string name="module_state_remove">移除</string>
     <string name="module_state_restore">還原</string>
     <string name="module_action_install_external">從本機安裝</string>
     <string name="module_update_none">您的模組已全部更新到最新！</string>
     <string name="update_available">有可用的更新</string>
-    <string name="installed">已安裝</string>
     <string name="sorting_order">排序方式</string>
 
     <!--Settings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="status">Status</string>
     <string name="home_package">Package</string>
     <string name="details">Details</string>
+    <string name="current_installed_version">Installed</string>
+    <string name="current_remote_version">Remote</string>
 
     <string name="home_notice_content">Always make sure you\'re using open-source Magisk Manager. Manager of unknown source can perform malicious actions.</string>
     <string name="home_support_title">Support Us</string>
@@ -124,15 +126,15 @@
     <string name="reboot_edl">Reboot to EDL</string>
     <string name="module_safe_mode_message">You\'re in safe mode. None of user modules will work.\nThis message will disappear once safe mode is disabled.</string>
     <string name="module_version_author">%1$s by %2$s</string>
-    <string name="module_section_pending">Updates</string>
-    <string name="module_section_pending_action">Update all</string>
+    <string name="module_section_installed">Installed</string>
+    <string name="module_section_updates">Updates</string>
+    <string name="module_section_action_update_all">Update all</string>
     <string name="module_section_remote">Remote</string>
     <string name="module_state_remove">Remove</string>
     <string name="module_state_restore">Restore</string>
     <string name="module_action_install_external">Install from storage</string>
     <string name="module_update_none">Your modules are up to date!</string>
     <string name="update_available">Update Available</string>
-    <string name="installed">Installed</string>
     <string name="sorting_order">Sorting Order</string>
 
     <!--Settings -->


### PR DESCRIPTION
In previous versions of Manager, we had specific strings for "Installed version" and "Latest version". Unfortunately, not only they were removed, but in Home section we re-use "Installed" and "Remote" from Modules section. It's confusing, but not only confusing, there are languages that don't work like English, some languages need singular and plural forms. For instance in Romanian case, "Instalate" in Modules section and "Instalat" in Home section ("Instalate" is the plural form and the other is the singular form). Other languages like French might need this as well. And now it's more easier to understand the context ("current_installed_version", "current_remote_version", "module_section_installed", "module_section_updates", "module_section_action_update_all").