### PR TITLE
Fix addon.d again + version display fixes

### DIFF
--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -9,14 +9,22 @@
 
 trampoline() {
   mount /data 2>/dev/null
-  if [ -f /data/adb/magisk/addon.d.sh ]; then
-    exec sh /data/adb/magisk/addon.d.sh "$@"
+  if [ -f $MAGISKBIN/addon.d.sh ]; then
+    exec sh $MAGISKBIN/addon.d.sh "$@"
+    exit $?
   else
-    OUTFD=$(ps | grep -v 'grep' | grep -oE 'update(.*)' | cut -d" " -f3)
-    [ "$OUTFD" == "$((OUTFD * 1))" ] || OUTFD=$(ps -Af | grep -v 'grep' | grep -oE 'update(.*)' | cut -d" " -f3)
-    [ "$OUTFD" == "$((OUTFD * 1))" ] || OUTFD=$(ps | grep -v 'grep' | grep -oE 'status_fd=(.*)' | cut -d= -f2)
-    [ "$OUTFD" == "$((OUTFD * 1))" ] || OUTFD=$(ps -Af | grep -v 'grep' | grep -oE 'status_fd=(.*)' | cut -d= -f2)
-    ui_print() { echo -e "ui_print $1\nui_print" >> /proc/self/fd/$OUTFD; }
+    ps | grep zygote | grep -v grep >/dev/null && BOOTMODE=true || BOOTMODE=false
+    $BOOTMODE || ps -A 2>/dev/null | grep zygote | grep -v grep >/dev/null && BOOTMODE=true
+
+    if ! $BOOTMODE; then
+      # update-binary|updater <RECOVERY_API_VERSION> <OUTFD> <ZIPFILE>
+      OUTFD=$(ps | grep -v 'grep' | grep -oE 'update(.*) 3 [0-9]+' | cut -d" " -f3)
+      [ -z $OUTFD ] && OUTFD=$(ps -Af | grep -v 'grep' | grep -oE 'update(.*) 3 [0-9]+' | cut -d" " -f3)
+      # update_engine_sideload --payload=file://<ZIPFILE> --offset=<OFFSET> --headers=<HEADERS> --status_fd=<OUTFD>
+      [ -z $OUTFD ] && OUTFD=$(ps | grep -v 'grep' | grep -oE 'status_fd=[0-9]+' | cut -d= -f2)
+      [ -z $OUTFD ] && OUTFD=$(ps -Af | grep -v 'grep' | grep -oE 'status_fd=[0-9]+' | cut -d= -f2)
+    fi
+    ui_print() { $BOOTMODE && log -t Magisk -- "$1" || echo -e "ui_print $1\nui_print" >> /proc/self/fd/$OUTFD; }
 
     ui_print "************************"
     ui_print "* Magisk addon.d failed"
@@ -28,10 +36,11 @@ trampoline() {
 }
 
 # Always use the script in /data
-[ "$0" = /data/adb/magisk/addon.d.sh ] || trampoline
+MAGISKBIN=/data/adb/magisk
+[ "$0" = $MAGISKBIN/addon.d.sh ] || trampoline "$@"
 
 V1_FUNCS=/tmp/backuptool.functions
-V2_FUNCS=/postinstall/system/bin/backuptool_ab.functions
+V2_FUNCS=/postinstall/tmp/backuptool.functions
 
 if [ -f $V1_FUNCS ]; then
   . $V1_FUNCS
@@ -43,13 +52,6 @@ else
 fi
 
 initialize() {
-  MAGISKBIN=/data/adb/magisk
-
-  if [ ! -d $MAGISKBIN ]; then
-    echo "! Cannot find Magisk binaries!"
-    exit 1
-  fi
-
   # Load utility functions
   . $MAGISKBIN/util_functions.sh
 
@@ -96,6 +98,7 @@ main() {
   install_magisk
 
   # Cleanups
+  cd /
   $BOOTMODE || recovery_cleanup
   rm -rf $TMPDIR
 


### PR DESCRIPTION
scripts: fix addon.d after merge to trampoline
- pass addon.d arguments through trampoline or nothing will happen
- exit immediately after handing over from trampoline
- better grep for recovery OUTFD which should work in all cases
- output to logcat when booted and no binaries are found
- use /postinstall/tmp path to call functions from addon.d-v2 in progress
- remove unnecessary check for $MAGISKBIN since we're already executing from within it
- make sure we're not in $TMPDIR again before we delete it
- use $MAGISKBIN wherever possible in case it ever needs to be changed

Version display fixes
- remove leading v from all versions since version may now just be a hash in the Canary channel
- always show versionCode/VER_CODE to help differentiate hash version builds in logs for debugging