### PR TITLE
Disable Volumes keys in FlashActivity

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/legacy/flash/FlashActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/legacy/flash/FlashActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Bundle
+import android.view.KeyEvent
 import androidx.core.net.toUri
 import com.topjohnwu.magisk.R
 import com.topjohnwu.magisk.core.Const
@@ -40,6 +41,12 @@ open class FlashActivity : BaseUIActivity<FlashViewModel, ActivityFlashBinding>(
         val id = intent.getIntExtra(Const.Key.DISMISS_ID, -1)
         if (id != -1)
             Notifications.mgr.cancel(id)
+        viewRoot.isFocusable = true
+        viewRoot.isFocusableInTouchMode = true
+        viewRoot.setOnKeyListener {
+            _, keyCode, _ -> keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN
+        }
+        viewRoot.requestFocus()
     }
 
     override fun onBackPressed() {


### PR DESCRIPTION
Sometimes modules ask to push volumes keys but the problem is that by pushing the volume keys during a flash it also changes the volume of the phone.

And I found a way to block volume keys so the volume doesn't change when flashing a module and pressing volume keys.