### PR TITLE
Xiaomi cross region flash hacks

### DIFF
--- a/native/jni/magiskhide/hide_policy.cpp
+++ b/native/jni/magiskhide/hide_policy.cpp
@@ -31,11 +31,11 @@ void hide_sensitive_props() {
 
 	// Xiaomi cross region flash
 	auto hwc = getprop("ro.boot.hwc");
-	if (!hwc.empty() && hwc.find("China") != string::npos) {
+	if (!hwc.empty() && hwc.find("CN") != string::npos) {
 		setprop("ro.boot.hwc", "GLOBAL", false);
 	}
 	auto hwcountry = getprop("ro.boot.hwcountry");
-	if (!hwcountry.empty() && hwcountry.find("CN") != string::npos) {
+	if (!hwcountry.empty() && hwcountry.find("China") != string::npos) {
 		setprop("ro.boot.hwcountry", "GLOBAL", false);
 	}
 }

--- a/native/jni/magiskhide/hide_policy.cpp
+++ b/native/jni/magiskhide/hide_policy.cpp
@@ -28,6 +28,16 @@ void hide_sensitive_props() {
 		if (!value.empty() && value != prop_value[i])
 			setprop(prop_key[i], prop_value[i], false);
 	}
+
+	// Xiaomi cross region flash
+	auto hwc = getprop("ro.boot.hwc");
+	if (!hwc.empty() && hwc.find("China") != string::npos) {
+		setprop("ro.boot.hwc", "GLOBAL", false);
+	}
+	auto hwcountry = getprop("ro.boot.hwcountry");
+	if (!hwcountry.empty() && hwcountry.find("CN") != string::npos) {
+		setprop("ro.boot.hwcountry", "GLOBAL", false);
+	}
 }
 
 static inline void lazy_unmount(const char* mountpoint) {


### PR DESCRIPTION
According the codes below, once China region device flash global ROM will cause reboot into recovery if sensitive props hide.

```java
    private static void rebootIntoRecovery() {
        BcbUtil.setupBcb("--show_version_mismatch\n");
        SystemProperties.set("sys.powerctl", "reboot,recovery");
    }

    private static boolean isGlobalHaredware(String product) {
        boolean z = true;
        if ("ugglite".equals(product) || "ugg".equals(product) || "ugglite_ru".equals(product) || "ugg_ru".equals(product)) {
            return !"China".equals(SystemProperties.get("ro.boot.hwcountry"));
        }
        if ("riva".equals(product) || "riva_ru".equals(product)) {
            if ("S88505AA1".equals(SystemProperties.get("ro.product.wt.boardid")) || "S88505DA1".equals(SystemProperties.get("ro.product.wt.boardid")) || "S88505AC1".equals(SystemProperties.get("ro.product.wt.boardid")) || "S88505DC1".equals(SystemProperties.get("ro.product.wt.boardid"))) {
                z = false;
            }
            return z;
        } else if ("rosy".equals(product) || "rosy_ru".equals(product)) {
            return !"CN".equals(SystemProperties.get("ro.boot.hwcountry"));
        } else {
            String country = SystemProperties.get("ro.boot.hwc");
            if ("CN".equals(country) || (country != null && country.startsWith("CN_"))) {
                return false;
            }
            return true;
        }
    }

    private static void enforceVersionPolicy() {
        String product = SystemProperties.get("ro.product.name");
        if (!sVersionPolicyDevices.contains(product)) {
            Slog.d(TAG, "enforceVersionPolicy: enable_flash_global enabled");
        } else if (!"locked".equals(SystemProperties.get("ro.secureboot.lockstate"))) {
            Slog.d(TAG, "enforceVersionPolicy: device unlocked");
        } else if (isGlobalHaredware(product)) {
            Slog.d(TAG, "enforceVersionPolicy: global device");
        } else {
            if (Build.IS_INTERNATIONAL_BUILD) {
                Slog.e(TAG, "CN hardware can't run Global build; reboot into recovery!!!");
                rebootIntoRecovery();
            }
        }
    }

```