### PR TITLE
Fixup mounting system on Lineage Recovery

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -209,6 +209,11 @@ mount_partitions() {
     SYSTEM_ROOT=true
     setup_mntpoint /system_root
     mount --move /system /system_root
+    if [ $? != 0 ]; then
+      umount /system
+      umount -l /system 2>/dev/null
+      mount_ro_ensure "system$SLOT app$SLOT" /system_root
+    fi
     mount -o bind /system_root/system /system
   else
     grep ' / ' /proc/mounts | grep -qv 'rootfs' || grep -q ' /system_root ' /proc/mounts \

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -208,8 +208,7 @@ mount_partitions() {
   if [ -f /system/init.rc ]; then
     SYSTEM_ROOT=true
     setup_mntpoint /system_root
-    mount --move /system /system_root
-    if [ $? != 0 ]; then
+    if ! mount --move /system /system_root; then
       umount /system
       umount -l /system 2>/dev/null
       mount_ro_ensure "system$SLOT app$SLOT" /system_root


### PR DESCRIPTION
 * Lineage Recovery 17.1, like AOSP Q recovery, has '/' as a shared
   mount point, causing `mount --move` to fail.
   If it fails, directly mount system to /system_root via
   the /dev/block/bootdevice symlink, like AnyKernel and OpenGapps