### PR TITLE
Add linebrake notice for module.prop

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -70,7 +70,7 @@ ex: ✓ `a_module`, ✓ `a.module`, ✓ `module-101`, ✗ `a module`, ✗ `1_mod
 This is the **unique identifier** of your module. You should not change it once published.
 - `versionCode` has to be an **integer**. This is used to compare versions
 - Others that weren't mentioned above can be any **single line** string.
-- Make sure to use the `UNIX (LF)` line brake type and not the `Windows (CR+LF)` or `Macintosh (CR)` one.
+- Make sure to use the `UNIX (LF)` line break type and not the `Windows (CR+LF)` or `Macintosh (CR)` one.
 
 #### Shell scripts (`*.sh`)
 Please read the [Boot Scripts](#boot-scripts) section to understand the difference between `post-fs-data.sh` and `service.sh`. For most module developers, `service.sh` should be good enough if you just need to run a boot script.

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -70,6 +70,7 @@ ex: ✓ `a_module`, ✓ `a.module`, ✓ `module-101`, ✗ `a module`, ✗ `1_mod
 This is the **unique identifier** of your module. You should not change it once published.
 - `versionCode` has to be an **integer**. This is used to compare versions
 - Others that weren't mentioned above can be any **single line** string.
+- Make sure to use the `UNIX (LF)` line brake type and not the `Windows (CR+LF)` or `Macintosh (CR)` one.
 
 #### Shell scripts (`*.sh`)
 Please read the [Boot Scripts](#boot-scripts) section to understand the difference between `post-fs-data.sh` and `service.sh`. For most module developers, `service.sh` should be good enough if you just need to run a boot script.


### PR DESCRIPTION
This made some trouble when creating a module.prop on Windows. The file could not be read properly by magisk manager and my module folder had an \r at the end which made it unremovable through Magisk Manager.