### PR TITLE
fix standalone shell exec

### DIFF
--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -60,7 +60,7 @@ initialize() {
     ui_print() { log -t Magisk -- "$1"; }
   fi
   OUTFD=
-  setup_flashable
+  setup_flashable "$@"
 }
 
 main() {
@@ -122,7 +122,7 @@ case "$1" in
     # Stub
   ;;
   post-restore)
-    initialize
+    initialize "$@"
     if $backuptool_ab; then
       $BOOTMODE && su=su || su=sh
       exec $su -c "sh $0 addond-v2"
@@ -132,7 +132,7 @@ case "$1" in
     fi
   ;;
   addond-v2)
-    initialize
+    initialize "$@"
     main
   ;;
 esac

--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -28,7 +28,7 @@ fi
 # Load utility fuctions
 . $COMMONDIR/util_functions.sh
 
-setup_flashable
+setup_flashable "$@"
 
 ############################################
 # Detection

--- a/scripts/magisk_uninstaller.sh
+++ b/scripts/magisk_uninstaller.sh
@@ -31,7 +31,7 @@ fi
 # Load utility functions
 . $INSTALLER/util_functions.sh
 
-setup_flashable
+setup_flashable "$@"
 
 print_title "Magisk Uninstaller"
 

--- a/scripts/module_installer.sh
+++ b/scripts/module_installer.sh
@@ -31,7 +31,7 @@ mount /data 2>/dev/null
 
 if [ $MAGISK_VER_CODE -ge 20400 ]; then
   # New Magisk have complete installation logic within util_functions.sh
-  install_module
+  install_module $@
   exit 0
 fi
 
@@ -65,7 +65,7 @@ print_modname() {
 }
 
 # Preperation for flashable zips
-setup_flashable
+setup_flashable "$@"
 
 # Mount partitions
 mount_partitions

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -70,7 +70,7 @@ print_title() {
 ######################
 
 setup_flashable() {
-  ensure_bb
+  ensure_bb "$@"
   $BOOTMODE && return
   if [ -z $OUTFD ] || readlink /proc/$$/fd/$OUTFD | grep -q /tmp; then
     # We will have to manually find out OUTFD
@@ -86,8 +86,7 @@ setup_flashable() {
 }
 
 ensure_bb() {
-  [ -o standalone ] && return
-  set -o standalone 2>/dev/null && return
+  [ $(echo $- | grep "S") ] && return
 
   # At this point, we are not running in BusyBox ash
   # Find our busybox binary
@@ -599,7 +598,7 @@ is_legacy_script() {
 install_module() {
   local PERSISTDIR=/sbin/.magisk/mirror/persist
 
-  setup_flashable
+  setup_flashable "$@"
   mount_partitions
   api_level_arch_detect
 


### PR DESCRIPTION
The checks for standalone were not quite working for me.
`[ -o option_name ]` seems to not be a thing in ash at all, and `set -o standalone 2>/dev/null && return` returned on my mksh too. So in https://github.com/topjohnwu/ndk-busybox/pull/3 i added a safe way to detect the standalone mode.

Also the exec was being called with no arguments cause "$@" was used inside a function.
So i routed "$@" through the function calls. I hope I did not leave any place behind.

Please check app/src/main/res/raw/util_functions.sh as i'm not sure what calls install_module() there, but that needs to pass "$@" through too