### PR TITLE
Add version code a few places to help debugging

### DIFF
--- a/build.py
+++ b/build.py
@@ -444,7 +444,7 @@ def zip_main(args):
 
         # End of zipping
 
-    output = os.path.join(config['outdir'], f'Magisk-v{config["version"]}.zip' if config['prettyName'] else
+    output = os.path.join(config['outdir'], f'Magisk-v{config["version"]}({config["versionCode"]}).zip' if config['prettyName'] else
                           'magisk-release.zip' if args.release else 'magisk-debug.zip')
     sign_zip(unsigned, output, args.release)
     rm(unsigned)

--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -74,8 +74,8 @@ main() {
 
   $BOOTMODE || recovery_actions
 
-  PRETTY_VER=$MAGISK_VER
-  echo $PRETTY_VER | grep -q '\.' && PRETTY_VER=v$PRETTY_VER
+  PRETTY_VER=$MAGISK_VER($MAGISK_VER_CODE)
+  echo $MAGISK_VER | grep -q '\.' && PRETTY_VER=v$MAGISK_VER
   print_title "Magisk $PRETTY_VER addon.d"
 
   mount_partitions

--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -34,8 +34,8 @@ setup_flashable
 # Detection
 ############
 
-PRETTY_VER=$MAGISK_VER
-echo $PRETTY_VER | grep -q '\.' && PRETTY_VER=v$PRETTY_VER
+PRETTY_VER=$MAGISK_VER($MAGISK_VER_CODE)
+echo $MAGISK_VER | grep -q '\.' && PRETTY_VER=v$MAGISK_VER
 print_title "Magisk $PRETTY_VER Installer"
 
 is_mounted /data || mount /data || is_mounted /cache || mount /cache


### PR DESCRIPTION
- show VER_CODE in installer/addon.d to help differentiate Canary hash version builds in logs
- use versionCode with prettyName zip build to match Magisk Manager