### PR TITLE
Polish translation - fix missing string

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -134,6 +134,7 @@
     <string name="module_action_install_external">Zainstaluj z pamięci</string>
     <string name="module_update_none">Twoje moduły są aktualne!</string>
     <string name="update_available">Dostępna aktualizacja</string>
+    <string name="module_installed">Zainstalowane</string>
     <string name="sorting_order">Kolejność sortowania</string>
     <string name="module_permission_declined">Zezwól na dostęp do pamięci wewnętrznej, aby włączyć tę funkcjonalność.</string>
 


### PR DESCRIPTION
Add previously deleted string, due incorrent (duplicated) variable name.
Described in: https://github.com/topjohnwu/Magisk/commit/31142180cbba79bf3fd07f9af6d8376171e29e96