### PR TITLE
core: clean up /data/adb/magisk.img, etc. as well

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -342,7 +342,10 @@ static bool magisk_env() {
 	// Remove stuffs
 	rm_rf("/cache/data_adb");
 	rm_rf("/data/adb/modules/.core");
+	unlink("/data/adb/magisk.img");
+	unlink("/data/adb/magisk_merge.img");
 	unlink("/data/magisk.img");
+	unlink("/data/magisk_merge.img");
 	unlink("/data/magisk_debug.log");
 
 	// Directories in tmpfs overlay


### PR DESCRIPTION
- now that magisk.img -> /data/adb/modules migration is no longer taking place make sure all magisk.img locations get cleaned up