### PR TITLE
Content in dt_fstab is not null terminated in emulator

### DIFF
--- a/native/jni/init/mount.cpp
+++ b/native/jni/init/mount.cpp
@@ -97,6 +97,7 @@ static bool read_dt_fstab(cmdline *cmd, const char *name) {
 	if ((fd = open(path, O_RDONLY | O_CLOEXEC)) >= 0) {
 		read(fd, path, sizeof(path));
 		close(fd);
+		path[strcspn(path, "\r\n")] = '\0';
 		// Some custom treble use different names, so use what we read
 		char *part = rtrim(strrchr(path, '/') + 1);
 		sprintf(partname, "%s%s", part, strend(part, cmd->slot) ? cmd->slot : "");
@@ -104,6 +105,7 @@ static bool read_dt_fstab(cmdline *cmd, const char *name) {
 		if ((fd = xopen(path, O_RDONLY | O_CLOEXEC)) >= 0) {
 			read(fd, fstype, 32);
 			close(fd);
+			fstype[strcspn(fstype, "\r\n")] = '\0';
 			return true;
 		}
 	}


### PR DESCRIPTION
Value of `<dt>/fstab/<partition>/dev` and `<dt>/fstab/<partition>/type` in official Android emulator ends with newline instead of \0, Magisk won’t be able to patch sepolicy and crash the system.

With this change we should be able to able to install Magisk on emulator from API 17 to 29 (except 28 which is SAR) by patching the ramdisk.img

Signed-off-by: Shaka Huang <shakalaca@gmail.com>