### PR TITLE
Add secure folder creation in boot_complete

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -722,6 +722,9 @@ void late_start(int client) {
 		// It's safe to create the folder at this point if the system didn't create it
 		if (access(SECURE_DIR, F_OK) != 0)
 			xmkdir(SECURE_DIR, 0700);
+		// Return if folder not created and do it again in boot_complete section
+		if (access(SECURE_DIR, F_OK) != 0)
+			return;
 		// And reboot to make proper setup possible
 		reboot();
 	}
@@ -758,6 +761,14 @@ void boot_complete(int client) {
 	// ack
 	write_int(client, 0);
 	close(client);
+
+	if (no_secure_dir) {
+		// It's safe to create the folder at this point if the system didn't create it
+		if (access(SECURE_DIR, F_OK) != 0)
+			xmkdir(SECURE_DIR, 0700);
+		// And reboot to make proper setup possible
+		reboot();
+	}
 
 	if (!pfs_done)
 		return;


### PR DESCRIPTION
On Oneplus 7T HD1900 OOS 10.0.8.HD65AA after userdata wiped, device will get bootloop because secure folder not created in late_start section, do it again under boot_complete will fix it.