### PR TITLE
Fix bug in compiling elf_cleaner with g++

### DIFF
--- a/build.py
+++ b/build.py
@@ -172,7 +172,7 @@ def clean_elf():
     else:
         elf_cleaner = os.path.join('native', 'out', 'elf-cleaner')
         if not os.path.exists(elf_cleaner):
-            execv(['g++', 'tools/termux-elf-cleaner/termux-elf-cleaner.cpp',
+            execv(['g++', '-std=c++11', 'tools/termux-elf-cleaner/termux-elf-cleaner.cpp',
                   '-o', elf_cleaner])
     args = [elf_cleaner]
     args.extend(os.path.join('native', 'out', arch, 'magisk') for arch in archs + arch64)


### PR DESCRIPTION
When compiling on a platfrom other than Windows, the binary "native/out/elf-cleaner" does not exist, so it tried to compile directly using g++ without passing a "-std=c++11" flag to the compiler. This caused several compilation errors.

Fixes #2632.