### PR TITLE
fix Magisk install on ODROID-N2/C4

### DIFF
--- a/scripts/magisk_uninstaller.sh
+++ b/scripts/magisk_uninstaller.sh
@@ -109,7 +109,7 @@ case $((STATUS & 3)) in
     if [ -d $BACKUPDIR ]; then
       ui_print "- Restoring stock boot image"
       flash_image $BACKUPDIR/boot.img.gz $BOOTIMAGE
-      for name in dtb dtbo; do
+      for name in dtb dtbo dtbs; do
         [ -f $BACKUPDIR/${name}.img.gz ] || continue
         IMAGE=`find_block $name$SLOT`
         [ -z $IMAGE ] && continue

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -409,7 +409,7 @@ flash_image() {
 patch_dtb_partitions() {
   local result=1
   cd $MAGISKBIN
-  for name in dtb dtbo; do
+  for name in dtb dtbo dtbs; do
     local IMAGE=`find_block $name$SLOT`
     if [ ! -z $IMAGE ]; then
       ui_print "- $name image: $IMAGE"
@@ -571,7 +571,7 @@ run_migrations() {
 
   # Stock backups
   LOCSHA1=$SHA1
-  for name in boot dtb dtbo; do
+  for name in boot dtb dtbo dtbs; do
     BACKUP=/data/adb/magisk/stock_${name}.img
     [ -f $BACKUP ] || continue
     if [ $name = 'boot' ]; then


### PR DESCRIPTION
This prevent install on some devices, in this case its Odroid dev boards
First it's a dtb block device node name, in Odroids it's a  /dev/block/dtbs
Next patched dtb does not flash with cat (insufficient space)
So i think dd is better option to write binary data.

Regards.