### PR TITLE
RECOVERYMODE should not always be overridden on legacy SaR devices.

### DIFF
--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -129,7 +129,7 @@ check_boot_ramdisk() {
   $ISAB && return 0
 
   # If we are using legacy SAR, but not AB, we do not have ramdisk in boot
-  if grep ' / ' /proc/mounts | grep -q '/dev/root'; then
+  if grep ' / ' /proc/mounts | grep -q '/dev/root' && getprop ro.boot.bootreason | grep -q recovery; then
     # Override recovery mode to true
     RECOVERYMODE=true
     return 1


### PR DESCRIPTION
When the device wasn't booted from recovery, it's presumably already rooted in the boot partition (e.g. Samsung Fold and Tab S6), so we should not force RECOVERYMODE to true.

Without this, Magisk Manager will erroneously install Magisk in the recovery partition of boot-rooted legacy SaR devices.

This sacrifices blanket detection of legacy SaR devices in favour of allowing boot-rooted devices to have Magisk updated by MM, rather than having to flash them in TWRP.