### PR TITLE
scripts: module and installation fixes

### DIFF
--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -78,6 +78,7 @@ chmod -R 755 $MAGISKBIN
 # addon.d
 if [ -d /system/addon.d ]; then
   ui_print "- Adding addon.d survival script"
+  blockdev --setrw /dev/block/mapper/system$SLOT 2>/dev/null
   mount -o rw,remount /system
   ADDOND=/system/addon.d/99-magisk.sh
   cp -af $COMMONDIR/addon.d.sh $ADDOND

--- a/scripts/module_installer.sh
+++ b/scripts/module_installer.sh
@@ -48,12 +48,15 @@ is_legacy_script() {
 }
 
 print_modname() {
-  local len
-  len=`echo -n $MODNAME | wc -c`
+  local authlen len namelen pounds
+  namelen=`echo -n $MODNAME | wc -c`
+  authlen=$((`echo -n $MODAUTH | wc -c` + 3))
+  [ $namelen -gt $authlen ] && len=$namelen || len=$authlen
   len=$((len + 2))
-  local pounds=`printf "%${len}s" | tr ' ' '*'`
+  pounds=$(printf "%${len}s" | tr ' ' '*')
   ui_print "$pounds"
   ui_print " $MODNAME "
+  ui_print " by $MODAUTH "
   ui_print "$pounds"
   ui_print "*******************"
   ui_print " Powered by Magisk "
@@ -95,8 +98,9 @@ unzip -o "$ZIPFILE" module.prop -d $TMPDIR >&2
 $BOOTMODE && MODDIRNAME=modules_update || MODDIRNAME=modules
 MODULEROOT=$NVBASE/$MODDIRNAME
 MODID=`grep_prop id $TMPDIR/module.prop`
-MODPATH=$MODULEROOT/$MODID
 MODNAME=`grep_prop name $TMPDIR/module.prop`
+MODAUTH=`grep_prop author $TMPDIR/module.prop`
+MODPATH=$MODULEROOT/$MODID
 
 # Create mod paths
 rm -rf $MODPATH 2>/dev/null

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -61,11 +61,15 @@ resolve_vars() {
 }
 
 print_title() {
-  local len=$(echo -n $1 | wc -c)
+  local len line1len line2len pounds
+  line1len=$(echo -n $1 | wc -c)
+  line2len=$(echo -n $2 | wc -c)
+  [ $line1len -gt $line2len ] && len=$line1len || len=$line2len
   len=$((len + 2))
-  local pounds=$(printf "%${len}s" | tr ' ' '*')
+  pounds=$(printf "%${len}s" | tr ' ' '*')
   ui_print "$pounds"
   ui_print " $1 "
+  [ "$2" ] && ui_print " $2 "
   ui_print "$pounds"
 }
 
@@ -652,8 +656,9 @@ install_module() {
   $BOOTMODE && MODDIRNAME=modules_update || MODDIRNAME=modules
   local MODULEROOT=$NVBASE/$MODDIRNAME
   MODID=`grep_prop id $TMPDIR/module.prop`
-  MODPATH=$MODULEROOT/$MODID
   MODNAME=`grep_prop name $TMPDIR/module.prop`
+  MODAUTH=`grep_prop author $TMPDIR/module.prop`
+  MODPATH=$MODULEROOT/$MODID
 
   # Create mod paths
   rm -rf $MODPATH 2>/dev/null
@@ -679,7 +684,7 @@ install_module() {
     ui_print "- Setting permissions"
     set_permissions
   else
-    print_title "$MODNAME"
+    print_title "$MODNAME" "by $MODAUTH"
     print_title "Powered by Magisk"
 
     unzip -o "$ZIPFILE" customize.sh -d $MODPATH >&2

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -481,6 +481,7 @@ sign_chromeos() {
 remove_system_su() {
   if [ -f /system/bin/su -o -f /system/xbin/su ] && [ ! -f /su/bin/su ]; then
     ui_print "- Removing system installed root"
+    blockdev --setrw /dev/block/mapper/system$SLOT 2>/dev/null
     mount -o rw,remount /system
     # SuperSU
     if [ -e /system/bin/.ext/.su ]; then


### PR DESCRIPTION
**scripts: ensure system is able to be mounted rw before attempting**
- this is needed for installations on Lineage 17.1 Recovery (AOSP Q) for logical partition devices, which uses /dev/block/mapper to stage the partitions

Thanks LuK1337 & erfanoabdi @ Lineage

**scripts: add author name back to module install banner print**
- print_title can now do up to 2 lines

**scripts: fix find_block false positives /dev/log/kernel and /dev/BOOT**
- try /dev/block first with full depth to catch all platform/soc variations to the by-name directory, and the new dynamic partition /dev/block/mapper
- next try uevent for block devices as before
- lastly try /dev with maxdepth 1 (immediate directory) to find /dev/bootimg, /dev/recovery, etc. while avoiding /dev/log/kernel
- move bootimg higher in the list than boot so /dev/bootimg gets found first and avoids /dev/BOOT
- recovery_a/_b now also exists
- minor touch-ups for readability and consistency

Fixes #2720