### PR TITLE
magiskpolicy: allow access to su client for untrusted_app_29 domain

### DIFF
--- a/native/jni/magiskpolicy/rules.cpp
+++ b/native/jni/magiskpolicy/rules.cpp
@@ -86,6 +86,7 @@ void sepol_magisk_rules() {
 	allowSuClient("untrusted_app");
 	allowSuClient("untrusted_app_25");
 	allowSuClient("untrusted_app_27");
+	allowSuClient("untrusted_app_29");
 	allowSuClient("update_engine");
 
 	// suRights


### PR DESCRIPTION
On the c94f9e1c canary build I was not being prompted for root by most apps.
Running `magiskpolicy --live 'allow untrusted_app_29 magisk unix_stream_socket connectto'`
fixed it on my device, this patch is probably a proper equivalent but I'm not
quite familiar with the source.
