### PR TITLE
scripts: fix persist out-of-space copying sepolicy.rule

### DIFF
--- a/scripts/module_installer.sh
+++ b/scripts/module_installer.sh
@@ -172,9 +172,11 @@ fi
 # Copy over custom sepolicy rules
 if [ -f $MODPATH/sepolicy.rule -a -e $PERSISTDIR ]; then
   ui_print "- Installing custom sepolicy patch"
+  # Remove old recovery logs (which may be filling partition) to make room
+  rm -f $PERSISTDIR/cache/recovery/*
   PERSISTMOD=$PERSISTDIR/magisk/$MODID
   mkdir -p $PERSISTMOD
-  cp -af $MODPATH/sepolicy.rule $PERSISTMOD/sepolicy.rule
+  cp -af $MODPATH/sepolicy.rule $PERSISTMOD/sepolicy.rule || abort "! Insufficient partition size"
 fi
 
 # Remove stuffs that don't belong to modules

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -727,9 +727,11 @@ install_module() {
   # Copy over custom sepolicy rules
   if [ -f $MODPATH/sepolicy.rule -a -e "$PERSISTDIR" ]; then
     ui_print "- Installing custom sepolicy patch"
+    # Remove old recovery logs (which may be filling partition) to make room
+    rm -f $PERSISTDIR/cache/recovery/*
     PERSISTMOD=$PERSISTDIR/magisk/$MODID
     mkdir -p $PERSISTMOD
-    cp -af $MODPATH/sepolicy.rule $PERSISTMOD/sepolicy.rule
+    cp -af $MODPATH/sepolicy.rule $PERSISTMOD/sepolicy.rule || abort "! Insufficient partition size"
   fi
 
   # Remove stuffs that don't belong to modules


### PR DESCRIPTION
- bugged TWRPs were filling persist with recovery logs, so clean those as a potential workaround
- abort module install if sepolicy.rule fails to copy, since 99% of the time the module wouldn't include it if it could function without it

Closes #2461