### PR TITLE
scripts: try to preserve /etc/fstab on AOSP Q-based recovery

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -140,6 +140,11 @@ recovery_actions() {
   unset LD_LIBRARY_PATH
   unset LD_PRELOAD
   unset LD_CONFIG_FILE
+  # Try to preserve /etc/fstab on AOSP Q-based recovery
+  if [ -L /etc ]; then
+    setup_mntpoint /etc
+    cp -af /etc_link/* /etc
+  fi
 }
 
 recovery_cleanup() {
@@ -152,7 +157,8 @@ recovery_cleanup() {
   fi
   umount -l /vendor
   umount -l /persist
-  for DIR in /apex /system /system_root; do
+  [ -L /etc_link ] && rm -rf /etc/*
+  for DIR in /apex /system /system_root /etc; do
     if [ -L "${DIR}_link" ]; then
       rmdir $DIR
       mv -f ${DIR}_link $DIR


### PR DESCRIPTION
- busybox mount using /etc/fstab would break on Lineage 17.1 since /etc is a symlink to /system/etc and Magisk uses /system as a mountpoint
- work around it for now by temporarily copying /system/etc/* to /etc/* in the rootfs, and once TWRP has finalized their Android 10+ recovery setup the mount scripts will need to be gutted and mostly rewritten