### PR TITLE
Hide certain props in boot_complete

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -326,6 +326,8 @@ void boot_complete(int client) {
 
 	auto_start_magiskhide();
 
+	hide_sensitive_props_late();
+
 	if (access(MANAGERAPK, F_OK) == 0) {
 		// Install Magisk Manager if exists
 		rename(MANAGERAPK, "/data/magisk.apk");

--- a/native/jni/include/daemon.hpp
+++ b/native/jni/include/daemon.hpp
@@ -51,6 +51,7 @@ void reboot();
 
 // MagiskHide
 void auto_start_magiskhide();
+void hide_sensitive_props_late();
 int stop_magiskhide();
 
 // Scripting

--- a/native/jni/magiskhide/hide_policy.cpp
+++ b/native/jni/magiskhide/hide_policy.cpp
@@ -14,7 +14,7 @@ static const char *prop_key[] =
 		  "ro.boot.veritymode", "ro.boot.warranty_bit", "ro.warranty_bit", "ro.debuggable",
 		  "ro.secure", "ro.build.type", "ro.build.tags", "ro.build.selinux",
 		  "ro.vendor.boot.warranty_bit", "ro.vendor.warranty_bit",
-		  "vendor.boot.vbmeta.device_state", "vendor.boot.verifiedbootstate", nullptr };
+		  "vendor.boot.vbmeta.device_state", nullptr };
 
 
 static const char *prop_value[] =
@@ -22,7 +22,13 @@ static const char *prop_value[] =
 		  "enforcing", "0", "0", "0",
 		  "1", "user", "release-keys", "0",
 		  "0", "0",
-		  "locked", "green", nullptr };
+		  "locked", nullptr };
+
+static const char *prop_key_late[] =
+		{ "vendor.boot.verifiedbootstate", nullptr };
+
+static const char *prop_value_late[] =
+		{ "green", nullptr };
 
 void hide_sensitive_props() {
 	LOGI("hide_policy: Hiding sensitive props\n");
@@ -55,6 +61,17 @@ void hide_sensitive_props() {
 	auto hwcountry = getprop("ro.boot.hwcountry");
 	if (!hwcountry.empty() && hwcountry.find("China") != string::npos) {
 		setprop("ro.boot.hwcountry", "GLOBAL", false);
+	}
+}
+
+void hide_sensitive_props_late() {
+	LOGI("hide_policy: Hiding sensitive props in boot_complete\n");
+
+	// Hide sensitive props after boot complete
+	for (int i = 0; prop_key_late[i]; ++i) {
+		auto value = getprop(prop_key_late[i]);
+		if (!value.empty() && value != prop_value_late[i])
+			setprop(prop_key_late[i], prop_value_late[i], false);
 	}
 }
 


### PR DESCRIPTION
Resolves broken fingerprint since Canary 20411 on OnePlus 7T, 8, and 8 Pro.

Fixes #2803