### PR TITLE
magiskboot: add support for lz4 compressed dt (extra)

### DIFF
--- a/native/jni/magiskboot/bootimg.hpp
+++ b/native/jni/magiskboot/bootimg.hpp
@@ -303,9 +303,10 @@ struct boot_img {
 	// Flags to indicate the state of current boot image
 	uint16_t flags = 0;
 
-	// The format of kernel and ramdisk
+	// The format of kernel, ramdisk and extra
 	format_t k_fmt;
 	format_t r_fmt;
+	format_t e_fmt;
 
 	/***************************************************
 	 * Following pointers points within the mmap region


### PR DESCRIPTION
- legacy devices brought up to Android 10 may now use a compressed dt in a hdr_v0 AOSP dt variant extra section, so detect, decompress and recompress this
- so far these have only been done using lz4 compression (latest format revision magic), e.g. LOS 17.1 victara (Moto X)