### PR TITLE
Fix Direct Install on NAND devices

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstallImpl.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstallImpl.kt
@@ -41,7 +41,6 @@ abstract class MagiskInstallImpl : FlashResultListener {
 
     private val console: MutableList<String>
     private val logs: MutableList<String>
-    private var srcNand: String = ""
     private var tarOut: TarOutputStream? = null
 
     private val service: GithubRawServices by inject()
@@ -240,6 +239,7 @@ abstract class MagiskInstallImpl : FlashResultListener {
     }
 
     private fun patchBoot(): Boolean {
+        var srcNand = ""
         if ("[ -c $srcBoot ] && nanddump -f boot.img $srcBoot".sh().isSuccess) {
             srcNand = srcBoot
             srcBoot = File(installDir, "boot.img").path

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -411,8 +411,8 @@ flash_image() {
     [ $img_sz -gt $blk_sz ] && return 1
     eval $CMD1 | eval $CMD2 | cat - /dev/zero > "$2" 2>/dev/null
   elif [ -c "$2" ]; then
-    flash_eraseall "$2"
-    eval $CMD1 | eval $CMD2 | nandwrite -p "$2" -
+    flash_eraseall "$2" >&2
+    eval $CMD1 | eval $CMD2 | nandwrite -p "$2" - >&2
   else
     ui_print "- Not block or char device, storing image"
     eval $CMD1 | eval $CMD2 > "$2" 2>/dev/null


### PR DESCRIPTION
- install functions are reimplemented in Java so the nanddump workarounds in util_functions.sh (from 47e50e8511b2b8990d72d8dde02e69d22e2e0c76) must be mirrored here as well

Fixes #2740