### PR TITLE
Fix: log spamming on NAND devices

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -411,8 +411,8 @@ flash_image() {
     [ $img_sz -gt $blk_sz ] && return 1
     eval $CMD1 | eval $CMD2 | cat - /dev/zero > "$2" 2>/dev/null
   elif [ -c "$2" ]; then
-    flash_eraseall "$2"
-    eval $CMD1 | eval $CMD2 | nandwrite -p "$2" -
+    flash_eraseall "$2" >&2
+    eval $CMD1 | eval $CMD2 | nandwrite -p "$2" - >&2
   else
     ui_print "- Not block or char device, storing image"
     eval $CMD1 | eval $CMD2 > "$2" 2>/dev/null


### PR DESCRIPTION
Appended ` >&2` at the end of the `flash_eraseall` and `nandwrite` to stop spamming progress lines on the screen while direct install in Magisk Manager.