### PR TITLE
Disable Volume keys in flash activity

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/base/BaseUIActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/base/BaseUIActivity.kt
@@ -2,6 +2,7 @@ package com.topjohnwu.magisk.ui.base
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDelegate
@@ -94,6 +95,10 @@ abstract class BaseUIActivity<ViewModel : BaseViewModel, Binding : ViewDataBindi
     override fun onResume() {
         super.onResume()
         delegate.onResume()
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        return currentFragment?.onKeyEvent(event) == true || super.dispatchKeyEvent(event)
     }
 
     override fun onEventDispatched(event: ViewEvent) {

--- a/app/src/main/java/com/topjohnwu/magisk/ui/base/BaseUIFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/base/BaseUIFragment.kt
@@ -1,6 +1,7 @@
 package com.topjohnwu.magisk.ui.base
 
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -49,6 +50,10 @@ abstract class BaseUIFragment<ViewModel : BaseViewModel, Binding : ViewDataBindi
     override fun onEventDispatched(event: ViewEvent) {
         super.onEventDispatched(event)
         delegate.onEventExecute(event, this)
+    }
+
+    open fun onKeyEvent(event: KeyEvent): Boolean {
+        return false
     }
 
     open fun onBackPressed(): Boolean = false

--- a/app/src/main/java/com/topjohnwu/magisk/ui/flash/FlashFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/flash/FlashFragment.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -60,6 +61,14 @@ class FlashFragment : BaseUIFragment<FlashViewModel, FragmentFlashMd2Binding>() 
             activity.requestedOrientation = defaultOrientation
         }
         super.onDestroyView()
+    }
+
+    override fun onKeyEvent(event: KeyEvent): Boolean {
+        return when(event.keyCode) {
+            KeyEvent.KEYCODE_VOLUME_UP,
+            KeyEvent.KEYCODE_VOLUME_DOWN -> true
+            else -> false
+        }
     }
 
     override fun onBackPressed(): Boolean {


### PR DESCRIPTION
Recap of old pull #2457: Sometimes modules ask to push volumes keys but the problem is that by pushing the volume keys during a flash it also changes the volume of the phone.

This time the code is much cleaner and should help more the project

I add a new API `BaseUIFragment.onKeyEvent` that should help #2027  
(Currently used for blocking volumes keys)
