### PR TITLE
Fix bytecode compatibility when compiling with Java9 ( Fix #2898 )

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/PatchAPK.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/PatchAPK.kt
@@ -20,6 +20,7 @@ import io.reactivex.Single
 import timber.log.Timber
 import java.io.File
 import java.io.FileOutputStream
+import java.nio.Buffer
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.security.SecureRandom
@@ -74,7 +75,8 @@ object PatchAPK {
 
         val toBuf = to.toString().toCharArray().copyOf(from.length)
         for (off in offList) {
-            buf.position(off)
+            // IMPORTANT CAST FOR BYTECODE COMPATIBILITY (DO NOT REMOVE)
+            (buf as Buffer).position(off)
             buf.put(toBuf)
         }
         return true

--- a/signing/src/main/java/com/topjohnwu/signing/SignBoot.java
+++ b/signing/src/main/java/com/topjohnwu/signing/SignBoot.java
@@ -18,6 +18,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.PrivateKey;
@@ -179,13 +180,15 @@ public class SignBoot {
                 + ((secondSize + pageSize - 1) / pageSize) * pageSize;
         int headerVersion = image.getInt(); // boot image header version or dt/extra size
         if (headerVersion > 0 && headerVersion < BOOT_IMAGE_HEADER_VERSION_MAXIMUM) {
-            image.position(BOOT_IMAGE_HEADER_V1_RECOVERY_DTBO_SIZE_OFFSET);
+            // IMPORTANT CAST FOR BYTECODE COMPATIBILITY (DO NOT REMOVE)
+            ((Buffer) image).position(BOOT_IMAGE_HEADER_V1_RECOVERY_DTBO_SIZE_OFFSET);
             int recoveryDtboLength = image.getInt();
             length += ((recoveryDtboLength + pageSize - 1) / pageSize) * pageSize;
             image.getLong(); // recovery_dtbo address
             int headerSize = image.getInt();
             if (headerVersion == 2) {
-                image.position(BOOT_IMAGE_HEADER_V2_DTB_SIZE_OFFSET);
+                // IMPORTANT CAST FOR BYTECODE COMPATIBILITY (DO NOT REMOVE)
+                ((Buffer) image).position(BOOT_IMAGE_HEADER_V2_DTB_SIZE_OFFSET);
                 int dtbLength = image.getInt();
                 length += ((dtbLength + pageSize - 1) / pageSize) * pageSize;
                 image.getLong(); // dtb address


### PR DESCRIPTION
This commit is a bit technical and may need bytecode knownedge to fully understand but I will try to explains it anyways
Fix #2898

This bugs is due to the fact that the bytecode generated in java9 make `buf.position(off)` with a java8 runtime  
This is due to a addition in the `ByteBuffer` / `CharBuffer` / `***Buffer` in java9 that add  
`public ByteBuffer position(int i)` this overide the supermethod in  `Buffer`
`public Buffer position(int i)` this lead to generate  
`INVOKEVIRTUAL java/lang/ByteBuffer position (I)Ljava/lang/ByteBuffer;`  instead of  
`INVOKEVIRTUAL java/lang/ByteBuffer position (I)Ljava/lang/Buffer;`  and because the descriptor  
`position (I)Ljava/lang/ByteBuffer;` for method `position` doesn't exists in Java8 this cause to create a `NoSuchMethodError`
Even if we don't need the return value java still throw this error because the return value asked doesn't exist  

I english the literal traduction is that when compiled in java9 it's ask `ByteBuffer` but since in java8 only the method that return `Buffer` exists it just return that the method doesn't exist  

To workaround this issue we just cast to `Buffer` forcing java9 to always ask for `Buffer` as return value instead of `ByteBuffer` for its method calls opcodes