### PR TITLE
Cast ByteBuffer to Buffer before calling position()

### DIFF
--- a/signing/src/main/java/com/topjohnwu/signing/SignBoot.java
+++ b/signing/src/main/java/com/topjohnwu/signing/SignBoot.java
@@ -18,6 +18,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.PrivateKey;
@@ -179,18 +180,18 @@ public class SignBoot {
                 + ((secondSize + pageSize - 1) / pageSize) * pageSize;
         int headerVersion = image.getInt(); // boot image header version or dt/extra size
         if (headerVersion > 0 && headerVersion < BOOT_IMAGE_HEADER_VERSION_MAXIMUM) {
-            image.position(BOOT_IMAGE_HEADER_V1_RECOVERY_DTBO_SIZE_OFFSET);
+            ((Buffer)image).position(BOOT_IMAGE_HEADER_V1_RECOVERY_DTBO_SIZE_OFFSET);
             int recoveryDtboLength = image.getInt();
             length += ((recoveryDtboLength + pageSize - 1) / pageSize) * pageSize;
             image.getLong(); // recovery_dtbo address
             int headerSize = image.getInt();
             if (headerVersion == 2) {
-                image.position(BOOT_IMAGE_HEADER_V2_DTB_SIZE_OFFSET);
+                ((Buffer)image).position(BOOT_IMAGE_HEADER_V2_DTB_SIZE_OFFSET);
                 int dtbLength = image.getInt();
                 length += ((dtbLength + pageSize - 1) / pageSize) * pageSize;
                 image.getLong(); // dtb address
             }
-            if (image.position() != headerSize) {
+            if (((Buffer)image).position() != headerSize) {
                 throw new IllegalArgumentException(
                         "Invalid image header: invalid header length");
             }


### PR DESCRIPTION
On some devices (e.g ROG Phone) there will be error while patching boot.img:

Caused by: java.lang.NoSuchMethodError: No virtual method position(I)Ljava/nio/ByteBuffer; in class Ljava/nio/ByteBuffer; or its super classes (declaration of 'java.nio.ByteBuffer' appears in /system/framework/core-oj.jar)

Signed-off-by: Shaka Huang <shakalaca@gmail.com>