### PR TITLE
Fix release build XLint error for translations

### DIFF
--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -103,8 +103,8 @@
     <string name="target_uid">UID target: %1$d</string>
 
     <!--SafetyNet-->
-    <string name="safetyNet_api_error">Kesalahan API SafetyNet</string>
-    <string name="safetyNet_res_invalid">Tanggapan tidak valid</string>
+    <string name="safetynet_api_error">Kesalahan API SafetyNet</string>
+    <string name="safetynet_res_invalid">Tanggapan tidak valid</string>
     <string name="safetynet_attest_success">Sukses!</string>
     <string name="safetynet_attest_failure">Pengesahan gagal!</string>
     <string name="safetynet_attest_loading">Tunggu sebentar…</string>


### PR DESCRIPTION
Due to the accidental safety>N<et the release build would fail with XLint complaining about a missing default translation. Correcting this to be in line with the actual translation fixes the build error.


Xlint Error in Question: 

```
res/values-in/strings.xml:106: Error: "safetyNet_api_error" is translated here but not found in default locale [ExtraTranslation]
    <string name="safetyNet_api_error">Kesalahan API SafetyNet</string>
```