### PR TITLE
Allowing modifications at /apex/

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -95,6 +95,7 @@ static bool magisk_env() {
 		if (0) {}
 		mount_mirror(system, MS_RDONLY)
 		mount_mirror(vendor, MS_RDONLY)
+		mount_mirror(apex, MS_RDONLY)
 		mount_mirror(product, MS_RDONLY)
 		mount_mirror(system_ext, MS_RDONLY)
 		mount_mirror(data, 0)
@@ -110,6 +111,7 @@ static bool magisk_env() {
 		LOGI("link: %s\n", buf1);
 	}
 	link_mirror(vendor);
+	link_mirror(apex);
 	link_mirror(product);
 	link_mirror(system_ext);
 

--- a/native/jni/core/module.cpp
+++ b/native/jni/core/module.cpp
@@ -595,7 +595,7 @@ void magic_mount() {
 		return;
 
 	// Handle special read-only partitions
-	for (const char *part : { "/vendor", "/product", "/system_ext" }) {
+	for (const char *part : { "/vendor", "/product", "/system_ext", "/apex" }) {
 		struct stat st;
 		if (lstat(part, &st) == 0 && S_ISDIR(st.st_mode)) {
 			if (auto old = system->extract(part + 1); old) {

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -309,12 +309,14 @@ mount_apex() {
     if [ -f $APEX ]; then
       # APEX APKs, extract and loop mount
       unzip -qo $APEX apex_payload.img -d /apex
-      loop_setup apex_payload.img
+      loop_setup /apex/apex_payload.img
       if [ ! -z $LOOPDEV ]; then
         ui_print "- Mounting $DEST"
         mount -t ext4 -o ro,noatime $LOOPDEV $DEST
+      else
+        ui_print "- Failed to mount: $DEST"
       fi
-      rm -f apex_payload.img
+      rm -f /apex/apex_payload.img
     elif [ -d $APEX ]; then
       # APEX folders, bind mount directory
       ui_print "- Mounting $DEST"


### PR DESCRIPTION
Magisk allows the replacement of files at `/apex` only for devices that are using extracted APEX modules, but wasn't working for APEX zip files. The tiny changes in this PR allows overlaying files to `/apex` after a `.apex` file is extracted and mounted.
Not sure if that's the way to do it, but it serves my purpose so I'm just sharing it.
It follows a detailed explanation of the issues I've had at #3008.

#### Working example with extracted APEX folders `@v20.4`:
The `system.img` of Google Pixel (sailfish) has extracted APEX modules.
To replace e.g. the runtime and dex2oat one could use a module like:
```
├── customize.sh
└── system
    └── apex
        └── com.android.runtime.release
            ├── bin
            │   └── dex2oat
            └── lib64
                └── libart.so
```

During boot, android mounts this folder to: `/apex/com.android.runtime/`
Then magisk applies the changes at `/system/apex/com.android.runtime.release/`,
which are reflected to the `/apex` mount.  With `customize.sh` relevant permissions/ownerships can be set.

#### Issue with .apex  zip files
Google Pixel 4 (flame) and possible other devices use APEX zip files, like:
`/system/apex/com.android.runtime.release.apex`.

Those are extracted and mounted (`apex_payload.img`) to `/apex/com.android.runtime/`.
I've tried many things unsuccessfully, some of which include:
- replacing files with a module that puts relevant files at:
    + `/apex/com.android.runtime`
    + `/system/apex/com.android.runtime`               (this PR will make this to work)
    + `/system/apex/com.android.runtime.release` (this was working fine with `sailfish`)
- combinations of above with attempts to remove the `.apex` file by masking it with either:
    + `boot.img:ramdisk/overlay.d/` approach
    +  an empty file at `/system/apex/com.android.runtime.release.apex`
    + the `REPLACE` variable in customize.sh
- other attempts to extract the `.apex` at `/system/apex/`, so magisk could then apply the changes on that folder
- modifying `env` variables like `ANDROID_RUNTIME_ROOT`, and put my changes directly in `/system/lib` to trick `linker` to use my versions

### Handling `/apex` like other special read only partitions (e.g. `/vendor`):
The minor changes in `92af79c` in combination with the module below do the trick:
```
├── customize.sh
├── service.sh
└── system
    └── apex
        └── com.android.runtime
            ├── bin
            │   └── dex2oat
            └── lib64
                └── libart.so
```
The  folder: `/system/apex/com.android.runtime` must be used,
and not the renamed one (that has appended `.release` or `.debug`).
Just for the libraries (binaries are ok), one must set permissions/ownership using `service.sh` (instead of `customize.sh`) like:
```
chown system.system    /apex/com.android.runtime/lib/libart.so
chmod 0644                    /apex/com.android.runtime/lib/libart.so
```


So Android extracts the `/system/apex/com.android.runtime.apex` zip file,
then mounts it at `/apex/com.android.runtime`, and then magisk directly overlays the changes of the module.

### Minor bugfix `086fa726b`
This must have been introduced during a cleanup. It did not affect/fix my issue.
Related to  #2114 #2109.
