### PR TITLE
Use uid 2000 to install patched apk

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/PatchAPK.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/PatchAPK.kt
@@ -130,8 +130,7 @@ object PatchAPK {
             return false
 
         // Install the application
-        repack.setReadable(true, false)
-        if (!Shell.su("pm install $repack").exec().isSuccess)
+        if (!Shell.su("adb_pm_install $repack").exec().isSuccess)
             return false
 
         Config.suManager = pkg.toString()

--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -85,6 +85,16 @@ EOF
   cd /
 }
 
+adb_pm_install() {
+  local tmp=/data/local/tmp/patched.apk
+  cp -f "$1" $tmp
+  chmod 644 $tmp
+  su 2000 -c pm install $tmp
+  local res=$?
+  rm -f $tmp
+  return $res
+}
+
 check_boot_ramdisk() {
   # Create boolean ISAB
   [ -z $SLOT ] && ISAB=false || ISAB=true


### PR DESCRIPTION
In some cases, installing with uid 0 will result in stricter checks, using uid 2000 to pass them.
close #2975 