### PR TITLE
Track more sepolicy cil files

### DIFF
--- a/native/jni/magiskpolicy/policydb.cpp
+++ b/native/jni/magiskpolicy/policydb.cpp
@@ -135,6 +135,19 @@ sepolicy *sepolicy::compile_split() {
 	sprintf(path, PLAT_POLICY_DIR "mapping/%s.cil", plat_ver);
 	load_cil(db, path);
 
+	sprintf(path, PLAT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
+	if (access(path, R_OK) == 0)
+		load_cil(db, path);
+
+	// system_ext
+	sprintf(path, SYSEXT_POLICY_DIR "mapping/%s.cil", plat_ver);
+	if (access(path, R_OK) == 0)
+		load_cil(db, path);
+	
+	cil_file = SYSEXT_POLICY_DIR "system_ext_sepolicy.cil";
+	if (access(cil_file, R_OK) == 0)
+		load_cil(db, cil_file);
+
 	// product
 	sprintf(path, PROD_POLICY_DIR "mapping/%s.cil", plat_ver);
 	if (access(path, R_OK) == 0)


### PR DESCRIPTION
Xiaomi Mi 10 series are the first devices to store system_ext_sepolicy.cil files under system_ext of the super partition. Add it to compile sepolicy.
This fixes #3093

Reference: https://android.googlesource.com/platform/system/core/+/refs/tags/android-r-beta-3/init/selinux.cpp
