### PR TITLE
Optimize network status display

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/data/repository/MagiskRepository.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/data/repository/MagiskRepository.kt
@@ -3,6 +3,7 @@ package com.topjohnwu.magisk.data.repository
 import com.topjohnwu.magisk.core.Config
 import com.topjohnwu.magisk.core.Info
 import com.topjohnwu.magisk.data.network.GithubRawServices
+import retrofit2.HttpException
 import timber.log.Timber
 import java.io.IOException
 
@@ -26,6 +27,9 @@ class MagiskRepository(
         Info.remote = info
         info
     } catch (e: IOException) {
+        Timber.e(e)
+        null
+    } catch (e: HttpException) {
         Timber.e(e)
         null
     }

--- a/app/src/main/java/com/topjohnwu/magisk/ktx/XAndroid.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ktx/XAndroid.kt
@@ -5,10 +5,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
-import android.content.pm.ApplicationInfo
-import android.content.pm.ComponentInfo
-import android.content.pm.PackageInfo
-import android.content.pm.PackageManager
+import android.content.pm.*
 import android.content.pm.PackageManager.*
 import android.content.res.Configuration
 import android.content.res.Resources
@@ -63,7 +60,11 @@ val PackageInfo.processes
             receivers?.processNames.orEmpty() +
             providers?.processNames.orEmpty()
 
-val Array<out ComponentInfo>.processNames get() = mapNotNull { it.processName }
+val Array<out ComponentInfo>.processNames
+    get() = mapNotNull {
+        if (it is ServiceInfo && it.flags and ServiceInfo.FLAG_ISOLATED_PROCESS != 0) null
+        else it.processName
+    }
 
 val ApplicationInfo.packageInfo: PackageInfo get() {
     val pm = get<PackageManager>()

--- a/app/src/main/java/com/topjohnwu/magisk/ktx/XAndroid.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ktx/XAndroid.kt
@@ -5,7 +5,10 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
-import android.content.pm.*
+import android.content.pm.ApplicationInfo
+import android.content.pm.ComponentInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.content.pm.PackageManager.*
 import android.content.res.Configuration
 import android.content.res.Resources
@@ -60,11 +63,7 @@ val PackageInfo.processes
             receivers?.processNames.orEmpty() +
             providers?.processNames.orEmpty()
 
-val Array<out ComponentInfo>.processNames
-    get() = mapNotNull {
-        if (it is ServiceInfo && it.flags and ServiceInfo.FLAG_ISOLATED_PROCESS != 0) null
-        else it.processName
-    }
+val Array<out ComponentInfo>.processNames get() = mapNotNull { it.processName }
 
 val ApplicationInfo.packageInfo: PackageInfo get() {
     val pm = get<PackageManager>()

--- a/app/src/main/java/com/topjohnwu/magisk/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/home/HomeViewModel.kt
@@ -70,6 +70,9 @@ class HomeViewModel(
     val showUninstall get() =
         Info.env.magiskVersionCode > 0 && stateMagisk != MagiskState.LOADING && isConnected.get()
 
+    @get:Bindable
+    val showSafetyNet get() = Info.hasGMS && isConnected.get()
+
     val itemBinding = itemBindingOf<IconLink> {
         it.bindExtra(BR.viewModel, this)
     }
@@ -77,8 +80,11 @@ class HomeViewModel(
     private var shownDialog = false
 
     override fun refresh() = viewModelScope.launch {
+        state = State.LOADING
         notifyPropertyChanged(BR.showUninstall)
+        notifyPropertyChanged(BR.showSafetyNet)
         repoMagisk.fetchUpdate()?.apply {
+            state = State.LOADED
             stateMagisk = when {
                 !Info.env.isActive -> MagiskState.NOT_INSTALLED
                 magisk.isObsolete -> MagiskState.OBSOLETE
@@ -99,7 +105,7 @@ class HomeViewModel(
             launch {
                 ensureEnv()
             }
-        }
+        } ?: apply { state = State.LOADING_FAILED }
     }
 
     val showTest = false

--- a/app/src/main/java/com/topjohnwu/magisk/utils/net/LollipopNetworkObserver.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/utils/net/LollipopNetworkObserver.kt
@@ -32,7 +32,7 @@ open class LollipopNetworkObserver(
         }
 
         override fun onLost(network: Network) {
-            emit(Connectivity.create(manager, network))
+            emit(Connectivity())
         }
     }
 }

--- a/app/src/main/res/layout/fragment_home_md2.xml
+++ b/app/src/main/res/layout/fragment_home_md2.xml
@@ -108,7 +108,7 @@
             <Space
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/l1"
-                gone="@{!Info.hasGMS &amp;&amp; !viewModel.showUninstall}" />
+                gone="@{!viewModel.showSafetyNet &amp;&amp; !viewModel.showUninstall}" />
 
             <Button
                 style="@style/WidgetFoundation.Button.Outlined"
@@ -120,7 +120,7 @@
                 android:textAllCaps="false"
                 android:textSize="12sp"
                 android:onClick="@{() -> viewModel.onSafetyNetPressed()}"
-                gone="@{!Info.hasGMS}"
+                gone="@{!viewModel.showSafetyNet}"
                 app:cornerRadius="@dimen/r1"
                 app:icon="@drawable/ic_safetynet_md2" />
 

--- a/app/src/main/res/layout/include_home_magisk.xml
+++ b/app/src/main/res/layout/include_home_magisk.xml
@@ -118,7 +118,7 @@
 
                             <TextView
                                 style="@style/W.Home.ItemContent.Right"
-                                android:text="@{viewModel.isConnected ? viewModel.magiskRemoteVersion : @string/not_available}"
+                                android:text="@{viewModel.loadFailed ? @string/not_available:viewModel.magiskRemoteVersion }"
                                 tools:text="20.1 (12345)" />
 
                         </LinearLayout>

--- a/app/src/main/res/layout/include_home_magisk.xml
+++ b/app/src/main/res/layout/include_home_magisk.xml
@@ -118,7 +118,7 @@
 
                             <TextView
                                 style="@style/W.Home.ItemContent.Right"
-                                android:text="@{viewModel.loadFailed ? @string/not_available:viewModel.magiskRemoteVersion }"
+                                android:text="@{viewModel.loadFailed ? @string/not_available : viewModel.magiskRemoteVersion }"
                                 tools:text="20.1 (12345)" />
 
                         </LinearLayout>

--- a/app/src/main/res/layout/include_home_manager.xml
+++ b/app/src/main/res/layout/include_home_manager.xml
@@ -121,7 +121,7 @@
 
                             <TextView
                                 style="@style/W.Home.ItemContent.Right"
-                                android:text="@{viewModel.isConnected ? viewModel.managerRemoteVersion : @string/not_available}"
+                                android:text="@{viewModel.loadFailed ? @string/not_available : viewModel.managerRemoteVersion}"
                                 tools:text="8.0.0 (123) (10)" />
 
                         </LinearLayout>


### PR DESCRIPTION
Catch retrofit2 RuntimeException.
Hide SafetyNet when no network.
Update "loading" to "not available" when fetch update failed.
Fix NetworkObserver on Android 11.  `NetworkInfo` was deprecated in API level 29, `getNetworkInfo` can't get accurate information when network lost. This is just a temporary fix.