### PR TITLE
Prevent UI loop

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallFragment.kt
@@ -1,6 +1,8 @@
 package com.topjohnwu.magisk.ui.install
 
 import android.content.Intent
+import android.os.Bundle
+import android.view.View
 import androidx.lifecycle.viewModelScope
 import com.topjohnwu.magisk.R
 import com.topjohnwu.magisk.arch.BaseUIFragment
@@ -14,6 +16,17 @@ class InstallFragment : BaseUIFragment<InstallViewModel, FragmentInstallMd2Bindi
 
     override val layoutRes = R.layout.fragment_install_md2
     override val viewModel by viewModel<InstallViewModel>()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        savedInstanceState?.getInt(KEY_CURRENT_METHOD, -1)?.let { viewModel.method = it }
+        binding.methodContainer.setOnCheckedChangeListener { group, checkedId ->
+            // If the UI is restored, this also triggers, but we only want user actions
+            if (group.findViewById<View>(checkedId)?.isPressed == true) {
+                viewModel.onMethodChanged(checkedId)
+            }
+        }
+    }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
@@ -29,4 +42,12 @@ class InstallFragment : BaseUIFragment<InstallViewModel, FragmentInstallMd2Bindi
         BaseDownloader.observeProgress(this, viewModel::onProgressUpdate)
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putInt(KEY_CURRENT_METHOD, viewModel.method)
+        super.onSaveInstanceState(outState)
+    }
+
+    companion object {
+        private const val KEY_CURRENT_METHOD = "current_method"
+    }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -1,6 +1,7 @@
 package com.topjohnwu.magisk.ui.install
 
 import android.net.Uri
+import androidx.annotation.IdRes
 import androidx.databinding.Bindable
 import androidx.lifecycle.viewModelScope
 import com.topjohnwu.magisk.BR
@@ -30,18 +31,7 @@ class InstallViewModel(
     var step = if (skipOptions) 1 else 0
         set(value) = set(value, field, { field = it }, BR.step)
 
-    @get:Bindable
     var method = -1
-        set(value) = set(value, field, { field = it }, BR.method) {
-            when (it) {
-                R.id.method_patch -> {
-                    RequestFileEvent().publish()
-                }
-                R.id.method_inactive_slot -> {
-                    SecondSlotWarningDialog().publish()
-                }
-            }
-        }
 
     @get:Bindable
     var progress = 0
@@ -58,6 +48,14 @@ class InstallViewModel(
     init {
         viewModelScope.launch {
             notes = stringRepo.getString(Info.remote.magisk.note)
+        }
+    }
+
+    fun onMethodChanged(newMethod: Int) {
+        method = newMethod
+        when (newMethod) {
+            R.id.method_patch -> RequestFileEvent().publish()
+            R.id.method_inactive_slot -> SecondSlotWarningDialog().publish()
         }
     }
 

--- a/app/src/main/res/layout/fragment_install_md2.xml
+++ b/app/src/main/res/layout/fragment_install_md2.xml
@@ -181,9 +181,10 @@
                             android:layout_height="wrap_content"
                             android:layout_marginStart="@dimen/l1"
                             android:layout_marginTop="@dimen/l_50"
+                            android:id="@+id/method_container"
                             android:layout_marginEnd="@dimen/l1"
                             android:layout_marginBottom="@dimen/l_50"
-                            android:checkedButton="@={viewModel.method}"
+                            android:checkedButton="@{viewModel.method}"
                             android:paddingStart="3dp"
                             android:paddingEnd="3dp">
 


### PR DESCRIPTION
Persist the current method install method and prevent programmatic restoration from triggering change listeners.

Fixes #3215 