### PR TITLE
[master] Fix ensure_bb by assigning the arguments properly

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -114,7 +114,7 @@ ensure_bb() {
   # Find our current arguments
   # Run in busybox environment to ensure consistent results
   # /proc/<pid>/cmdline shall be <interpreter> <script> <arguments...>
-  local cmds=$($bb sh -o standalone -c "
+  local cmds="$($bb sh -o standalone -c "
   for arg in \$(tr '\0' '\n' < /proc/$$/cmdline); do
     if [ -z \"\$cmds\" ]; then
       # Skip the first argument as we want to change the interpreter
@@ -123,7 +123,7 @@ ensure_bb() {
       cmds=\"\$cmds '\$arg'\"
     fi
   done
-  echo \$cmds")
+  echo \$cmds")"
 
   # Re-exec our script
   echo $cmds | $bb xargs $bb


### PR DESCRIPTION
If we assign the execution output directly it will fail (tested on Android 11):

```
pdx201:/ # INSTALLER=/data/adb/magisk_install /data/adb/magisk_install/flash_script.sh                                                                          
/data/adb/magisk_install/flash_script.sh[31]: typeset: -o: is not an identifier
```

Because:

```
local cmds=$($bb sh -o standalone -c "
	  for arg in \$(tr '\0' '\n' < /proc/$$/cmdline); do
	    if [ -z \"\$cmds\" ]; then
	      # Skip the first argument as we want to change the interpreter
	      cmds=\"sh -o standalone\"
	    else
	      cmds=\"\$cmds '\$arg'\"
	    fi
	  done
	  echo \$cmds")
/system/bin/sh: typeset: -o: is not an identifier
```

Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>