### PR TITLE
Fag.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -15,3 +15,4 @@ If unfortunately you do not have USB debugging enabled, reboot into Safe Mode. M
 On devices running Android 9.0+, Magisk Manager will use a more advanced hiding method. It will install a "stub" APK that has nothing in it. The only functionality the stub app has is downloading the full Magisk Manager APK into its internal storage and dynamically load it. Due to the fact that the APK is literally *empty*, it does not contain the image resource for the app icon.
 
 When you open the hidden Magisk Manager, it will offer you the option to create a shortcut in the homescreen (which has both the correct app name and icon) for your convenience. You can also manually ask the app to create the icon in Magisk Manager settings.
+Adb device​


### PR DESCRIPTION
When you open the hidden Magisk Manager, it will offer you the option to create a shortcut in the homescreen (which has both the correct app name and icon) for your convenience. You can also manually ask the app to create the icon in Magisk Manager settings.On devices running Android 9.0+, Magisk Manager will use a more advanced hiding method. It will install a "stub" APK that has nothing in it. The only functionality the stub app has is downloading the full Magisk Manager APK into its internal storage and dynamically load it. Due to the fact that the APK is literally empty, it does not contain the image resource for the app icon.