### PR TITLE
Fix a typo and use the proper Unicode characters

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -234,7 +234,7 @@
     <string name="unsupport_magisk_title">Version de Magisk non prise en charge</string>
     <string name="unsupport_magisk_msg">Cette version de Magisk Manager ne prend pas en charge les versions de Magisk inférieures à %1$s.\n\nL’application se comportera comme si Magisk n’était pas installé. Veuillez mettre à jour Magisk aussi vite que possible.</string>
     <string name="external_rw_permission_denied">Permettre l’accès au stockage pour activer cette fonctionnalité</string>
-    <string name="add_shortcut_title">Ajouter un raccourcis à l’écran d’accueil</string>
-    <string name="add_shortcut_msg">Après avoir caché Magisk Manager, son nom et son icône peuvent devenir difficiles à reconnaître. Voulez-vous ajouter un joli raccourci vers l’écran d’accueil ?</string>
+    <string name="add_shortcut_title">Ajouter un raccourci à l’écran d’accueil</string>
+    <string name="add_shortcut_msg">Après avoir caché Magisk Manager, son nom et son icône peuvent devenir difficiles à reconnaître. Voulez‑vous ajouter un joli raccourci vers l’écran d’accueil ?</string>
 
 </resources>


### PR DESCRIPTION
- fix a French typo: raccourcis → raccourci
- French orthotypography: use a thin space before a question mark, and a true (non breaking) hyphen instead of a dash.