### PR TITLE
Tapjacking protection

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIActivity.kt
@@ -70,6 +70,10 @@ abstract class BaseUIActivity<VM : BaseViewModel, Binding : ViewDataBinding> :
         ensureInsets()
     }
 
+    fun setAccessibilityDelegate(delegate: View.AccessibilityDelegate?) {
+        viewRoot.rootView.accessibilityDelegate = delegate
+    }
+
     override fun onResume() {
         super.onResume()
         viewModel.requestRefresh()
@@ -79,7 +83,7 @@ abstract class BaseUIActivity<VM : BaseViewModel, Binding : ViewDataBinding> :
         return currentFragment?.onKeyEvent(event) == true || super.dispatchKeyEvent(event)
     }
 
-    override fun onEventDispatched(event: ViewEvent) = when(event) {
+    override fun onEventDispatched(event: ViewEvent) = when (event) {
         is ContextExecutor -> event(this)
         is ActivityExecutor -> event(this)
         else -> Unit

--- a/app/src/main/java/com/topjohnwu/magisk/core/Config.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/Config.kt
@@ -50,6 +50,7 @@ object Config : PreferenceModel, DBConfig {
         const val SU_AUTO_RESPONSE = "su_auto_response"
         const val SU_NOTIFICATION = "su_notification"
         const val SU_REAUTH = "su_reauth"
+        const val SU_TAPJACK = "su_tapjack"
         const val CHECK_UPDATES = "check_update"
         const val UPDATE_CHANNEL = "update_channel"
         const val CUSTOM_CHANNEL = "custom_channel"
@@ -134,6 +135,7 @@ object Config : PreferenceModel, DBConfig {
     var darkTheme by preference(Key.DARK_THEME, AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
     var themeOrdinal by preference(Key.THEME_ORDINAL, Theme.Piplup.ordinal)
     var suReAuth by preference(Key.SU_REAUTH, false)
+    var suTapjack by preference(Key.SU_TAPJACK, true)
     var checkUpdate by preference(Key.CHECK_UPDATES, true)
     var doh by preference(Key.DOH, false)
     var magiskHide by preference(Key.MAGISKHIDE, true)

--- a/app/src/main/java/com/topjohnwu/magisk/events/ViewEvents.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/events/ViewEvents.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.view.View
 import android.widget.Toast
 import androidx.navigation.NavDirections
 import com.topjohnwu.magisk.MainDirections
@@ -58,9 +59,11 @@ class DieEvent : ViewEvent(), ActivityExecutor {
     }
 }
 
-class ShowUIEvent : ViewEvent(), ActivityExecutor {
+class ShowUIEvent(private val delegate: View.AccessibilityDelegate?)
+    : ViewEvent(), ActivityExecutor {
     override fun invoke(activity: BaseUIActivity<*, *>) {
         activity.setContentView()
+        activity.setAccessibilityDelegate(delegate)
     }
 }
 

--- a/app/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsItems.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsItems.kt
@@ -189,6 +189,13 @@ object SystemlessHosts : BaseSettingsItem.Blank() {
     override val description = R.string.settings_hosts_summary.asTransitive()
 }
 
+object Tapjack : BaseSettingsItem.Toggle() {
+    override val title = R.string.settings_su_tapjack_title.asTransitive()
+    override var description = R.string.settings_su_tapjack_summary.asTransitive()
+    override var value = Config.suTapjack
+        set(value) = setV(value, field, { field = it }) { Config.suTapjack = it }
+}
+
 object Biometrics : BaseSettingsItem.Toggle() {
     override val title = R.string.settings_su_biometric_title.asTransitive()
     override var value = Config.suBiometric

--- a/app/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsViewModel.kt
@@ -79,7 +79,7 @@ class SettingsViewModel(
         if (Utils.showSuperUser()) {
             list.addAll(listOf(
                 Superuser,
-                Biometrics, AccessMode, MultiuserMode, MountNamespaceMode,
+                Tapjack, Biometrics, AccessMode, MultiuserMode, MountNamespaceMode,
                 AutomaticResponse, RequestTimeout, SUNotification
             ))
             if (Build.VERSION.SDK_INT < 23) {

--- a/app/src/main/java/com/topjohnwu/magisk/ui/surequest/SuRequestActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/surequest/SuRequestActivity.kt
@@ -28,8 +28,8 @@ open class SuRequestActivity : BaseUIActivity<SuRequestViewModel, ActivityReques
     override fun onCreate(savedInstanceState: Bundle?) {
         supportRequestWindowFeature(Window.FEATURE_NO_TITLE)
         lockOrientation()
-        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
-            WindowManager.LayoutParams.FLAG_SECURE)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        window.addFlags(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
         super.onCreate(savedInstanceState)
 
         fun showRequest() {

--- a/app/src/main/res/layout/activity_request.xml
+++ b/app/src/main/res/layout/activity_request.xml
@@ -138,6 +138,7 @@
                 <Button
                     android:id="@+id/grant_btn"
                     style="@style/WidgetFoundation.Button.Text"
+                    onTouch="@{viewModel.grantTouchListener}"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
 
     <!--Superuser-->
     <string name="su_request_title">Superuser Request</string>
+    <string name="touch_filtered_warning">Because an app is obscuring a superuser request, Magisk can’t verify your response</string>
     <string name="deny">Deny</string>
     <string name="prompt">Prompt</string>
     <string name="grant">Grant</string>
@@ -172,6 +173,8 @@
     <string name="superuser_notification">Superuser Notification</string>
     <string name="settings_su_reauth_title">Reauthenticate after upgrade</string>
     <string name="settings_su_reauth_summary">Reauthenticate superuser permissions after an application upgrades</string>
+    <string name="settings_su_tapjack_title">Enable Tapjacking Protection</string>
+    <string name="settings_su_tapjack_summary">The superuser prompt dialog will not respond to input while obscured by any other window or overlay</string>
     <string name="settings_su_biometric_title">Enable Biometric Authentication</string>
     <string name="settings_su_biometric_summary">Use biometric authentication to allow superuser requests</string>
     <string name="no_biometric">Unsupported device or no biometric settings are enabled</string>


### PR DESCRIPTION
#2417 
> Secure surfaces are used to prevent content rendered into those surfaces by applications from appearing in screenshots or from being viewed on non-secure displays. An application can use the absence of this flag as a hint that it should not create secure surfaces or protected buffers on this display because the content may not be visible.

This flag cannot block the accessibility services click button. @Fox2Code 