### PR TITLE
utils_functions: Added a check for the system_root

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -247,6 +247,10 @@ mount_partitions() {
   [ -z $SLOT ] || ui_print "- Current boot slot: $SLOT"
 
   # Mount ro partitions
+  if is_mounted /system_root; then
+    umount /system 2&>/dev/null
+    umount /system_root 2&>/dev/null
+  fi
   mount_ro_ensure "system$SLOT app$SLOT" /system
   if [ -f /system/init -o -L /system/init ]; then
     SYSTEM_ROOT=true


### PR DESCRIPTION
now on addon while flashing recovery usign mount point /system_root by which this is causing a flashing error.
Let's first check and unmount /system_root if mounted