### PR TITLE
Support rootwait cmdline parameter on legacy SAR

### DIFF
--- a/native/jni/init/getinfo.cpp
+++ b/native/jni/init/getinfo.cpp
@@ -160,6 +160,8 @@ void load_kernel_info(cmdline *cmd) {
 			cmd->skip_initramfs = true;
 		} else if (key == "androidboot.force_normal_boot") {
 			cmd->force_normal_boot = value[0] == '1';
+		} else if (key == "rootwait") {
+			cmd->rootwait = true;
 		} else if (key == "androidboot.android_dt_dir") {
 			strcpy(cmd->dt_dir, value);
 		} else if (key == "androidboot.hardware") {
@@ -174,6 +176,7 @@ void load_kernel_info(cmdline *cmd) {
 	LOGD("Kernel cmdline info:\n");
 	LOGD("skip_initramfs=[%d]\n", cmd->skip_initramfs);
 	LOGD("force_normal_boot=[%d]\n", cmd->force_normal_boot);
+	LOGD("rootwait=[%d]\n", cmd->rootwait);
 	LOGD("slot=[%s]\n", cmd->slot);
 	LOGD("dt_dir=[%s]\n", cmd->dt_dir);
 	LOGD("fstab_suffix=[%s]\n", cmd->fstab_suffix);

--- a/native/jni/init/init.hpp
+++ b/native/jni/init/init.hpp
@@ -5,6 +5,7 @@
 struct cmdline {
 	bool skip_initramfs;
 	bool force_normal_boot;
+	bool rootwait;
 	char slot[3];
 	char dt_dir[64];
 	char fstab_suffix[32];

--- a/native/jni/init/mount.cpp
+++ b/native/jni/init/mount.cpp
@@ -309,22 +309,27 @@ void SARBase::backup_files() {
 void SARBase::mount_system_root() {
 	LOGD("Early mount system_root\n");
 	strcpy(blk_info.block_dev, "/dev/root");
-	// Try legacy SAR dm-verity
-	strcpy(blk_info.partname, "vroot");
-	auto dev = setup_block(false);
-	if (dev >= 0)
-		goto mount_root;
 
-	// Try NVIDIA naming scheme
-	strcpy(blk_info.partname, "APP");
-	dev = setup_block(false);
-	if (dev >= 0)
-		goto mount_root;
+	do {
+		// Try legacy SAR dm-verity
+		strcpy(blk_info.partname, "vroot");
+		auto dev = setup_block(false);
+		if (dev >= 0)
+			goto mount_root;
 
-	sprintf(blk_info.partname, "system%s", cmd->slot);
-	dev = setup_block(false);
-	if (dev >= 0)
-		goto mount_root;
+		// Try NVIDIA naming scheme
+		strcpy(blk_info.partname, "APP");
+		dev = setup_block(false);
+		if (dev >= 0)
+			goto mount_root;
+
+		sprintf(blk_info.partname, "system%s", cmd->slot);
+		dev = setup_block(false);
+		if (dev >= 0)
+			goto mount_root;
+
+		// Poll forever if rootwait was given in cmdline
+	} while (cmd->rootwait);
 
 	// We don't really know what to do at this point...
 	LOGE("Cannot find root partition, abort\n");


### PR DESCRIPTION
On devices where the primary storage is slow to probe it makes sense to
wait forever for the system partition to mount, this emulates the
kernel's behaviour when waiting for rootfs on SAR if the rootwait
parameter is supplied.

This issue was encountered with some SD cards on the Nintendo Switch.