### PR TITLE
Proper implementation of cgroup migration

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/events/RebootEvent.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/events/RebootEvent.kt
@@ -29,10 +29,10 @@ object RebootEvent {
     fun inflateMenu(activity: BaseActivity): PopupMenu {
         val themeWrapper = ContextThemeWrapper(activity, R.style.Foundation_PopupMenu)
         val menu = PopupMenu(themeWrapper, activity.findViewById(R.id.action_reboot))
+        activity.menuInflater.inflate(R.menu.menu_reboot, menu.menu)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
             activity.getSystemService<PowerManager>()?.isRebootingUserspaceSupported == true)
-            menu.menu.getItem(R.id.action_reboot_userspace).isVisible = true
-        activity.menuInflater.inflate(R.menu.menu_reboot, menu.menu)
+            menu.menu.findItem(R.id.action_reboot_userspace).isVisible = true
         menu.setOnMenuItemClickListener(::reboot)
         return menu
     }


### PR DESCRIPTION
https://www.kernel.org/doc/Documentation/admin-guide/cgroup-v1/cgroups.rst
https://www.kernel.org/doc/Documentation/admin-guide/cgroup-v2.rst
> A process can be migrated into a cgroup by writing its PID to the target cgroup's "cgroup.procs" file.  Only one process can be migrated on a single write(2) call.  If a process is composed of multiple threads, writing the PID of any thread migrates all threads of the process.