### PR TITLE
Fix "rm_rf" in build.py on Windows

### DIFF
--- a/build.py
+++ b/build.py
@@ -11,6 +11,7 @@ import lzma
 import platform
 import urllib.request
 import os.path as op
+import stat
 from distutils.dir_util import copy_tree
 
 
@@ -95,10 +96,15 @@ def rm(file):
         if e.errno != errno.ENOENT:
             raise
 
+def rm_on_error(func, path, _):
+    # Remove a read-only file on Windows will get "WindowsError: [Error 5] Access is denied"
+    # Clear the "read-only" and retry
+    os.chmod(path, stat.S_IWRITE)
+    os.unlink(path)
 
 def rm_rf(path):
     vprint(f'rm -rf {path}')
-    shutil.rmtree(path, ignore_errors=True)
+    shutil.rmtree(path, ignore_errors=True, onerror=rm_on_error)
 
 
 def mkdir(path, mode=0o755):

--- a/build.py
+++ b/build.py
@@ -96,11 +96,13 @@ def rm(file):
         if e.errno != errno.ENOENT:
             raise
 
+
 def rm_on_error(func, path, _):
     # Remove a read-only file on Windows will get "WindowsError: [Error 5] Access is denied"
     # Clear the "read-only" and retry
     os.chmod(path, stat.S_IWRITE)
     os.unlink(path)
+
 
 def rm_rf(path):
     vprint(f'rm -rf {path}')


### PR DESCRIPTION
prebuilt/windows-x86_64/bin/libpython2.7.dll
prebuilt/windows-x86_64/lib/python2.7/config/libpython2.7.dll.a

These two files in NDK has read-only attribute on Windows, remove these files with Python will get "WindowsError: [Error 5] Access is denied". It will finally make "build.py ndk" unable to remove the "magisk" folder.

This commit add a onerror callback for "shutil.rmtree" which clear the "read-only" attribute and retry.