### PR TITLE
Fix mount rules dir

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -289,7 +289,7 @@ void post_fs_data(int client) {
         } else {
             // If the folder is not automatically created by Android,
             // do NOT proceed further. Manual creation of the folder
-            // will cause bootloops on FBE devices.
+            // will have no encryption flag, which will cause bootloops on FBE devices.
             LOGE(SECURE_DIR " is not present, abort\n");
             goto early_abort;
         }

--- a/native/jni/init/mount.cpp
+++ b/native/jni/init/mount.cpp
@@ -234,16 +234,20 @@ void MagiskInit::mount_rules_dir(const char *dev_base, const char *mnt_base) {
         goto cache;
 
     strcpy(p, "/data/unencrypted");
-    if (access(path, F_OK) == 0) {
+    if (xaccess(path, F_OK) == 0) {
         // FBE, need to use an unencrypted path
         custom_rules_dir = path + "/magisk"s;
     } else {
         // Skip if /data/adb does not exist
-        strcpy(p, "/data/adb");
-        if (access(path, F_OK) != 0)
+        strcpy(p, SECURE_DIR);
+        if (xaccess(path, F_OK) != 0)
             return;
+        strcpy(p, MODULEROOT);
+        if (xaccess(path, F_OK) != 0) {
+            goto cache;
+        }
         // Unencrypted, directly use module paths
-        custom_rules_dir = string(mnt_base) + MODULEROOT;
+        custom_rules_dir = string(path);
     }
     goto success;
 

--- a/native/jni/init/rootdir.cpp
+++ b/native/jni/init/rootdir.cpp
@@ -100,10 +100,10 @@ bool MagiskInit::patch_sepolicy(const char *file) {
 
     // Custom rules
     if (!custom_rules_dir.empty()) {
-        if (auto dir = open_dir(custom_rules_dir.data())) {
+        if (auto dir = xopen_dir(custom_rules_dir.data())) {
             for (dirent *entry; (entry = xreaddir(dir.get()));) {
                 auto rule = custom_rules_dir + "/" + entry->d_name + "/sepolicy.rule";
-                if (access(rule.data(), R_OK) == 0) {
+                if (xaccess(rule.data(), R_OK) == 0) {
                     LOGD("Loading custom sepolicy patch: [%s]\n", rule.data());
                     sepol->load_rule_file(rule.data());
                 }

--- a/native/jni/utils/xwrap.cpp
+++ b/native/jni/utils/xwrap.cpp
@@ -272,6 +272,14 @@ int xpthread_create(pthread_t *thread, const pthread_attr_t *attr,
     return errno;
 }
 
+int xaccess(const char *path, int mode) {
+    int ret = access(path, mode);
+    if (ret < 0) {
+        PLOGE("access %s", path);
+    }
+    return ret;
+}
+
 int xstat(const char *pathname, struct stat *buf) {
     int ret = stat(pathname, buf);
     if (ret < 0) {

--- a/native/jni/utils/xwrap.hpp
+++ b/native/jni/utils/xwrap.hpp
@@ -33,6 +33,7 @@ ssize_t xsendmsg(int sockfd, const struct msghdr *msg, int flags);
 ssize_t xrecvmsg(int sockfd, struct msghdr *msg, int flags);
 int xpthread_create(pthread_t *thread, const pthread_attr_t *attr,
                     void *(*start_routine) (void *), void *arg);
+int xaccess(const char *path, int mode);
 int xstat(const char *pathname, struct stat *buf);
 int xlstat(const char *pathname, struct stat *buf);
 int xfstat(int fd, struct stat *buf);

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -528,9 +528,8 @@ check_data() {
   if grep ' /data ' /proc/mounts | grep -vq 'tmpfs'; then
     # Test if data is writable
     touch /data/.rw && rm /data/.rw && DATA=true
-    # Test if DE storage is writable
+    # Test if data is decrypted
     $DATA && [ -d /data/adb ] && touch /data/adb/.rw && rm /data/adb/.rw && DATA_DE=true
-    # Some recovery have broken FDE implementations, which cannot access existing folders
     $DATA_DE && [ -d /data/adb/magisk ] || mkdir /data/adb/magisk || DATA_DE=false
   fi
   NVBASE=/data


### PR DESCRIPTION
close #4006

before
```
<12>[    3.216565] c4      1 magiskinit: custom_rules_dir: .magisk/mirror/data/adb/modules
<12>[    3.217100] c5      1 magiskinit: opendir: .magisk/mirror/data/adb/modules failed with 2: No such file or directory
```
after
```
[    2.180856]  [7:             am:    1] magiskinit: Setup userdata: [sda31] (259, 15)
[    2.279430]  [7:             am:    1] EXT4-fs (sda31): Root reserved blocks 32768
[    2.279437]  [7:             am:    1] EXT4-fs (sda31): Reserve inodes (8192/3657728)
[    2.279859]  [7:             am:    1] New pool created id:3
[    2.281028]  [7:             am:    1] EXT4-fs (sda31): recovery complete
[    2.281341]  [7:             am:    1] EXT4-fs (sda31): mounted filesystem with ordered data mode. Opts: inlinecrypt; (null)
[    2.281728]  [7:             am:    1] magiskinit: access /dev/9AYkGP/.magisk/mirror/data/unencrypted failed with 2: No such file or directory
[    2.282089]  [7:             am:    1] magiskinit: access /dev/9AYkGP/.magisk/mirror/data/adb/modules failed with 2: No such file or directory
[    2.282104]  [7:             am:    1] magiskinit: Setup cache: [sda28] (259, 12)
[    2.286709]  [7:             am:    1] New pool created id:4
[    2.286745]  [7:             am:    1] EXT4-fs (sda28): recovery complete
[    2.287055]  [7:             am:    1] EXT4-fs (sda28): mounted filesystem with ordered data mode. Opts: (null)
[    2.317616]  [7:             am:    1] magiskinit: Replace [/system/etc/selinux/plat_sepolicy.cil] -> [xxx]
[    2.332171]  [7:             am:    1] magiskinit: Replace [/sepolicy] -> [/dev/.se]
[    2.334704]  [7:             am:    1] magiskinit: sepol: split policy
[    2.340275]  [7:             am:    1] magiskinit: /system/etc/selinux/plat_sepolicy_and_mapping.sha256=[4ce2e3529952464d6fef54e63c744ed59cf9ae09e489c7359449264383357329]
[    2.340281]  [7:             am:    1] magiskinit: /vendor/etc/selinux/precompiled_sepolicy.plat_sepolicy_and_mapping.sha256=[4ce2e3529952464d6fef54e63c744ed59cf9ae09e489c7359449264383357329]
[    2.341251]  [7:             am:    1] magiskinit: /system_ext/etc/selinux/system_ext_sepolicy_and_mapping.sha256=[39fa08586bbb067e48d3aa190054e543241ae77acf7bbe6c090eb78ddce60852]
[    2.341257]  [7:             am:    1] magiskinit: /vendor/etc/selinux/precompiled_sepolicy.system_ext_sepolicy_and_mapping.sha256=[39fa08586bbb067e48d3aa190054e543241ae77acf7bbe6c090eb78ddce60852]
[    2.341262]  [7:             am:    1] magiskinit: Load policy from: /vendor/etc/selinux/precompiled_sepolicy
[    2.382503]  [7:             am:    1] magiskinit: Loading custom sepolicy patch: [/dev/9AYkGP/.magisk/mirror/cache/magisk/riru-core/sepolicy.rule]
[    2.382812]  [7:             am:    1] magiskinit: Loading custom sepolicy patch: [/dev/9AYkGP/.magisk/mirror/cache/magisk/riru_lsposed/sepolicy.rule]
[    2.382970]  [7:             am:    1] magiskinit: Dumping sepolicy to: [/dev/.se]
[    2.411366]  [7:             am:    1] magiskinit: ACK init daemon to write backup files
[    2.414017]  [7:             am:    1] magiskinit: Inject magisk services: [yQ77IFoEac] [aXUVPC3qIxp] [8ZsqLvZzX]
```

Add xaccess(), so we can know which folders are not available when we debug. I don't know why /data/adb exist but /data/adb/modules doesn't exist. After booted, /data/adb/modules exist.