### PR TITLE
Ensure the installer knows the API version when running from addon.d

### DIFF
--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -110,6 +110,7 @@ main() {
 
   remove_system_su
   find_manager_apk
+  api_level_arch_detect
   install_magisk
 
   # Cleanups


### PR DESCRIPTION
`install_magisk` checks the API version to avoid running the bootsigner on older phones which do not support it. Although the variable it checks (`$API`) is set when it's called from the main Magisk installer, when running from the `addon.d` script the helper `api_level_arch_detect` is never called and so the variable is empty.

Although it still works in most cases, if the boot image was signed (and would have been resigned by the normal install process) the `addon.d` script fails to resign it after installation. Adding a call to `api_level_arch_detect` here fixes this problem (which was causing bootloops after OTA updates for me)