### PR TITLE
Fix install regressions and a few other fixes/improvements

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
@@ -255,7 +255,7 @@ abstract class MagiskInstallImpl protected constructor(
                 val alpha = "abcdefghijklmnopqrstuvwxyz"
                 val alphaNum = "$alpha${alpha.toUpperCase(Locale.ROOT)}0123456789"
                 val random = SecureRandom()
-                val filename = StringBuilder("magisk_patched_").run {
+                val filename = StringBuilder("magisk_patched-${BuildConfig.VERSION_CODE}_").run {
                     for (i in 1..5) {
                         append(alphaNum[random.nextInt(alphaNum.length)])
                     }

--- a/app/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsItems.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsItems.kt
@@ -87,7 +87,7 @@ object Hide : BaseSettingsItem.Input() {
         get() = if (isError) null else result
 
     @get:Bindable
-    var result = "Manager"
+    var result = "Settings"
         set(value) = set(value, field, { field = it }, BR.result, BR.error)
 
     val maxLength

--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -1,5 +1,5 @@
 ##################################
-# Magisk Manager internal scripts
+# Magisk app internal scripts
 ##################################
 
 run_delay() {
@@ -115,8 +115,8 @@ id=hosts
 name=Systemless Hosts
 version=1.0
 versionCode=1
-author=Magisk Manager
-description=Magisk Manager built-in systemless hosts module
+author=Magisk
+description=Magisk app built-in systemless hosts module
 EOF
   magisk --clone /system/etc/hosts hosts/system/etc/hosts
   touch hosts/update

--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -109,7 +109,7 @@ main() {
   ui_print "- Target image: $BOOTIMAGE"
 
   remove_system_su
-  find_manager_apk
+  find_magisk_apk
   install_magisk
 
   # Cleanups

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -86,12 +86,16 @@ ui_print "- Unpacking boot image"
 ./magiskboot unpack "$BOOTIMAGE"
 
 case $? in
+  0 ) ;;
   1 )
     abort "! Unsupported/Unknown image format"
     ;;
   2 )
     ui_print "- ChromeOS boot image detected"
     CHROMEOS=true
+    ;;
+  * )
+    abort "! Unable to unpack boot image"
     ;;
 esac
 
@@ -191,7 +195,7 @@ fi
 #################
 
 ui_print "- Repacking boot image"
-./magiskboot repack "$BOOTIMAGE" || abort "! Unable to repack boot image!"
+./magiskboot repack "$BOOTIMAGE" || abort "! Unable to repack boot image"
 
 # Sign chromeos boot
 $CHROMEOS && sign_chromeos

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -54,7 +54,7 @@ if [ -z $SOURCEDMODE ]; then
   # Load utility functions
   . ./util_functions.sh
   # Check if 64-bit
-  [ -d /system/lib64 ] && IS64BIT=true || IS64BIT=false
+  api_level_arch_detect
 fi
 
 BOOTIMAGE="$1"

--- a/scripts/emulator.sh
+++ b/scripts/emulator.sh
@@ -4,10 +4,10 @@
 #####################################################################
 #
 # This script will setup an environment with minimal Magisk that
-# Magisk Manager will be happy to run properly within the official
+# the Magisk app will be happy to run properly within the official
 # emulator bundled with Android Studio (AVD).
 #
-# ONLY use this script for developing Magisk Manager or root apps
+# ONLY use this script for developing the Magisk app or root apps
 # in the emulator. The constructed Magisk environment is not a
 # fully functional one as if it is running on an actual device.
 #

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -538,7 +538,7 @@ check_data() {
   resolve_vars
 }
 
-find_manager_apk() {
+find_magisk_apk() {
   local DBAPK
   [ -z $APK ] && APK=/data/adb/magisk.apk
   [ -f $APK ] || APK=/data/magisk/magisk.apk
@@ -549,7 +549,7 @@ find_manager_apk() {
     [ -z $DBAPK ] || APK=/data/user_de/*/$DBAPK/dyn/*.apk
     [ -f $APK ] || [ -z $DBAPK ] || APK=/data/app/$DBAPK*/*.apk
   fi
-  [ -f $APK ] || ui_print "! Unable to detect Magisk Manager APK for BootSigner"
+  [ -f $APK ] || ui_print "! Unable to detect Magisk app APK for BootSigner"
 }
 
 run_migrations() {
@@ -742,7 +742,7 @@ install_module() {
   done
 
   if $BOOTMODE; then
-    # Update info for Magisk Manager
+    # Update info for Magisk app
     mktouch $NVBASE/modules/$MODID/update
     cp -af $MODPATH/module.prop $NVBASE/modules/$MODID/module.prop
   fi

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -37,9 +37,9 @@ getvar() {
   local VARNAME=$1
   local VALUE
   local PROPPATH='/data/.magisk /cache/.magisk'
-  [ -n $MAGISKTMP ] && PROPPATH="$MAGISKTMP/config $PROPPATH"
+  [ ! -z $MAGISKTMP ] && PROPPATH="$MAGISKTMP/config $PROPPATH"
   VALUE=$(grep_prop $VARNAME $PROPPATH)
-  [ -n $VALUE ] && eval $VARNAME=\$VALUE
+  [ ! -z $VALUE ] && eval $VARNAME=\$VALUE
 }
 
 is_mounted() {
@@ -50,7 +50,7 @@ is_mounted() {
 abort() {
   ui_print "$1"
   $BOOTMODE || recovery_cleanup
-  [ -n $MODPATH ] && rm -rf $MODPATH
+  [ ! -z $MODPATH ] && rm -rf $MODPATH
   rm -rf $TMPDIR
   exit 1
 }
@@ -394,7 +394,7 @@ find_boot_image() {
   BOOTIMAGE=
   if $RECOVERYMODE; then
     BOOTIMAGE=`find_block recovery_ramdisk$SLOT recovery$SLOT sos`
-  elif [ -n $SLOT ]; then
+  elif [ ! -z $SLOT ]; then
     BOOTIMAGE=`find_block ramdisk$SLOT recovery_ramdisk$SLOT boot$SLOT`
   else
     BOOTIMAGE=`find_block ramdisk recovery_ramdisk kern-a android_boot kernel bootimg boot lnx boot_a`

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -753,10 +753,11 @@ install_module() {
     copy_sepolicy_rules
   fi
 
-  # Remove stuffs that don't belong to modules
+  # Remove stuff that doesn't belong to modules and clean up any empty directories
   rm -rf \
   $MODPATH/system/placeholder $MODPATH/customize.sh \
   $MODPATH/README.md $MODPATH/.git*
+  rmdir -p $MODPATH
 
   cd /
   $BOOTMODE || recovery_cleanup


### PR DESCRIPTION
scripts: clean up remaining Manager references

scripts: fix find_boot_image using wrong partition list on non-slot
- revert logic changes introduced by ec8fffe which break find_boot_image on NAND devices and any others using non-standard naming supported by the A-only device boot partition name list
- despite being accepted equivalents in modern shells -n does not work on Android in some shell/env scenarios where ! -z always does

scripts: add boot_patch unpack error catching
- failure to unpack wasn't being caught so boot_patch would continue to build a new cpio out of nothing and attempt to repack it (identified in #4049)

scripts: improve boot_patch 64bit detection
- use existing api_level_arch_detect function
Fixes #3961

App: add versionCode to magisk_patched.img filenames

scripts: fix empty module cleanup
- should be sufficient for all basic modules, see https://github.com/topjohnwu/Magisk/issues/3119#issuecomment-704000783 for ideas for fixing it further on the daemon module-processing side
Fixes #3119