### PR TITLE
Fix copying sepolicy.rule 

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -594,7 +594,7 @@ copy_sepolicy_rules() {
   # Find current active RULESDIR
   local RULESDIR
   local active_dir=$(magisk --path)/.magisk/mirror/sepolicy.rules
-  if [ -L $active_dir ]; then
+  if [ -e $active_dir ]; then
     RULESDIR=$(readlink -f $active_dir)
   elif [ -d /data/unencrypted ] && ! grep ' /data ' /proc/mounts | grep -qE 'dm-|f2fs'; then
     RULESDIR=/data/unencrypted/magisk


### PR DESCRIPTION
 * Somehow commit 8b5cb4c causes sepolicy.rule being linked
   to /metadata/magisk which does not even exists.(?!) Reverting the
   change fixes the behavior, though a reflash of affected modules
   is needed.

Close #4098 