### PR TITLE
Don't use readlink when getting sepolicy rules dir

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -595,7 +595,7 @@ copy_sepolicy_rules() {
   local RULESDIR
   local active_dir=$(magisk --path)/.magisk/mirror/sepolicy.rules
   if [ -L $active_dir ]; then
-    RULESDIR=$(readlink -f $active_dir)
+    RULESDIR=$(ls -l $active_dir | awk -F'->' '{print $2}' | tr -d ' ')
   elif [ -d /data/unencrypted ] && ! grep ' /data ' /proc/mounts | grep -qE 'dm-|f2fs'; then
     RULESDIR=/data/unencrypted/magisk
   elif grep -q ' /cache ' /proc/mounts; then


### PR DESCRIPTION
 * `readlink -f` implementation of busybox is broken because
   its `-f` is actually `-e` which requires all components to exist,
   which is not the case here and results in wrong output. We
   can pass `-m` here instead, but busybox does not implement 
   this argument. To work around this issue, use `ls -l` which
   can generate correct path. This closes #4098.