### PR TITLE
resetprop: load_prop_file: delete props before setting them

### DIFF
--- a/native/jni/resetprop/resetprop.cpp
+++ b/native/jni/resetprop/resetprop.cpp
@@ -277,6 +277,7 @@ void load_prop_file(const char *filename, bool prop_svc) {
     auto impl = get_impl();
     LOGD("resetprop: Parse prop file [%s]\n", filename);
     parse_prop_file(filename, [=](auto key, auto val) -> bool {
+        impl->delprop(key.data(), false);
         impl->setprop(key.data(), val.data(), prop_svc);
         return true;
     });


### PR DESCRIPTION
* In some cases not deleting a prop before setting it can lead
  to the prop being duplicated rendering the device unbootable
* An example for such a case is the 'Magisk Hide Props Config'
  module, if ro.build.fingerprint is not set in the device's
  /system/build.prop but instead being autogenerated at runtime
  setting a build fingerprint with this module will break booting.