### PR TITLE
Fix random return value of faccessat() in x86

### DIFF
--- a/native/jni/utils/files.cpp
+++ b/native/jni/utils/files.cpp
@@ -108,7 +108,7 @@ void mv_dir(int src, int dest) {
     for (dirent *entry; (entry = xreaddir(dir.get()));) {
         switch (entry->d_type) {
         case DT_DIR:
-            if (faccessat(dest, entry->d_name, F_OK, 0) == 0) {
+            if (xfaccessat(dest, entry->d_name) == 0) {
                 // Destination folder exists, needs recursive move
                 int newsrc = xopenat(src, entry->d_name, O_RDONLY | O_CLOEXEC);
                 int newdest = xopenat(dest, entry->d_name, O_RDONLY | O_CLOEXEC);

--- a/native/jni/utils/xwrap.cpp
+++ b/native/jni/utils/xwrap.cpp
@@ -359,6 +359,20 @@ ssize_t xreadlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz) {
 #endif
 }
 
+int xfaccessat(int dirfd, const char *pathname) {
+    int ret = faccessat(dirfd, pathname, F_OK, 0);
+    if (ret < 0) {
+        PLOGE("faccessat %s", pathname);
+    }
+#if defined(__i386__) || defined(__x86_64__)
+    if (ret > 0 && errno == 0) {
+        PLOGE("faccessat success but ret is %d", ret);
+        ret = 0;
+    }
+#endif
+    return ret;
+}
+
 int xsymlink(const char *target, const char *linkpath) {
     int ret = symlink(target, linkpath);
     if (ret < 0) {

--- a/native/jni/utils/xwrap.cpp
+++ b/native/jni/utils/xwrap.cpp
@@ -366,7 +366,7 @@ int xfaccessat(int dirfd, const char *pathname) {
     }
 #if defined(__i386__) || defined(__x86_64__)
     if (ret > 0 && errno == 0) {
-        PLOGE("faccessat success but ret is %d", ret);
+        LOGD("faccessat success but ret is %d\n", ret);
         ret = 0;
     }
 #endif

--- a/native/jni/utils/xwrap.hpp
+++ b/native/jni/utils/xwrap.hpp
@@ -42,6 +42,7 @@ int xdup2(int oldfd, int newfd);
 int xdup3(int oldfd, int newfd, int flags);
 ssize_t xreadlink(const char *pathname, char *buf, size_t bufsiz);
 ssize_t xreadlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz);
+int xfaccessat(int dirfd, const char *pathname);
 int xsymlink(const char *target, const char *linkpath);
 int xsymlinkat(const char *target, int newdirfd, const char *linkpath);
 int xlinkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, int flags);


### PR DESCRIPTION
faccessat() should return 0 when success, but it returns random number with errno == 0 in x86 platform.

It’s a side effect of commit bf80b08b5febd3f311108ff1c6e6a6bf2d1113b7 when Magisk binaries ‘correctly’ linked with library of API16 .. lol