### PR TITLE
Prevent overriding API variable if already set

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -508,7 +508,7 @@ remove_system_su() {
 }
 
 api_level_arch_detect() {
-  API=`grep_prop ro.build.version.sdk`
+  [ -z $API ] && API=`grep_prop ro.build.version.sdk`
   ABI=`grep_prop ro.product.cpu.abi | cut -c-3`
   ABI2=`grep_prop ro.product.cpu.abi2 | cut -c-3`
   ABILONG=`grep_prop ro.product.cpu.abi`


### PR DESCRIPTION
 * We have already exported $API when initializing shell, doing
   this again will clear it if device's build.prop does not contain
   ro.build.version.sdk, as seen on oppo devices.