### PR TITLE
Don't kill USAP processes for now

### DIFF
--- a/native/jni/magiskhide/hide_utils.cpp
+++ b/native/jni/magiskhide/hide_utils.cpp
@@ -241,8 +241,6 @@ static bool init_list() {
 
     // If Android Q+, also kill blastula pool and all app zygotes
     if (SDK_INT >= 29) {
-        kill_process("usap32", true);
-        kill_process("usap64", true);
         kill_process("_zygote", true, proc_name_match<&str_ends_safe>);
     }
 


### PR DESCRIPTION
 * It is observed that every application fails to launch after
   enabling MagiskHide with the toggle in the app. After
   debugging, it seems that `usap` processes are killed in
   `init_list()` when starting MagiskHide, and zygote fails
   to re-create these processes. This results in zygote
   consuming 100% CPU (possibly runs in a dead loop).
   As a band-aid, for now, don't kill USAP processes.

 * Tested on Oneplus8T Open Beta 3.