### PR TITLE
Kill processes with SIGKILL rather than SIGTERM

### DIFF
--- a/native/jni/magiskhide/hide_utils.cpp
+++ b/native/jni/magiskhide/hide_utils.cpp
@@ -92,7 +92,7 @@ static void kill_process(const char *name, bool multi = false,
         bool (*filter)(int, const char *) = proc_name_match<&str_eql>) {
     crawl_procfs([=](int pid) -> bool {
         if (filter(pid, name)) {
-            kill(pid, SIGTERM);
+            kill(pid, SIGKILL);
             return multi;
         }
         return true;


### PR DESCRIPTION
Another (better) workaround for https://github.com/topjohnwu/Magisk/pull/4283.