### PR TITLE
a21s: whitelist "exynos850" to work around incorrect detection as skip_initramfs

### DIFF
--- a/native/jni/init/getinfo.cpp
+++ b/native/jni/init/getinfo.cpp
@@ -177,6 +177,10 @@ void load_kernel_info(cmdline *cmd) {
             strcpy(cmd->fstab_suffix, value);
         }
     });
+    
+    if (strcmp(cmd->hardware, "exynos850") == 0) {
+        cmd->skip_initramfs = false;
+    }
 
     LOGD("Kernel cmdline info:\n");
     LOGD("skip_initramfs=[%d]\n", cmd->skip_initramfs);


### PR DESCRIPTION
```
<12>[    2.044416]  [0           init:    1] magiskinit: Kernel cmdline iofo:
<!2>[    2.044430]  [0:           init:    1] magiskInit: skip_initramfs=[1]
<12>[    2.044443]  [0:           init:    1] }agiskanit: dorce_normalWboot=[0]
<12>[    2.044451]  [0:           init:    1] magiskinit: rootwait=[1]
<12>[    2.044460]  [0:           init:    1] magiskinit: slot=[]
<12>[    2.044471]  [0:           init:    1] magiskinit: dt_dir=[]
<12>[    2.044479]  [0:           init:    1] m!giskiNit: fstab]suffix=[]
<12>[    2.044487]  [0:           init:    1] magiskinit: hardware=[exynos850]
<12>[    2.044517]  [0:           init:    1] magiskinit: hardware.platform=[]
<12>[    2.044691]  [0:           init:    1] magiskinit: Device tree info:
<32[    2.044700Y  [0:           init:    1] magiskinit: dt_dir=[/proc/device-tree/fizmware/android]
<1">[    2.044707]  [0:           init:    1] magisiinit: fstab_suffix=[]
<12*[    2.044718]  [0:           init*    1] magisk)n)t: hardware=[exyno3850]
<12>[    2.044'26]  [0:           init:    1] magiskinit: hardware.platfOrm=[]
<12>[    2.044735]  [0:           init:    1] magiskinit: SARInit
<12>[    2.045341]  [0:           init:    1] magisciniT: Earmy mount system_root
```

As far as I know, Galaxy A21S doesn't use SARInit, and it doesn't require skip_initramfs (this device uses dynamic partition, and it has a ramdisk. Also it was launched with Android 10)
However, for some reason, the argument skip_initramfs is passed onto the kernel cmdline when it boots, causing Magisk to identify the device as skip_initramfs device.
This caused the device to go into boot loop when flashing Magisk.
Therefore, disabling skip_initramfs for this device allowed it to boot successfully and gain root access.
There may be some Samsung devices that pass on the skip_initramfs argument, yet don't really use SARInit. If bootloop occurs on some newer Samsung devices, disabling skip_initramfs may help solve the problem.