### PR TITLE
Bypass unzip command for old TWRP

### DIFF
--- a/scripts/update_binary.sh
+++ b/scripts/update_binary.sh
@@ -5,15 +5,17 @@ rm -rf $TMPDIR
 mkdir -p $TMPDIR 2>/dev/null
 
 export BBBIN=$TMPDIR/busybox
-unzip -o "$3" "lib/*/libbusybox.so" -d $TMPDIR >&2
-chmod -R 755 $TMPDIR/lib
+
 for arch in "x86_64" "x86" "arm64-v8a" "armeabi-v7a"; do
+  unzip -o "$3" "lib/$arch/libbusybox.so" -d $TMPDIR >&2
+  chmod -R 755 $TMPDIR/libs06
   libpath="$TMPDIR/lib/$arch/libbusybox.so"
   if [ -x $libpath ] && $libpath >/dev/null 2>&1; then
     mv -f $libpath $BBBIN
     break
   fi
 done
+
 $BBBIN rm -rf $TMPDIR/lib
 
 export INSTALLER=$TMPDIR/install

--- a/scripts/update_binary.sh
+++ b/scripts/update_binary.sh
@@ -8,7 +8,7 @@ export BBBIN=$TMPDIR/busybox
 
 for arch in "x86_64" "x86" "arm64-v8a" "armeabi-v7a"; do
   unzip -o "$3" "lib/$arch/libbusybox.so" -d $TMPDIR >&2
-  chmod -R 755 $TMPDIR/libs
+  chmod -R 755 $TMPDIR/lib
   libpath="$TMPDIR/lib/$arch/libbusybox.so"
   if [ -x $libpath ] && $libpath >/dev/null 2>&1; then
     mv -f $libpath $BBBIN

--- a/scripts/update_binary.sh
+++ b/scripts/update_binary.sh
@@ -8,7 +8,7 @@ export BBBIN=$TMPDIR/busybox
 
 for arch in "x86_64" "x86" "arm64-v8a" "armeabi-v7a"; do
   unzip -o "$3" "lib/$arch/libbusybox.so" -d $TMPDIR >&2
-  chmod -R 755 $TMPDIR/libs06
+  chmod -R 755 $TMPDIR/libs
   libpath="$TMPDIR/lib/$arch/libbusybox.so"
   if [ -x $libpath ] && $libpath >/dev/null 2>&1; then
     mv -f $libpath $BBBIN


### PR DESCRIPTION
This may bypass on some old TWRP version that the unzip command unsupport with wildcard character