### PR TITLE
Stop target process properly

### DIFF
--- a/native/jni/magiskhide/proc_monitor.cpp
+++ b/native/jni/magiskhide/proc_monitor.cpp
@@ -228,8 +228,11 @@ static bool check_pid(int pid) {
 
     // Detach but the process should still remain stopped
     // The hide daemon will resume the process after hiding it
+    // Note that we are now in "PTRACE_EVENT stop", not "signal-delivery-stop",
+    // signal injection (PTRACE_restart with signal) may simply be ignored, so use kill() instead
     LOGI("proc_monitor: [%s] PID=[%d] UID=[%d]\n", cmdline, pid, uid);
-    detach_pid(pid, SIGSTOP);
+    kill(pid, SIGSTOP);
+    detach_pid(pid);
     hide_daemon(pid);
     return true;
 


### PR DESCRIPTION
In `check_pid()`, we are in "PTRACE_EVENT stop", and signal injection (PTRACE_restart with signal) requires us in "signal-delivery-stop", otherwise the signal we want to inject may simply be ignored. See https://man7.org/linux/man-pages/man2/ptrace.2.html
> Restarting ptrace commands issued in ptrace-stops other than signal-delivery-stop are not guaranteed to inject a signal, even if sig is nonzero.  No error is reported; a nonzero sig may simply be ignored.  Ptrace users should not try to "create a new signal" this way: use tgkill(2) instead.

This will cause a race condition between magiskhide and target process, so hiding root may fail randomly.
This PR fixes it by using `kill()` instead of signal injection to send SIGSTOP .