### PR TITLE
Add support for legacy ARM32 zImage

### DIFF
--- a/native/jni/magiskboot/bootimg.hpp
+++ b/native/jni/magiskboot/bootimg.hpp
@@ -41,6 +41,20 @@ struct blob_hdr {
     uint32_t version;       /* 0x00000001 */
 } __attribute__((packed));
 
+struct zimage_hdr {
+    uint8_t head[36];
+    uint32_t magic;         /* zImage magic */
+    uint32_t load_addr;     /* absolute load/run zImage address */
+    uint32_t end_addr;      /* zImage end address */
+    uint32_t endianess;     /* endianess flag */
+    uint8_t code[];
+} __attribute__((packed));
+
+struct zimage_tail {
+    uint8_t *data;
+    uint32_t size;
+} __attribute__((packed));
+
 /**************
  * AVB Headers
  **************/
@@ -446,6 +460,7 @@ enum {
     NOOKHD_FLAG,
     ACCLAIM_FLAG,
     AVB_FLAG,
+    ZIMAGE_KERNEL,
     BOOT_FLAGS_MAX
 };
 
@@ -472,6 +487,10 @@ struct boot_img {
     // MTK headers
     mtk_hdr *k_hdr;
     mtk_hdr *r_hdr;
+
+    // ZIMAGE data
+    zimage_hdr *z_hdr;
+    zimage_tail z_tail;
 
     // Pointer to dtb that is embedded in kernel
     uint8_t *kernel_dtb;

--- a/native/jni/magiskboot/format.cpp
+++ b/native/jni/magiskboot/format.cpp
@@ -36,6 +36,8 @@ format_t check_fmt(const void *buf, size_t len) {
         return DHTB;
     } else if (CHECKED_MATCH(TEGRABLOB_MAGIC)) {
         return BLOB;
+    } else if (len >= 0x28 && memcmp(&((char *)buf)[0x24], ZIMAGE_MAGIC, 4) == 0) {
+        return ZIMAGE;
     } else {
         return UNKNOWN;
     }
@@ -61,6 +63,8 @@ const char *Fmt2Name::operator[](format_t fmt) {
             return "lz4_lg";
         case DTB:
             return "dtb";
+        case ZIMAGE:
+            return "zimage";
         default:
             return "raw";
     }

--- a/native/jni/magiskboot/format.hpp
+++ b/native/jni/magiskboot/format.hpp
@@ -23,6 +23,7 @@ typedef enum {
 /* Misc */
     MTK,
     DTB,
+    ZIMAGE,
 } format_t;
 
 #define COMPRESSED(fmt)      ((fmt) >= GZIP && (fmt) < LZOP)
@@ -57,6 +58,7 @@ typedef enum {
 #define ACCLAIM_PRE_HEADER_SZ 262144
 #define AVB_FOOTER_MAGIC "AVBf"
 #define AVB_MAGIC "AVB0"
+#define ZIMAGE_MAGIC "\x18\x28\x6f\x01"
 
 class Fmt2Name {
 public:


### PR DESCRIPTION
This will only work if the recompressed kernel is <= the original gzip.
If that fails it will fall back to using the original kernel (Essentially what Magisk is doing currently).

While this will work in many cases, unfortunately zlib compression will sometimes result in gzips that are slightly larger than the original.

To remedy this, I'll add a separate PR (#4527) which adds googles zopfli gzip encoder that will typically produce better compression than zlib.

fixes #1714 #1674 #2827 #3529