### PR TITLE
Do not use glob in the system's unzip parameter

### DIFF
--- a/scripts/update_binary.sh
+++ b/scripts/update_binary.sh
@@ -5,10 +5,10 @@ rm -rf $TMPDIR
 mkdir -p $TMPDIR 2>/dev/null
 
 export BBBIN=$TMPDIR/busybox
-unzip -o "$3" "lib/*/libbusybox.so" -d $TMPDIR >&2
-chmod -R 755 $TMPDIR/lib
 for arch in "x86_64" "x86" "arm64-v8a" "armeabi-v7a"; do
+  unzip -o "$3" "lib/$arch/libbusybox.so" -d $TMPDIR >&2
   libpath="$TMPDIR/lib/$arch/libbusybox.so"
+  chmod 755 $libpath
   if [ -x $libpath ] && $libpath >/dev/null 2>&1; then
     mv -f $libpath $BBBIN
     break


### PR DESCRIPTION
https://android.googlesource.com/platform/system/core/+/refs/tags/android-10.0.0_r47/libziparchive/unzip.cpp#57 unzip did not support glob before Android 11