### PR TITLE
l10n: Fix typo of chinese Simplified translations

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -24,7 +24,7 @@
     <string name="home_notice_content">仅从官方 GitHub 页面下载 Magisk。未知来源的文件可能具有恶意行为！</string>
     <string name="home_support_title">支持开发</string>
     <string name="home_item_source">源代码</string>
-    <string name="home_support_content">Magisk 将一直保持免费且开源，向开发者捐赠以表示支持。</string>
+    <string name="home_support_content">Magisk 将一直保持自由且开源，向开发者捐赠以表示支持。</string>
     <string name="home_installed_version">当前</string>
     <string name="home_latest_version">最新</string>
     <string name="invalid_update_channel">无效的更新通道</string>


### PR DESCRIPTION
Free means libre instead of meaning costing nothing。

[上一次讨论](https://github.com/topjohnwu/Magisk/pull/4611#issuecomment-908221801)
之前忘记指明来由了，麻烦开发者们再次确认

> 开源软件和自由软件这两个词在很大程度上描述的是同一类软件，但是它们所基于的价值观却有着本质上的区别。对于自由软件运动而言，自由软件是一个道德底线，是对用户自由的基本尊重。开源软件则与此不同，开源哲学考虑的是怎么做把软件做得“更好”—仅仅从实用的角度。
https://www.gnu.org/philosophy/open-source-misses-the-point.zh-cn.html

因此我觉得在此处使用自由更为妥当（因为同时包含了“免费”与用户自由的意思，也更能体现 Magisk 作为一个社区项目的一方面意义）