### PR TITLE
Fix ccache

### DIFF
--- a/.github/ccache.sh
+++ b/.github/ccache.sh
@@ -15,3 +15,5 @@ case $OS in
     unzip -j ccache-*-windows-64.zip '*/ccache.exe'
     ;;
 esac
+mkdir ./.ccache
+./ccache -o compiler_check='%compiler% -dumpmachine; %compiler% -dumpversion'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     env:
       NDK_CCACHE: ${{ github.workspace }}/ccache
-      CCACHE_DIR: ~/.ccache
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
 
     steps:
       - name: Check out
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.ccache
+            ${{ github.workspace }}/.ccache
             ~/.gradle/caches/build-cache-*
           key: ${{ runner.os }}-build-cache-${{ github.sha }}
           restore-keys: ${{ runner.os }}-build-cache-


### PR DESCRIPTION
1. `ccache dir` seems to need manually `mkdir`
2. `compiler_check` needs to be changed from `mtime` since ndk is generated every time.