### PR TITLE
Remove magiskhide documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,9 +1,5 @@
 # Frequently Asked Questions
 
-### Q: Why is X app detecting root?
-
-Manually enable MagiskHide in settings (MagiskHide is no longer enabled by default). Also, there are known methods to detect Magisk, so your mileage may vary.
-
 ### Q: I installed a module and it bootlooped my device. Help!
 
 If you have USB debugging enabled in developer options, connect your phone to the PC. If your device is detected (check by `adb devices`), enter ADB shell and run the command `magisk --remove-modules`. This will remove all your modules and automatically reboot the device.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,7 +7,6 @@ magiskinit                 /* binary */
 magiskpolicy -> magiskinit
 supolicy -> magiskinit
 magisk                     /* binary */
-magiskhide -> magisk
 resetprop -> magisk
 su -> magisk
 ```
@@ -218,7 +217,7 @@ Advanced Options (Internal APIs):
    --path                    print Magisk tmpfs mount path
 
 Available applets:
-    su, resetprop, magiskhide
+    su, resetprop
 ```
 
 ### su
@@ -262,21 +261,4 @@ Flags:
            (this flag only affects setprop)
    -p      read/write props from/to persistent storage
            (this flag only affects getprop and delprop)
-```
-
-### magiskhide
-An applet of `magisk`, the CLI to control MagiskHide. Use this tool to communicate with the daemon to change MagiskHide settings.
-
-```
-Usage: magiskhide [action [arguments...] ]
-
-Actions:
-   status          Return the status of magiskhide
-   enable          Start magiskhide
-   disable         Stop magiskhide
-   add PKG [PROC]  Add a new target to the hide list
-   rm PKG [PROC]   Remove target(s) from the hide list
-   ls              Print the current hide list
-   exec CMDs...    Execute commands in isolated mount
-                   namespace and do all hide unmounts
 ```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,6 +7,7 @@ magiskinit                 /* binary */
 magiskpolicy -> magiskinit
 supolicy -> magiskinit
 magisk                     /* binary */
+magiskdenylist -> magisk
 resetprop -> magisk
 su -> magisk
 ```
@@ -217,7 +218,7 @@ Advanced Options (Internal APIs):
    --path                    print Magisk tmpfs mount path
 
 Available applets:
-    su, resetprop
+    su, resetprop, denylist
 ```
 
 ### su

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,7 +7,7 @@ magiskinit                 /* binary */
 magiskpolicy -> magiskinit
 supolicy -> magiskinit
 magisk                     /* binary */
-magiskdenylist -> magisk
+denylist -> magisk
 resetprop -> magisk
 su -> magisk
 ```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -262,3 +262,20 @@ Flags:
    -p      read/write props from/to persistent storage
            (this flag only affects getprop and delprop)
 ```
+
+### denylist
+An applet of `magisk`, the CLI to control DenyList. Use this tool to communicate with the daemon to change DenyList settings.
+
+```
+Usage: magisk --denylist [action [arguments...] ]
+
+Actions:
+   status          Return the enforcement status
+   enable          Enable denylist enforcement
+   disable         Disable denylist enforcement
+   add PKG [PROC]  Add a new target to the denylist
+   rm PKG [PROC]   Remove target(s) from the denylist
+   ls              Print the current denylist
+   exec CMDs...    Execute commands in isolated mount
+                   namespace and do all unmounts
+```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,7 +7,6 @@ magiskinit                 /* binary */
 magiskpolicy -> magiskinit
 supolicy -> magiskinit
 magisk                     /* binary */
-denylist -> magisk
 resetprop -> magisk
 su -> magisk
 ```


### PR DESCRIPTION
This is a pull to delete the MagiskHide FAQ and the usage of MagiskHide. I don't see them necessary, as MagiskHide will be replaced with DenyList, and it's code has already been deleted.

Edit: Also added DenyList to it 🙃
~~Edit 2: I forgot to add it to the applet part and at the top in which executable it is embedded 😓~~