### PR TITLE
Fix downgrade database will crash magiskd

### DIFF
--- a/native/jni/core/db.cpp
+++ b/native/jni/core/db.cpp
@@ -149,7 +149,7 @@ static char *open_and_init_db(sqlite3 *&db) {
     if (ver > DB_VERSION) {
         // Don't support downgrading database
         sqlite3_close(db);
-        return nullptr;
+        return strdup("Downgrading database is not supported");
     }
     if (ver < 3) {
         // Policies


### PR DESCRIPTION
Don't return `nullptr` in `open_and_init_db` if the database downgrades since is `nullptr` treated as successful.