### PR TITLE
Prevent original libselinux.so to be unmounted

### DIFF
--- a/native/jni/core/daemon.cpp
+++ b/native/jni/core/daemon.cpp
@@ -336,6 +336,7 @@ static void daemon_entry() {
         });
     }
     unlink("/dev/.se");
+    unlink(mount_list.data());
 
     // Load config status
     auto config = MAGISKTMP + "/" INTLROOT "/config";


### PR DESCRIPTION
libselinux.so will be unmounted when magiskd starts. If magiskd restarts (like it died before boot completed), the files we want to unmount is the original files because the modified files is unmounted in previous start, which will causes many crashes due to missing libselinux.so.