### PR TITLE
Fix terminal on android 8

### DIFF
--- a/native/jni/magiskpolicy/rules.cpp
+++ b/native/jni/magiskpolicy/rules.cpp
@@ -54,6 +54,14 @@ void sepolicy::magisk_rules() {
         allow(SEPOL_CLIENT_DOMAIN, SEPOL_EXEC_TYPE, "file", ALL);
         allow(SEPOL_CLIENT_DOMAIN, SEPOL_CLIENT_DOMAIN, ALL, ALL);
 
+        const char *pts[]{"devpts", "untrusted_app_devpts", "untrusted_app_25_devpts"};
+        for (auto type : pts) {
+            allow(SEPOL_CLIENT_DOMAIN, type, "chr_file", "getattr");
+            allow(SEPOL_CLIENT_DOMAIN, type, "chr_file", "read");
+            allow(SEPOL_CLIENT_DOMAIN, type, "chr_file", "write");
+            allow(SEPOL_CLIENT_DOMAIN, type, "chr_file", "ioctl");
+        }
+
         // Allow these processes to access MagiskSU
         vector<const char *> clients{ "init", "shell", "update_engine", "appdomain" };
         for (auto type : clients) {


### PR DESCRIPTION
No need to handle untrusted_app_all_devpts on modern devices, but devpts policy is different for older devices.