### PR TITLE
Disable an optimization of busybox that causes UB

### DIFF
--- a/native/jni/Application.mk
+++ b/native/jni/Application.mk
@@ -10,6 +10,7 @@ APP_STRIP_MODE   := --strip-all
 # Busybox should use stock libc.a
 ifdef B_BB
 APP_PLATFORM     := android-22
+APP_CFLAGS       += -DBB_GLOBAL_CONST=""
 ifeq ($(OS),Windows_NT)
 APP_SHORT_COMMANDS := true
 endif


### PR DESCRIPTION
This optimization will cause busybox crash:
For example, the compile result of Init_G from ash.c is:
```
    0x491624 <+32>:   bl     0x4472d4                  ; xzalloc at xfuncs_printf.c:70
    0x491628 <+36>:   bl     0x49e070                  ; OUTLINED_FUNCTION_1
    0x49162c <+40>:   mov    w9, #-0x1
    0x491630 <+44>:   ldr    x21, [x8]
    0x491634 <+48>:   str    x0, [x8]
    0x491638 <+52>:   add    x8, x21, #0x54            ; =0x54
->  0x49163c <+56>:   stp    x8, x8, [x21, #0x20] ;<--- crash point
```

Here, x8 is the register that stores the addr of `ash_ptr_to_globals_misc`. It's loaded first to x21 and then store from x0. And thus the reset instruction crashed since x21 is 0 (addr of `ash_ptr_to_globals_misc` before assigned by `xzalloc`).

Co-authored-by: canyie <31466456+canyie@users.noreply.github.com>