### PR TITLE
Erase previous prop info when setting/deleting prop

### DIFF
--- a/native/jni/external/systemproperties/include/system_properties/prop_area.h
+++ b/native/jni/external/systemproperties/include/system_properties/prop_area.h
@@ -110,7 +110,7 @@ class prop_area {
 
   const prop_info* find(const char* name);
   bool add(const char* name, unsigned int namelen, const char* value, unsigned int valuelen);
-  bool rm(const char *name);
+  prop_info* rm(const char *name);
 
   bool foreach (void (*propfn)(const prop_info* pi, void* cookie), void* cookie);
 


### PR DESCRIPTION
If a prop named "test" and has value "abcd", we setting its value to "a", then its value is actually "a\0cd\0", this is a special case so apps can infer the original value.
Also, deleting a prop (like resetting readonly prop) just removes the pointer to the prop info from the trie tree, apps can find the previous prop by searching the area.
In example, [Riru](https://github.com/RikkaApps/Riru) changes "ro.dalvik.vm.native.bridge" to inject into zygote processes and recover it after system server starts. Because the previous value still exists in the prop area, apps can detect Riru by simply search whether `libriruloader.so` is in the area.

**Only simple tested and passed, further testing is recommended** 