### PR TITLE
Fix race condition of thread pool by lock free impl

### DIFF
--- a/native/jni/core/thread.cpp
+++ b/native/jni/core/thread.cpp
@@ -3,82 +3,91 @@
 #include <utils.hpp>
 
 #include <daemon.hpp>
+#include <memory>
 
 using namespace std;
 
 #define THREAD_IDLE_MAX_SEC 60
-#define MAX_THREAD_BLOCK_MS 5
 #define CORE_POOL_SIZE 3
 
-static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t send_task = PTHREAD_COND_INITIALIZER;
-static pthread_cond_t recv_task = PTHREAD_COND_INITIALIZER;
+using Task = std::function<void()>;
 
-// The following variables should be guarded by lock
-static int available_threads = 0;
-static int active_threads = 0;
-static function<void()> pending_task;
+// idle thread should be waited only by exec and notified only by loop
+static atomic_int idle_threads = 0;
+// running thread should be waited only by loop and notified only by exec
+static atomic_int running_threads = 0;
+static shared_ptr<Task> pending_task = nullptr;
 
-static void operator+=(timeval &a, const timeval &b) {
-    a.tv_sec += b.tv_sec;
-    a.tv_usec += b.tv_usec;
-    if (a.tv_usec >= 1000000) {
-        a.tv_sec++;
-        a.tv_usec -= 1000000;
-    }
-}
-
-static timespec to_ts(const timeval &tv) { return { tv.tv_sec, tv.tv_usec * 1000 };  }
-
-static void *thread_pool_loop(void * const is_core_pool) {
+static void *thread_pool_loop(void *const) {
+    idle_threads.fetch_add(1, memory_order_relaxed);
     // Block all signals
     sigset_t mask;
     sigfillset(&mask);
 
+    bool timeout = false;
     for (;;) {
         // Restore sigmask
         pthread_sigmask(SIG_SETMASK, &mask, nullptr);
-        function<void()> local_task;
-        {
-            mutex_guard g(lock);
-            ++available_threads;
-            if (!pending_task) {
-                if (is_core_pool) {
-                    pthread_cond_wait(&send_task, &lock);
-                } else {
-                    timeval tv;
-                    gettimeofday(&tv, nullptr);
-                    tv += { THREAD_IDLE_MAX_SEC, 0 };
-                    auto ts = to_ts(tv);
-                    if (pthread_cond_timedwait(&send_task, &lock, &ts) == ETIMEDOUT) {
-                        // Terminate thread after max idle time
-                        --available_threads;
-                        --active_threads;
-                        return nullptr;
-                    }
-                }
+        auto num_thread = running_threads.load(memory_order_acquire);
+        std::shared_ptr<Task> null_task = nullptr;
+        std::shared_ptr<Task> local_task =
+                std::atomic_exchange_explicit(&pending_task, null_task, memory_order_acq_rel);
+        if (!local_task) {
+            // someone else consumes the task
+            if (timeout) {
+                auto idl = idle_threads.fetch_sub(1, memory_order_acq_rel);
+                if (idl > 1 && (num_thread + idl) > CORE_POOL_SIZE)
+                    return nullptr;
+                else
+                    idle_threads.fetch_add(1, memory_order_release);
             }
-            local_task.swap(pending_task);
-            pthread_cond_signal(&recv_task);
-            --available_threads;
+            // wait running thread changed, which indicates a job is added
+            timeval tv{};
+            gettimeofday(&tv, nullptr);
+            auto sleep_time = tv.tv_sec;
+            running_threads.wait(num_thread, memory_order_acquire);
+            gettimeofday(&tv, nullptr);
+            timeout = tv.tv_sec - sleep_time > THREAD_IDLE_MAX_SEC;
+            // notified, try to fetch pending task again
+            continue;
         }
-        local_task();
+        // successfully fetch a task
+        timeout = false;
+        // the following is done on exec_task
+        // running_threads.fetch_add(1, memory_order_release);
+        // idle_threads.fetch_sub(1, memory_order_release);
+        // notify for potential new thread
+        idle_threads.notify_one();
+        (*local_task)();
+        running_threads.fetch_sub(1, memory_order_relaxed);
+        idle_threads.fetch_add(1, memory_order_acq_rel);
+        idle_threads.notify_one();
     }
 }
 
-void exec_task(function<void()> &&task) {
-    mutex_guard g(lock);
-    pending_task.swap(task);
-    if (available_threads == 0) {
-        ++active_threads;
-        new_daemon_thread(thread_pool_loop, active_threads > CORE_POOL_SIZE ? nullptr : (void*)(1));
-    } else {
-        pthread_cond_signal(&send_task);
+void exec_task(Task &&task) {
+    if (!task) return;
+    auto desired_task = make_shared<Task>(std::move(task));
+    for (;;) {
+        shared_ptr<Task> null_task = nullptr;
+        auto num_thread = idle_threads.load(memory_order_relaxed);
+        // if pending_task == null_task: pending_task = desired_task
+        // else: null_task = pending_task
+        if (atomic_compare_exchange_strong_explicit(&pending_task, &null_task, desired_task,
+                                                    memory_order_release,
+                                                    memory_order_relaxed)) {
+            break;
+        } else {
+            // some exec_task is still running, wait active thread change,
+            // which indicates a pending task is consumed.
+            idle_threads.wait(num_thread, memory_order_acquire);
+        }
     }
-    timeval tv;
-    gettimeofday(&tv, nullptr);
-    // Wait for task consumption
-    tv += { 0, MAX_THREAD_BLOCK_MS * 1000 };
-    auto ts = to_ts(tv);
-    pthread_cond_timedwait(&recv_task, &lock, &ts);
+    // starting from here, there's must only be one exec_task
+    if (idle_threads.fetch_sub(1, memory_order_acq_rel) == 0) {
+        // no available_threads, new one
+        new_daemon_thread(thread_pool_loop, nullptr);
+    }
+    running_threads.fetch_add(1, memory_order_release);
+    running_threads.notify_all();
 }


### PR DESCRIPTION
There's a race condition on https://github.com/topjohnwu/Magisk/commit/0cd99712fa4df231b74092938081856b6c1a4bc4.

To test it, use the following script:
```bash
for i in $(seq 1 100); do
  su -c "echo hello $i"&
done
```
And soon you will see an error `No daemon is currently running!`. Apparently `magiskd` is dead.
By tomestoned you will see:
```
backtrace:
      #00 pc 0000000000089acc  /apex/com.android.runtime/lib64/bionic/libc.so (abort+164) (BuildId: a790cdbd8e44ea8a90802da343cb82ce)
      #01 pc 000000000000c620  /dev/UXUO2/magisk64
```
Refer to the source, this is because `local_task` of the thread pool is referring to a `nullptr`.

So I reimplement it as a lock-free version and improve (maybe) the efficiency.
After this patch, the above script won't crash `magiskd`.

HOWEVER, some interesting things I found are:
```
887-3782/system_process E/ActivityManager: Timeout waiting for provider com.topjohnwu.magisk/10154 for provider com.topjohnwu.magisk.provider providerRunning=false caller=unknown/0
```
The toast of the authentication badly decreases the concurrency `su`'s and CRASHes the system. Killing the AndroidRuntime can dramatically increase the concurrency of the above script.

Moreover, I found that `su -c 'echo hello'&` cannot be done and it will be in the job list FOREVER.