### PR TITLE
Skip loading Magisk when detecting DSU

### DIFF
--- a/native/jni/init/getinfo.cpp
+++ b/native/jni/init/getinfo.cpp
@@ -193,6 +193,7 @@ void BootConfig::print() {
     LOGD("fstab_suffix=[%s]\n", fstab_suffix);
     LOGD("hardware=[%s]\n", hardware);
     LOGD("hardware.platform=[%s]\n", hardware_plat);
+    LOGD("dsu=[%d]\n", dsu);
 }
 
 #define read_dt(name, key)                                          \
@@ -218,6 +219,8 @@ void load_kernel_info(BootConfig *config) {
 
     // Log to kernel
     setup_klog();
+
+    config->dsu = is_dsu();
 
     config->set(parse_cmdline(full_read("/proc/cmdline")));
     LOGD("Kernel cmdline info:\n");

--- a/native/jni/init/getinfo.cpp
+++ b/native/jni/init/getinfo.cpp
@@ -193,7 +193,6 @@ void BootConfig::print() {
     LOGD("fstab_suffix=[%s]\n", fstab_suffix);
     LOGD("hardware=[%s]\n", hardware);
     LOGD("hardware.platform=[%s]\n", hardware_plat);
-    LOGD("dsu=[%d]\n", dsu);
 }
 
 #define read_dt(name, key)                                          \
@@ -219,8 +218,6 @@ void load_kernel_info(BootConfig *config) {
 
     // Log to kernel
     setup_klog();
-
-    config->dsu = is_dsu();
 
     config->set(parse_cmdline(full_read("/proc/cmdline")));
     LOGD("Kernel cmdline info:\n");

--- a/native/jni/init/init.hpp
+++ b/native/jni/init/init.hpp
@@ -6,6 +6,7 @@ struct BootConfig {
     bool skip_initramfs;
     bool force_normal_boot;
     bool rootwait;
+    bool dsu;
     char slot[3];
     char dt_dir[64];
     char fstab_suffix[32];
@@ -38,6 +39,7 @@ extern std::vector<std::string> mount_list;
 
 bool unxz(int fd, const uint8_t *buf, size_t size);
 void load_kernel_info(BootConfig *config);
+bool is_dsu();
 bool check_two_stage();
 void setup_klog();
 const char *backup_init();

--- a/native/jni/init/init.hpp
+++ b/native/jni/init/init.hpp
@@ -6,7 +6,6 @@ struct BootConfig {
     bool skip_initramfs;
     bool force_normal_boot;
     bool rootwait;
-    bool dsu;
     char slot[3];
     char dt_dir[64];
     char fstab_suffix[32];

--- a/native/jni/init/mount.cpp
+++ b/native/jni/init/mount.cpp
@@ -204,16 +204,14 @@ bool is_dsu() {
         PLOGE("Failed to mount /metadata");
         return false;
     } else {
-        run_finally finally([] {
-            xumount2("/metadata", MNT_DETACH);
-        });
+        run_finally f([]{ xumount2("/metadata", MNT_DETACH); });
         constexpr auto dsu_status = "/metadata/gsi/dsu/install_status";
         if (xaccess(dsu_status, F_OK) == 0) {
-            char buf[PATH_MAX] = {0};
-            auto f = xopen_file(dsu_status, "r");
-            fgets(buf, sizeof(buf), f.get());
-            std::string_view status = buf;
-            if (status == "ok" || status == "0") return true;
+            char status[PATH_MAX] = {0};
+            auto fp = xopen_file(dsu_status, "r");
+            fgets(status, sizeof(status), fp.get());
+            if (status == "ok"sv || status == "0"sv)
+                return true;
         }
     }
     return false;

--- a/native/jni/init/mount.cpp
+++ b/native/jni/init/mount.cpp
@@ -93,7 +93,7 @@ static int64_t setup_block(bool write_block) {
 }
 
 static bool is_lnk(const char *name) {
-    struct stat st;
+    struct stat st{};
     if (lstat(name, &st))
         return false;
     return S_ISLNK(st.st_mode);
@@ -194,6 +194,29 @@ static void switch_root(const string &path) {
 
     LOGD("Cleaning rootfs\n");
     frm_rf(root);
+}
+
+bool is_dsu() {
+    strcpy(blk_info.partname, "metadata");
+    xmkdir("/metadata", 0755);
+    if (setup_block(true) < 0 ||
+        xmount(blk_info.block_dev, "/metadata", "ext4", MS_RDONLY, nullptr)) {
+        PLOGE("Failed to mount /metadata");
+        return false;
+    } else {
+        run_finally finally([] {
+            xumount2("/metadata", MNT_DETACH);
+        });
+        constexpr auto dsu_status = "/metadata/gsi/dsu/install_status";
+        if (xaccess(dsu_status, F_OK) == 0) {
+            char buf[PATH_MAX] = {0};
+            auto f = xopen_file(dsu_status, "r");
+            fgets(buf, sizeof(buf), f.get());
+            std::string_view status = buf;
+            if (status == "ok" || status == "0") return true;
+        }
+    }
+    return false;
 }
 
 void MagiskInit::mount_rules_dir(const char *dev_base, const char *mnt_base) {

--- a/native/jni/init/twostage.cpp
+++ b/native/jni/init/twostage.cpp
@@ -63,6 +63,12 @@ static bool read_fstab_file(const char *fstab_file, vector<fstab_entry> &fstab) 
 extern uint32_t patch_verity(void *buf, uint32_t size);
 
 void FirstStageInit::prepare() {
+    if (config->dsu) {
+        rename(backup_init(), "/init");
+        LOGI("Skip loading Magisk because of DSU");
+        return;
+    }
+
     run_finally finally([]{ chdir("/"); });
     if (config->force_normal_boot) {
         xmkdirs(FSR "/system/bin", 0755);

--- a/native/jni/init/twostage.cpp
+++ b/native/jni/init/twostage.cpp
@@ -63,9 +63,9 @@ static bool read_fstab_file(const char *fstab_file, vector<fstab_entry> &fstab) 
 extern uint32_t patch_verity(void *buf, uint32_t size);
 
 void FirstStageInit::prepare() {
-    if (config->dsu) {
+    if (is_dsu()) {
         rename(backup_init(), "/init");
-        LOGI("Skip loading Magisk because of DSU");
+        LOGI("Skip loading Magisk because of DSU\n");
         return;
     }
 


### PR DESCRIPTION
Partially fix #4402 #5123

To load Magisk on DSU, we need to parse `lp_metadata` and transform fstab in the first stage of `magiskinit`, patch `init` to skip DSU, and write info to `/metadata` in the second stage of `magskinit`. Since it's way too complicated, I skip DSU as a tmp fix.