### PR TITLE
Refine zygisk

### DIFF
--- a/native/jni/core/module.cpp
+++ b/native/jni/core/module.cpp
@@ -691,9 +691,9 @@ static void collect_modules() {
         if (faccessat(modfd, "disable", F_OK, 0) == 0)
             return;
         // Riru and its modules are not compatible with zygisk
-        if (zygisk_enabled && (
-                entry->d_name == "riru-core"sv ||
-                faccessat(modfd, "riru", F_OK, 0) == 0))
+        if (zygisk_enabled && faccessat(modfd, "zygisk", F_OK, 0) == -1 &&
+                (std::string_view(entry->d_name).rfind("riru") == 0 ||
+                        faccessat(modfd, "riru", F_OK, 0) == 0))
             return;
 
         module_list.emplace_back(entry->d_name);

--- a/native/jni/zygisk/api.hpp
+++ b/native/jni/zygisk/api.hpp
@@ -186,7 +186,8 @@ struct Api {
 
 private:
     internal::api_table *impl;
-    friend void internal::entry_impl<class T>(internal::api_table *, JNIEnv *);
+    template<class T>
+    friend void internal::entry_impl(internal::api_table *, JNIEnv *);
 };
 
 // Register a class as a Zygisk module
@@ -253,7 +254,7 @@ struct api_table {
 
 template <class T>
 void entry_impl(api_table *table, JNIEnv *env) {
-    auto module = new T();
+    ModuleBase* module = new T();
     if (!table->registerModule(table, new module_abi(module)))
         return;
     auto api = new Api();


### PR DESCRIPTION
- Skip modules when it's name starts with `riru`
- Except for modules supporting `zygisk` (with zygisk dir) to allow modules support riru and zygisk simultaneously
- Call `onLoad` as `ModuleBase *` to avoid `private` or `protected`
- Proper declare friend, otherwise `zygisk.h: error: 'impl' is a private member of 'zygisk::Api'`