### PR TITLE
Fix UB of loading modules

### DIFF
--- a/native/jni/core/module.cpp
+++ b/native/jni/core/module.cpp
@@ -753,7 +753,7 @@ void remove_modules() {
 void exec_module_scripts(const char *stage) {
     vector<string_view> module_names;
     std::transform(modules->begin(), modules->end(), std::back_inserter(module_names),
-        [](const module_info &info) { return info.name; });
+        [](const module_info &info) -> string_view { return info.name; });
     exec_module_scripts(stage, module_names);
 }
 


### PR DESCRIPTION
- The lambda here infers its return type as `std::string`,
  and since `info` is `const`, the labmda copies `info.name`
  and returns a `std::string&&`. After captured by the
  `std::string_view`, the `std::string&&` return value
  deconstructs and makes `std::string_view` refers to a
  dangling pointer.