### PR TITLE
Add rules to fix xhook fails on webview_zygote

### DIFF
--- a/native/jni/magiskpolicy/rules.cpp
+++ b/native/jni/magiskpolicy/rules.cpp
@@ -179,6 +179,7 @@ void sepolicy::magisk_rules() {
     // Allow hook
     allow("zygote", "zygote", "process", "execmem");
     allow("system_server", "system_server", "process", "execmem");
+    allow("webview_zygote", "zygote_exec", "file", "read");
 
     // Allow update_engine/addon.d-v2 to run permissive on all ROMs
     permissive("update_engine");


### PR DESCRIPTION
```
2021-10-17 03:52:16.898 1064-1064/? I/Magisk: xhook: found _ZN7android14AndroidRuntime8setArgv0EPKcb at .rel.plt offset: 0x46d8
2021-10-17 03:52:16.898 1064-1064/? E/Magisk: xhook: set addr prot failed. ret: 13
2021-10-17 03:52:16.896 1064-1064/? W/webview_zygote: type=1400 audit(0.0:90): avc: denied { read } for path="/system/bin/app_process32" dev="dm-1" ino=151 scontext=u:r:webview_zygote:s0 tcontext=u:object_r:zygote_exec:s0 tclass=file permissive=0
2021-10-17 03:52:16.899 1064-1064/? E/Magisk: xhook: replace function failed: _ZN7android14AndroidRuntime8setArgv0EPKcb at .rel.plt
```