### PR TITLE
scripts: support Samsung 2SI with skip_initramfs in dtb cmdline

### DIFF
--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -189,8 +189,14 @@ rm -f ramdisk.cpio.orig config magisk*.xz
 # Binary Patches
 #################
 
-for dt in dtb kernel_dtb extra; do
-  [ -f $dt ] && ./magiskboot dtb $dt patch && ui_print "- Patch fstab in $dt"
+for DT in dtb kernel_dtb extra; do
+  if [ -f $DT ]; then
+    ./magiskboot dtb $DT patch && ui_print "- Patch fstab in $DT"
+    # Patch Samsung dtb cmdline skip_initramfs -> uses_initramfs
+    ./magiskboot hexpatch $DT \
+    736B69705F696E697472616D667300 \
+    757365735F696E697472616D667300
+  fi
 done
 
 if [ -f kernel ]; then


### PR DESCRIPTION
Samsung Galaxy A21S and Galaxy M12, probably others, are hdr_v2 boot.img with 2SI judging by the ramdisk contents (init, apex, etc.), but the dtb contains an extra cmdline with skip_initramfs present, even though this shouldn't exist on 2SI and the kernel apparently doesn't even contain a skip_initramfs function

I can't find examples of other devices where skip_initramfs is present in the dtb plainly other than these so patch it out like we do for the kernel

Closes #4307