### PR TITLE
Fix nullptr dereference when env abnormal

### DIFF
--- a/native/jni/core/module.cpp
+++ b/native/jni/core/module.cpp
@@ -549,7 +549,7 @@ struct module_info {
 #endif
 };
 
-static vector<module_info> *modules = nullptr;
+static vector<module_info> *modules;
 
 #define mount_zygisk(bit) \
 if (access("/system/bin/app_process" #bit, F_OK) == 0) { \


### PR DESCRIPTION
When the env is abnormal (usually new install by patching boot and busybox is missing), Magisk will skip collecting modules and skip `default_new(modules)` making a null pointer dereference.