### PR TITLE
Don't auto unlock blocks

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -275,7 +275,6 @@ void post_fs_data(int client) {
 
     LOGI("** post-fs-data mode running\n");
 
-    unlock_blocks();
     mount_mirrors();
 
     if (access(SECURE_DIR, F_OK) != 0) {


### PR DESCRIPTION
close #4830
It is better to execute `blockdev --setrw xxx` command manually 