### PR TITLE
Don't use xwrite() when patching legacy rootfs init

### DIFF
--- a/native/jni/init/rootdir.cpp
+++ b/native/jni/init/rootdir.cpp
@@ -343,11 +343,16 @@ void RootFSBase::patch_rootfs() {
     }
 
     if (patch_sepolicy("/sepolicy")) {
-        auto init = mmap_data::ro(access("/system/bin/init",F_OK) == 0 ? "/system/bin/init" : "/init");
-        init.patch({ make_pair(SPLIT_PLAT_CIL, "xxx") });
-        int dest = xopen("/init", O_TRUNC | O_WRONLY | O_CLOEXEC, 0);
-        xwrite(dest, init.buf, init.sz);
-        close(dest);
+        if (access("/system/bin/init", F_OK) == 0) {
+            auto init = mmap_data::ro("/system/bin/init");
+            init.patch({ make_pair(SPLIT_PLAT_CIL, "xxx") });
+            int dest = xopen("/init", O_TRUNC | O_WRONLY | O_CLOEXEC, 0);
+            xwrite(dest, init.buf, init.sz);
+            close(dest);
+        } else {
+            auto init = mmap_data::rw("/init");
+            init.patch({ make_pair(SPLIT_PLAT_CIL, "xxx") });
+        }
     }
 
     // Handle overlays


### PR DESCRIPTION
Fix #4810

> [    2.927463]  [1:           init:    1] magiskinit: Replace [/system/etc/selinux/plat_sepolicy.cil] -> [xxx]
[    2.936801]  [1:           init:    1] magiskinit: write failed with 14: Bad address

Since #4596, magisk fails to patch `/init`, xwrite() fails with EFAULT, break the original `/init` file and make the device unbootable. Reverting this commit for legacy rootfs devices fixes the problem. I think this is a Samsung kernel magic since currently I can't reproduce this on other devices or find something special in the log currently we have.