### PR TITLE
Disable riru modules when zygisk is on

### DIFF
--- a/native/jni/core/module.cpp
+++ b/native/jni/core/module.cpp
@@ -707,6 +707,7 @@ static void collect_modules(bool open_zygisk) {
             // Riru and its modules are not compatible with zygisk
             if (entry->d_name == "riru-core"sv || faccessat(modfd, "riru", F_OK, 0) == 0) {
                 close(openat(modfd, "disable", O_CREAT | O_WRONLY, S_IRWXU));
+                LOGI("%s: disable\n", entry->d_name);
                 return;
             }
             if (open_zygisk) {
@@ -728,6 +729,7 @@ static void collect_modules(bool open_zygisk) {
             // Disable zygisk modules when zygisk is not enabled
             if (faccessat(modfd, "zygisk", F_OK, 0) == 0) {
                 close(openat(modfd, "disable", O_CREAT | O_WRONLY, S_IRWXU));
+                LOGI("%s: disable\n", entry->d_name);
                 return;
             }
         }


### PR DESCRIPTION
Also disable zygisk modules when zygisk is off

Reveal in the manager and let the user know why modules are not loaded