### PR TITLE
Fix fragments lifecycleOwner

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIFragment.kt
@@ -35,7 +35,7 @@ abstract class BaseUIFragment<VM : BaseViewModel, Binding : ViewDataBinding> :
     ): View? {
         binding = DataBindingUtil.inflate<Binding>(inflater, layoutRes, container, false).also {
             it.setVariable(BR.viewModel, viewModel)
-            it.lifecycleOwner = this
+            it.lifecycleOwner = viewLifecycleOwner
         }
         return binding.root
     }

--- a/app/src/main/java/com/topjohnwu/magisk/ui/theme/ThemeFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/theme/ThemeFragment.kt
@@ -34,7 +34,7 @@ class ThemeFragment : BaseUIFragment<ThemeViewModel, FragmentThemeMd2Binding>() 
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         super.onCreateView(inflater, container, savedInstanceState)
 
         for ((a, b) in Theme.values().paired()) {
@@ -48,7 +48,7 @@ class ThemeFragment : BaseUIFragment<ThemeViewModel, FragmentThemeMd2Binding>() 
                 ItemThemeBindingImpl.inflate(LayoutInflater.from(themed), view, true).also {
                     it.setVariable(BR.viewModel, viewModel)
                     it.setVariable(BR.theme, theme)
-                    it.lifecycleOwner = this
+                    it.lifecycleOwner = viewLifecycleOwner
                 }
             }
 


### PR DESCRIPTION
When using Data Binding with Fragments, make sure to use Fragment.getViewLifecycleOwner(). Using the Fragment as the LifecycleOwner might cause memory leaks since the Fragment's Lifecycle outlives the view Lifecycle.

https://cs.android.com/androidx/platform/frameworks/data-binding/+/9f1cfe0585a773f23db82c7f96a62ed9833d3dec