### PR TITLE
Fix slot on devices where not in /proc/cmdline

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -261,10 +261,13 @@ mount_ro_ensure() {
 
 mount_partitions() {
   # Check A/B slot
-  SLOT=`grep_cmdline androidboot.slot_suffix`
+  SLOT=`getprop ro.boot.slot_suffix`
   if [ -z $SLOT ]; then
-    SLOT=`grep_cmdline androidboot.slot`
-    [ -z $SLOT ] || SLOT=_${SLOT}
+    SLOT=`grep_cmdline androidboot.slot_suffix`
+    if [ -z $SLOT ]; then
+      SLOT=`grep_cmdline androidboot.slot`
+      [ -z $SLOT ] || SLOT=_${SLOT}
+    fi
   fi
   [ -z $SLOT ] || ui_print "- Current boot slot: $SLOT"
 


### PR DESCRIPTION
It appears that `androidboot.slot_suffix` is missing from `/proc/cmdline` on Pixel 6, which prevents [`mount_partitions`](https://github.com/topjohnwu/Magisk/blob/472656517f5e353198b64cf2749dce6a4bd91ad0/scripts/util_functions.sh#L264-L269) from setting `$SLOT`, which causes [`find_boot_image`](https://github.com/topjohnwu/Magisk/blob/472656517f5e353198b64cf2749dce6a4bd91ad0/scripts/util_functions.sh#L404-L411) to default to `boot_a`.

Google uses [`ro.boot.slot_suffix`](https://android.googlesource.com/device/google/gs101/+/refs/heads/master/interfaces/boot/1.2/BootControl.cpp#194) to detect the current slot in `update_engine` for Pixel 6, so I used that for the first test. I'm not sure what implications that will have on other devices. It also worked on a Pixel 5a, for whatever that's worth.