### PR TITLE
Support `bootconfig` and quotes in `grep_cmdline`

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -22,7 +22,7 @@ toupper() {
 
 grep_cmdline() {
   local REGEX="s/^$1=//p"
-  { cat /proc/cmdline 2>/dev/null | tr '[:space:]' '\n'; cat /proc/bootconfig 2>/dev/null | sed 's/[[:space:]]*=[[:space:]]*/=/g'; } | sed -n "$REGEX" 2>/dev/null
+  { cat /proc/cmdline 2>/dev/null | tr '[:space:]' '\n'; cat /proc/bootconfig 2>/dev/null | sed 's/[[:space:]]*=[[:space:]]*\"\(.*\)\"/=\1/g'; } | sed -n "$REGEX" 2>/dev/null
 }
 
 grep_prop() {

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -22,7 +22,9 @@ toupper() {
 
 grep_cmdline() {
   local REGEX="s/^$1=//p"
-  { cat /proc/cmdline 2>/dev/null | tr '[:space:]' '\n'; cat /proc/bootconfig 2>/dev/null | sed 's/[[:space:]]*=[[:space:]]*\"\(.*\)\"/=\1/g'; } | sed -n "$REGEX" 2>/dev/null
+  local CMDLINE=$(cat /proc/cmdline 2>/dev/null)
+  POSTFIX=$([ $(expr $(echo "$CL" | tr -d -c '"' | wc -m) % 2) == 0 ] && echo -n '' || echo -n '"')
+  { eval "for i in $CL$POSTFIX; do echo \$i; done" ; cat /proc/bootconfig 2>/dev/null | sed 's/[[:space:]]*=[[:space:]]*\"\(.*\)\"/=\1/g'; } | sed -n "$REGEX" 2>/dev/null
 }
 
 grep_prop() {

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -22,7 +22,7 @@ toupper() {
 
 grep_cmdline() {
   local REGEX="s/^$1=//p"
-  cat /proc/cmdline | tr '[:space:]' '\n' | sed -n "$REGEX" 2>/dev/null
+  { cat /proc/cmdline 2>/dev/null | tr '[:space:]' '\n'; cat /proc/bootconfig 2>/dev/null | sed 's/[[:space:]]*=[[:space:]]*/=/g'; } | sed -n "$REGEX" 2>/dev/null
 }
 
 grep_prop() {

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -22,7 +22,7 @@ toupper() {
 
 grep_cmdline() {
   local REGEX="s/^$1=//p"
-  local CMDLINE=$(cat /proc/cmdline 2>/dev/null)
+  local CL=$(cat /proc/cmdline 2>/dev/null)
   POSTFIX=$([ $(expr $(echo "$CL" | tr -d -c '"' | wc -m) % 2) == 0 ] && echo -n '' || echo -n '"')
   { eval "for i in $CL$POSTFIX; do echo \$i; done" ; cat /proc/bootconfig 2>/dev/null | sed 's/[[:space:]]*=[[:space:]]*\"\(.*\)\"/=\1/g'; } | sed -n "$REGEX" 2>/dev/null
 }

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -24,7 +24,7 @@ grep_cmdline() {
   local REGEX="s/^$1=//p"
   local CL=$(cat /proc/cmdline 2>/dev/null)
   POSTFIX=$([ $(expr $(echo "$CL" | tr -d -c '"' | wc -m) % 2) == 0 ] && echo -n '' || echo -n '"')
-  { eval "for i in $CL$POSTFIX; do echo \$i; done" ; cat /proc/bootconfig 2>/dev/null | sed 's/[[:space:]]*=[[:space:]]*\"\(.*\)\"/=\1/g'; } | sed -n "$REGEX" 2>/dev/null
+  { eval "for i in $CL$POSTFIX; do echo \$i; done" ; cat /proc/bootconfig 2>/dev/null | sed 's/[[:space:]]*=[[:space:]]*\(.*\)/=\1/g' | sed 's/"//g'; } | sed -n "$REGEX" 2>/dev/null
 }
 
 grep_prop() {


### PR DESCRIPTION
androidboot.slot_suffix is missing from /proc/cmdline on Pixel 6, and is now in /proc/bootconfig

Close #4869