### PR TITLE
Revert avbflags breaking boot on many MIUI devices

### DIFF
--- a/native/jni/magiskboot/bootimg.cpp
+++ b/native/jni/magiskboot/bootimg.cpp
@@ -735,7 +735,7 @@ void repack(const char *src_img, const char *out_img, bool skip_comp) {
         memcpy(footer, boot.avb_footer, sizeof(AvbFooter));
         footer->original_image_size = __builtin_bswap64(off.total);
         footer->vbmeta_offset = __builtin_bswap64(off.vbmeta);
-        vbmeta->flags = __builtin_bswap32(3);
+        vbmeta->flags = __builtin_bswap32(0); // avbtool uses 0 here; 3 breaks booting on a number of devices
     }
 
     if (boot.flags[DHTB_FLAG]) {


### PR DESCRIPTION
- the attempt to disable vbmeta verification (set to 3) didn't help on some devices (see #4421) and actively broke many others (see #4447)
- avbtool sets it to 0 and TWRP uses this for recovery.img and it boots fine on all devices, so revert to using 0 for all

Fixes #4447
Closes #4719