### PR TITLE
Only fully disable vbmeta on seandroid/mtk kernels

### DIFF
--- a/native/jni/magiskboot/bootimg.cpp
+++ b/native/jni/magiskboot/bootimg.cpp
@@ -735,7 +735,13 @@ void repack(const char *src_img, const char *out_img, bool skip_comp) {
         memcpy(footer, boot.avb_footer, sizeof(AvbFooter));
         footer->original_image_size = __builtin_bswap64(off.total);
         footer->vbmeta_offset = __builtin_bswap64(off.vbmeta);
-        vbmeta->flags = __builtin_bswap32(3);
+        // Enabling 0x2 bootloop some devices, but fix boot on other devices.
+        if (boot.flags[SEANDROID_FLAG] || boot.flags[MTK_KERNEL]) {
+            vbmeta->flags = __builtin_bswap32(3);
+        } else {
+            // Use |= operator to keep 0x2 flag on custom kernels/ROMs
+            vbmeta->flags |= __builtin_bswap32(1);
+        }
     }
 
     if (boot.flags[DHTB_FLAG]) {

--- a/native/jni/magiskboot/bootimg.cpp
+++ b/native/jni/magiskboot/bootimg.cpp
@@ -738,9 +738,9 @@ void repack(const char *src_img, const char *out_img, bool skip_comp) {
         // Enabling 0x2 bootloop some devices, but fix boot on other devices.
         if (boot.flags[SEANDROID_FLAG] || boot.flags[MTK_KERNEL]) {
             vbmeta->flags = __builtin_bswap32(3);
-        } else {
-            // Use |= operator to keep 0x2 flag on custom kernels/ROMs
-            vbmeta->flags |= __builtin_bswap32(1);
+        } else if (vbmeta->flags == 0) {
+            // Only patch flags if they are 0 to avoid conflicting with custom ROMs
+            vbmeta->flags = __builtin_bswap32(1);
         }
     }
 


### PR DESCRIPTION
See #4901 

Many MIUI devices require 0 to boot properly
But Samsung/MTK may need 3 to boot properly

This is still POC as we have not many information about the issue, 
I theorized that MIUI on Android11 crashed due to the lack of avb flags due to the `0x2` flag being set.
The `0x1` disable most checks already, and should be enough for most devices.

Note: please restore stock image before trying this build, the fix target MIUI Android 11 users, but any other device owner are welcome to test the changes included in this PR to check for any regressions.

Fixes #4447