### PR TITLE
Fix flow parallel

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ktx/XFlow.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ktx/XFlow.kt
@@ -1,0 +1,13 @@
+package com.topjohnwu.magisk.ktx
+
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+
+@FlowPreview
+inline fun <T, R> Flow<T>.concurrentMap(crossinline transform: suspend (T) -> R): Flow<R> {
+    return flatMapMerge { value ->
+        flow { emit(transform(value)) }
+    }
+}

--- a/app/src/main/java/com/topjohnwu/magisk/ui/deny/DenyListViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/deny/DenyListViewModel.kt
@@ -9,6 +9,7 @@ import com.topjohnwu.magisk.arch.Queryable
 import com.topjohnwu.magisk.databinding.filterableListOf
 import com.topjohnwu.magisk.databinding.itemBindingOf
 import com.topjohnwu.magisk.di.AppContext
+import com.topjohnwu.magisk.ktx.concurrentMap
 import com.topjohnwu.magisk.utils.Utils
 import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.*
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.*
 import java.util.*
 import kotlin.collections.ArrayList
 
+@FlowPreview
 class DenyListViewModel : BaseViewModel(), Queryable {
 
     override val queryDelay = 0L
@@ -46,14 +48,6 @@ class DenyListViewModel : BaseViewModel(), Queryable {
         it.bindExtra(BR.viewModel, this)
     }
 
-    @FlowPreview
-    private inline fun <T, R> Flow<T>.concurrentMap(crossinline transform: suspend (T) -> R): Flow<R> {
-        return flatMapMerge { value ->
-            flow { emit(transform(value)) }
-        }
-    }
-
-    @FlowPreview
     @SuppressLint("InlinedApi")
     override fun refresh() = viewModelScope.launch {
         if (!Utils.showSuperUser()) {


### PR DESCRIPTION
> Normally, flows are sequential. It means that the code of all operators is executed in the same coroutine. For example, consider the following code using onEach and collect operators:
> 
> flowOf("A", "B", "C")
>     .onEach  { println("1$it") }
>     .collect { println("2$it") }
> It is going to be executed in the following order by the coroutine Q that calls this code:
> 
> Q : -->-- [1A] -- [2A] -- [1B] -- [2B] -- [1C] -- [2C] -->--
> 