### PR TITLE
Scripts fixes and improvements

### DIFF
--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -91,7 +91,7 @@ restore_imgs() {
 }
 
 post_ota() {
-  cd /data/adb
+  cd $NVBASE
   cp -f $1 bootctl
   rm -f $1
   chmod 755 bootctl

--- a/scripts/emulator.sh
+++ b/scripts/emulator.sh
@@ -114,20 +114,20 @@ else
   mount -t tmpfs -o 'mode=0755' tmpfs /dev/avd-magisk
 fi
 
-# Magisk stuffs
-mkdir -p /data/adb/magisk 2>/dev/null
-unzip -oj app-debug.apk 'assets/*' -x 'assets/chromeos/*' -d /data/adb/magisk
-mkdir /data/adb/modules 2>/dev/null
-mkdir /data/adb/post-fs-data.d 2>/dev/null
-mkdir /data/adb/services.d 2>/dev/null
+# Magisk stuff
+mkdir -p $MAGISKBIN 2>/dev/null
+unzip -oj app-debug.apk 'assets/*' -x 'assets/chromeos/*' -d $MAGISKBIN
+mkdir $NVBASE/modules 2>/dev/null
+mkdir $POSTFSDATAD 2>/dev/null
+mkdir $SERVICED 2>/dev/null
 
 for file in magisk32 magisk64 magiskinit; do
   chmod 755 ./$file
   cp -af ./$file $MAGISKTMP/$file
-  cp -af ./$file /data/adb/magisk/$file
+  cp -af ./$file $MAGISKBIN/$file
 done
-cp -af ./magiskboot /data/adb/magisk/magiskboot
-cp -af ./busybox /data/adb/magisk/busybox
+cp -af ./magiskboot $MAGISKBIN/magiskboot
+cp -af ./busybox $MAGISKBIN/busybox
 
 ln -s ./magisk64 $MAGISKTMP/magisk
 ln -s ./magisk $MAGISKTMP/su

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -22,9 +22,9 @@ toupper() {
 
 grep_cmdline() {
   local REGEX="s/^$1=//p"
-  local CL=$(cat /proc/cmdline 2>/dev/null)
-  POSTFIX=$([ $(expr $(echo "$CL" | tr -d -c '"' | wc -m) % 2) == 0 ] && echo -n '' || echo -n '"')
-  { eval "for i in $CL$POSTFIX; do echo \$i; done" ; cat /proc/bootconfig 2>/dev/null | sed 's/[[:space:]]*=[[:space:]]*\(.*\)/=\1/g' | sed 's/"//g'; } | sed -n "$REGEX" 2>/dev/null
+  { echo $(cat /proc/cmdline)$(sed -e 's/[^"]//g' -e 's/""//g' /proc/cmdline) | xargs -n 1; \
+    sed -e 's/ = /=/g' -e 's/, /,/g' -e 's/"//g' /proc/bootconfig; \
+  } 2>/dev/null | sed -n "$REGEX"
 }
 
 grep_prop() {
@@ -323,6 +323,9 @@ mount_apex() {
   local PATTERN='s/.*"name":[^"]*"\([^"]*\).*/\1/p'
   for APEX in /system/apex/*; do
     if [ -f $APEX ]; then
+      # handle CAPEX APKs, extract actual APEX APK first
+      unzip -qo $APEX original_apex -d /apex
+      [ -f /apex/original_apex ] && APEX=/apex/original_apex # unzip doesn't do return codes
       # APEX APKs, extract and loop mount
       unzip -qo $APEX apex_payload.img -d /apex
       DEST=$(unzip -qp $APEX apex_manifest.pb | strings | head -n 1)
@@ -335,7 +338,7 @@ mount_apex() {
         ui_print "- Mounting $DEST"
         mount -t ext4 -o ro,noatime $LOOPDEV $DEST
       fi
-      rm -f /apex/apex_payload.img
+      rm -f /apex/original_apex /apex/apex_payload.img
     elif [ -d $APEX ]; then
       # APEX folders, bind mount directory
       if [ -f $APEX/apex_manifest.json ]; then
@@ -560,13 +563,13 @@ check_data() {
 
 find_magisk_apk() {
   local DBAPK
-  [ -z $APK ] && APK=/data/adb/magisk.apk
-  [ -f $APK ] || APK=/data/magisk/magisk.apk
+  [ -z $APK ] && APK=$NVBASE/magisk.apk
+  [ -f $APK ] || APK=$MAGISKBIN/magisk.apk
   [ -f $APK ] || APK=/data/app/com.topjohnwu.magisk*/*.apk
   [ -f $APK ] || APK=/data/app/*/com.topjohnwu.magisk*/*.apk
   if [ ! -f $APK ]; then
     DBAPK=$(magisk --sqlite "SELECT value FROM strings WHERE key='requester'" 2>/dev/null | cut -d= -f2)
-    [ -z $DBAPK ] && DBAPK=$(strings /data/adb/magisk.db | grep -oE 'requester..*' | cut -c10-)
+    [ -z $DBAPK ] && DBAPK=$(strings $NVBASE/magisk.db | grep -oE 'requester..*' | cut -c10-)
     [ -z $DBAPK ] || APK=/data/user_de/*/$DBAPK/dyn/*.apk
     [ -f $APK ] || [ -z $DBAPK ] || APK=/data/app/$DBAPK*/*.apk
     [ -f $APK ] || [ -z $DBAPK ] || APK=/data/app/*/$DBAPK*/*.apk
@@ -578,7 +581,7 @@ run_migrations() {
   local LOCSHA1
   local TARGET
   # Legacy app installation
-  local BACKUP=/data/adb/magisk/stock_boot*.gz
+  local BACKUP=$MAGISKBIN/stock_boot*.gz
   if [ -f $BACKUP ]; then
     cp $BACKUP /data
     rm -f $BACKUP
@@ -596,7 +599,7 @@ run_migrations() {
   # Stock backups
   LOCSHA1=$SHA1
   for name in boot dtb dtbo dtbs; do
-    BACKUP=/data/adb/magisk/stock_${name}.img
+    BACKUP=$MAGISKBIN/stock_${name}.img
     [ -f $BACKUP ] || continue
     if [ $name = 'boot' ]; then
       LOCSHA1=`$MAGISKBIN/magiskboot sha1 $BACKUP`
@@ -615,10 +618,12 @@ copy_sepolicy_rules() {
 
   # Find current active RULESDIR
   local RULESDIR
-  local active_dir=$(magisk --path)/.magisk/mirror/sepolicy.rules
-  if [ -L $active_dir ]; then
-    RULESDIR=$(readlink $active_dir)
+  local ACTIVEDIR=$(magisk --path)/.magisk/mirror/sepolicy.rules
+  if [ -L $ACTIVEDIR ]; then
+    RULESDIR=$(readlink $ACTIVEDIR)
     [ "${RULESDIR:0:1}" != "/" ] && RULESDIR="$(magisk --path)/.magisk/mirror/$RULESDIR"
+  elif ! $ISENCRYPTED; then
+    RULESDIR=$NVBASE/modules
   elif [ -d /data/unencrypted ] && ! grep ' /data ' /proc/mounts | grep -qE 'dm-|f2fs'; then
     RULESDIR=/data/unencrypted/magisk
   elif grep -q ' /cache ' /proc/mounts; then
@@ -642,7 +647,7 @@ copy_sepolicy_rules() {
   fi
 
   # Copy all enabled sepolicy.rule
-  for r in /data/adb/modules*/*/sepolicy.rule; do
+  for r in $NVBASE/modules*/*/sepolicy.rule; do
     [ -f "$r" ] || continue
     local MODDIR=${r%/*}
     [ -f $MODDIR/disable ] && continue


### PR DESCRIPTION
- ensure all scripts use $NVBASE $MAGISKBIN $POSTFSDATAD and $SERVICED where appropriate
- simplify new grep_cmdline() using xargs and more sed
- show correct active sepolicy $RULESDIR on devices with no encryption (matching magiskinit)
- add support for Android 12 .capex (compressed apex) files