### PR TITLE
fix bootloop on redmi and xiaomi when vbmeta verity is disabled

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -40,6 +40,8 @@ Supported actions:
     to [outbootimg], or new-boot.img if not specified.
     If '-n' is provided, it will not attempt to recompress ramdisk.cpio,
     otherwise it will compress ramdisk.cpio and kernel with the same method
+    If '-k' is provided, it will not attempt to disable vbmeta_verity,
+    otherwise it will disable vbmeta_verity
     in <origbootimg> if the file provided is not already compressed.
 
   hexpatch <file> <hexpattern1> <hexpattern2>

--- a/native/jni/magiskboot/bootimg.cpp
+++ b/native/jni/magiskboot/bootimg.cpp
@@ -503,7 +503,7 @@ int unpack(const char *image, bool skip_decomp, bool hdr) {
 #define file_align() \
 write_zero(fd, align_off(lseek(fd, 0, SEEK_CUR) - off.header, boot.hdr->page_size()))
 
-void repack(const char *src_img, const char *out_img, bool skip_comp) {
+void repack(const char *src_img, const char *out_img, bool skip_comp, bool keep_vbmeta_verity) {
     const boot_img boot(src_img);
     fprintf(stderr, "Repack to boot image: [%s]\n", out_img);
 
@@ -761,7 +761,9 @@ void repack(const char *src_img, const char *out_img, bool skip_comp) {
         memcpy(footer, boot.avb_footer, sizeof(AvbFooter));
         footer->original_image_size = __builtin_bswap64(off.total);
         footer->vbmeta_offset = __builtin_bswap64(off.vbmeta);
-        vbmeta->flags = __builtin_bswap32(3);
+        if(!keep_vbmeta_verity) {
+            vbmeta->flags = __builtin_bswap32(3);
+        }
     }
 
     if (boot.flags[DHTB_FLAG]) {

--- a/native/jni/magiskboot/magiskboot.hpp
+++ b/native/jni/magiskboot/magiskboot.hpp
@@ -13,7 +13,7 @@
 #define NEW_BOOT        "new-boot.img"
 
 int unpack(const char *image, bool skip_decomp = false, bool hdr = false);
-void repack(const char *src_img, const char *out_img, bool skip_comp = false);
+void repack(const char *src_img, const char *out_img, bool skip_comp = false, bool keep_vbmeta_verity = false);
 int split_image_dtb(const char *filename);
 int hexpatch(const char *image, const char *from, const char *to);
 int cpio_commands(int argc, char *argv[]);

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -208,8 +208,11 @@ fi
 #################
 
 ui_print "- Repacking boot image"
-./magiskboot repack "$BOOTIMAGE" || abort "! Unable to repack boot image"
-
+if [ "$(grep_get_prop ro.product.brand)" == "Xiaomi" ] || [ "$(grep_get_prop ro.product.brand)" == "Redmi" ]; then
+  ./magiskboot repack -k "$BOOTIMAGE" || abort "! Unable to repack boot image"
+else
+  ./magiskboot repack "$BOOTIMAGE" || abort "! Unable to repack boot image"
+fi
 # Sign chromeos boot
 $CHROMEOS && sign_chromeos
 


### PR DESCRIPTION
#4447 #4906 #4901 

add a parameter to decide to set avb flag to 0 or 3 in magiskboot repack.
and we can get the device brand or device model by boot_patch.sh.
