### PR TITLE
Dump vendor_ramdisk_table and bootconfig from vendor_boot v4

### DIFF
--- a/native/jni/magiskboot/bootimg.hpp
+++ b/native/jni/magiskboot/bootimg.hpp
@@ -369,8 +369,8 @@ struct dyn_img_hdr {
 
     // v4 specific
     decl_val(signature_size, uint32_t)
-    decl_val(vendor_ramdisk_table_size, uint32_t)
-    decl_val(bootconfig_size, uint32_t)
+    decl_var(vendor_ramdisk_table_size, 32)
+    decl_var(bootconfig_size, 32)
 
     virtual ~dyn_img_hdr() {
         free(raw);
@@ -619,6 +619,8 @@ struct boot_img {
     uint8_t *extra;
     uint8_t *recovery_dtbo;
     uint8_t *dtb;
+    uint8_t *vendor_ramdisk_table;
+    uint8_t *bootconfig;
 
     // Pointer to blocks defined in header, but we do not care
     uint8_t *ignore;

--- a/native/jni/magiskboot/magiskboot.hpp
+++ b/native/jni/magiskboot/magiskboot.hpp
@@ -10,6 +10,8 @@
 #define KER_DTB_FILE    "kernel_dtb"
 #define RECV_DTBO_FILE  "recovery_dtbo"
 #define DTB_FILE        "dtb"
+#define RAMD_TABLE_FILE "ramdisk_table"
+#define BOOTCFG_FILE    "bootconfig"
 #define NEW_BOOT        "new-boot.img"
 
 int unpack(const char *image, bool skip_decomp = false, bool hdr = false);


### PR DESCRIPTION
bootconfig is basically another cmdline with no size limit, and a vendor_ramdisk_table dump is needed currently for any potential external parsing of the vendor_boot v4 monolithic multi-ramdisk