### PR TITLE
Disable CompatVectorFromResources

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/App.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/App.kt
@@ -6,7 +6,6 @@ import android.app.Application
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatDelegate
 import com.topjohnwu.magisk.DynAPK
 import com.topjohnwu.magisk.core.utils.AppShellInit
 import com.topjohnwu.magisk.core.utils.BusyBoxInit
@@ -25,7 +24,6 @@ open class App() : Application() {
     }
 
     init {
-        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
         Shell.setDefaultBuilder(Shell.Builder.create()
             .setFlags(Shell.FLAG_MOUNT_MASTER)
             .setInitializers(BusyBoxInit::class.java, AppShellInit::class.java)


### PR DESCRIPTION
https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setCompatVectorFromResourcesEnabled(boolean)
> Sets whether vector drawables on older platforms (< API 21) can be used within DrawableContainer resources.

> This feature defaults to disabled, since enabling it can cause issues with memory usage, and problems updating Configuration instances. If you update the configuration manually, then you probably do not want to enable this. You have been warned.

Keep `vectorDrawables.useSupportLibrary = true` and `app:srcCompat`, only disable CompatVectorFromResources.