### PR TITLE
Patch and restore `vbmeta` partition on Magisk install and uninstall

### DIFF
--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -57,18 +57,20 @@ direct_install() {
       ;;
   esac
 
-  echo "- Flashing new vbmeta image"
-  flash_image $1/new-vbmeta.img $3
-  case $? in
-    1)
-      echo "! Insufficient partition size"
-      return 1
-      ;;
-    2)
-      echo "! $2 is read only"
-      return 2
-      ;;
-  esac
+  if [ ! -z $3 ]; then
+    echo "- Flashing new vbmeta image"
+    flash_image $1/new-vbmeta.img $3
+    case $? in
+      1)
+        echo "! Insufficient partition size"
+        return 1
+        ;;
+      2)
+        echo "! $2 is read only"
+        return 2
+        ;;
+    esac
+  fi
 
   rm -f $1/new-boot.img
   rm -f $1/new-vbmeta.img

--- a/build.py
+++ b/build.py
@@ -59,7 +59,7 @@ except FileNotFoundError:
 
 cpu_count = multiprocessing.cpu_count()
 archs = ['armeabi-v7a', 'x86', 'arm64-v8a', 'x86_64']
-default_targets = ['magisk', 'magiskinit', 'magiskboot', 'busybox']
+default_targets = ['magisk', 'magiskinit', 'magiskboot', 'magiskvbmeta', 'busybox']
 support_targets = default_targets + ['magiskpolicy', 'resetprop', 'test']
 
 sdk_path = os.environ['ANDROID_SDK_ROOT']
@@ -348,6 +348,9 @@ def build_binary(args):
 
     if 'magiskboot' in args.target:
         flag += ' B_BOOT=1'
+
+    if 'magiskvbmeta' in args.target:
+        flag += ' B_VBMETA=1'
 
     if flag:
         run_ndk_build(flag)

--- a/buildSrc/src/main/java/Setup.kt
+++ b/buildSrc/src/main/java/Setup.kt
@@ -82,30 +82,30 @@ fun Project.setupApp() {
         into("src/main/jniLibs")
         into("armeabi-v7a") {
             from(rootProject.file("native/out/armeabi-v7a")) {
-                include("busybox", "magiskboot", "magiskinit", "magisk")
+                include("busybox", "magiskboot", "magiskvbmeta", "magiskinit", "magisk")
                 rename { if (it == "magisk") "libmagisk32.so" else "lib$it.so" }
             }
         }
         into("x86") {
             from(rootProject.file("native/out/x86")) {
-                include("busybox", "magiskboot", "magiskinit", "magisk")
+                include("busybox", "magiskboot", "magiskvbmeta", "magiskinit", "magisk")
                 rename { if (it == "magisk") "libmagisk32.so" else "lib$it.so" }
             }
         }
         into("arm64-v8a") {
             from(rootProject.file("native/out/arm64-v8a")) {
-                include("busybox", "magiskboot", "magiskinit", "magisk")
+                include("busybox", "magiskboot", "magiskvbmeta", "magiskinit", "magisk")
                 rename { if (it == "magisk") "libmagisk64.so" else "lib$it.so" }
             }
         }
         into("x86_64") {
             from(rootProject.file("native/out/x86_64")) {
-                include("busybox", "magiskboot", "magiskinit", "magisk")
+                include("busybox", "magiskboot", "magiskvbmeta", "magiskinit", "magisk")
                 rename { if (it == "magisk") "libmagisk64.so" else "lib$it.so" }
             }
         }
         onlyIf {
-            if (inputs.sourceFiles.files.size != 16)
+            if (inputs.sourceFiles.files.size != 20)
                 throw StopExecutionException("Please build binaries first! (./build.py binary)")
             true
         }
@@ -117,7 +117,7 @@ fun Project.setupApp() {
         inputs.property("versionCode", Config.versionCode)
         into("src/main/assets")
         from(rootProject.file("scripts")) {
-            include("util_functions.sh", "boot_patch.sh", "uninstaller.sh", "addon.d.sh")
+            include("util_functions.sh", "boot_patch.sh", "vbmeta_patch.sh", "uninstaller.sh", "addon.d.sh")
         }
         into("chromeos") {
             from(rootProject.file("tools/futility"))

--- a/native/jni/Android.mk
+++ b/native/jni/Android.mk
@@ -91,6 +91,22 @@ include $(BUILD_EXECUTABLE)
 
 endif
 
+ifdef B_VBMETA
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := magiskvbmeta
+LOCAL_STATIC_LIBRARIES := libutils
+
+LOCAL_SRC_FILES := \
+    magiskvbmeta/main.cpp \
+    magiskvbmeta/vbmeta.cpp
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/magiskboot
+LOCAL_LDFLAGS := -static
+include $(BUILD_EXECUTABLE)
+
+endif
+
 ifdef B_POLICY
 
 include $(CLEAR_VARS)

--- a/native/jni/magiskvbmeta/magiskvbmeta.hpp
+++ b/native/jni/magiskvbmeta/magiskvbmeta.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <sys/types.h>
+
+#define PATCHED    (1 << 0)
+#define OTHER      (1 << 1)
+#define INVALID    (1 << 2)
+#define NEW_VBMETA "new-vbmeta.img"
+
+int test(const char *image);
+int size(const char *image);
+int patch(const char *src_img, const char *out_img);

--- a/native/jni/magiskvbmeta/main.cpp
+++ b/native/jni/magiskvbmeta/main.cpp
@@ -1,0 +1,50 @@
+#include <utils.hpp>
+
+#include "magiskvbmeta.hpp"
+
+using namespace std;
+
+static void usage(char *arg0) {
+    fprintf(stderr,
+R"EOF(MagiskVbmeta - Vbmeta Image Modification Tool
+
+Usage: %s <action> [args...]
+
+Supported actions:
+  test <vbmetaimg>
+    Test <vbmetaimg>'s status
+    Return values:
+    0:stock    1:patched    2:other    4:invalid
+
+  size <vbmetaimg>
+    Print padded <vbmetaimg> size
+
+  patch <origvbmetaimg> [outvbmetaimg]
+    Patch <origvbmetaimg> to [outbootimg], or
+    new-vbmeta.img if not specified.
+    All disable flags will be set.)EOF", arg0);
+
+    fprintf(stderr, "\n\n");
+    exit(1);
+}
+
+int main(int argc, char *argv[]) {
+    cmdline_logging();
+    umask(0);
+
+    if (argc < 3)
+        usage(argv[0]);
+
+    string_view action(argv[1]);
+
+    if (argc > 2 && action == "test") {
+        return test(argv[2]);
+    } else if (argc > 2 && action == "size") {
+        return size(argv[2]);
+    } else if (argc > 2 && action == "patch") {
+        return patch(argv[2], argv[3] ? argv[3] : NEW_VBMETA);
+    } else {
+        usage(argv[0]);
+    }
+    return 0;
+}

--- a/native/jni/magiskvbmeta/vbmeta.cpp
+++ b/native/jni/magiskvbmeta/vbmeta.cpp
@@ -1,0 +1,90 @@
+#include <functional>
+#include <memory>
+
+#include <inttypes.h>
+#include <utils.hpp>
+
+#include "vbmeta.hpp"
+#include "bootimg.hpp"
+#include "magiskvbmeta.hpp"
+
+vbmeta_img::vbmeta_img(const char *image) {
+    mmap_ro(image, map_addr, map_size);
+}
+
+vbmeta_img::~vbmeta_img() {
+    munmap(map_addr, map_size);
+}
+
+// https://android.googlesource.com/platform/external/avb/+/refs/tags/android-12.0.0_r12/avbtool.py#203
+uint64_t round_to_multiple(uint64_t number, uint16_t size) {
+    uint16_t remainder = number % size;
+    if (remainder == 0) {
+        return number;
+    }
+    return number + size - remainder;
+}
+
+// https://android.googlesource.com/platform/external/avb/+/refs/tags/android-12.0.0_r12/libavb/avb_vbmeta_image.h#66
+// https://android.googlesource.com/platform/external/avb/+/refs/tags/android-12.0.0_r12/avbtool.py#2332
+// https://android.googlesource.com/platform/external/avb/+/refs/tags/android-12.0.0_r12/avbtool.py#732
+uint64_t calculate_size(AvbVBMetaImageHeader *header) {
+    auto authentication_data_block_size = __builtin_bswap64(header->authentication_data_block_size);
+    auto auxiliary_data_block_size = __builtin_bswap64(header->auxiliary_data_block_size);
+    return round_to_multiple(AVB_VBMETA_IMAGE_HEADER_SIZE + authentication_data_block_size + auxiliary_data_block_size, AVB_VBMETA_IMAGE_BLOCK_SIZE);
+}
+
+int test(const char *image) {
+    vbmeta_img vbmeta(image);
+    auto header = reinterpret_cast<AvbVBMetaImageHeader*>(vbmeta.map_addr);
+    if (memcmp(header->magic, AVB_MAGIC, AVB_MAGIC_LEN) == 0) {
+        auto flags = __builtin_bswap32(header->flags);
+        if (flags == 0) {
+        } else if (flags == 3) {
+            return PATCHED;
+        } else {
+            return OTHER;
+        }
+    } else {
+        return INVALID;
+    }
+    return 0;
+}
+
+int size(const char *image) {
+    vbmeta_img vbmeta(image);
+    auto header = reinterpret_cast<AvbVBMetaImageHeader*>(vbmeta.map_addr);
+    if (memcmp(header->magic, AVB_MAGIC, AVB_MAGIC_LEN) == 0) {
+        auto vbmeta_size = calculate_size(header);
+        printf("%" PRIu64 "\n", vbmeta_size);
+    } else {
+        return INVALID;
+    }
+    return 0;
+}
+
+int patch(const char *src_img, const char *out_img) {
+    vbmeta_img vbmeta(src_img);
+    auto header = reinterpret_cast<AvbVBMetaImageHeader*>(vbmeta.map_addr);
+    if (memcmp(header->magic, AVB_MAGIC, AVB_MAGIC_LEN) == 0) {
+        auto flags = __builtin_bswap32(header->flags);
+        if (flags == 0) {
+            fprintf(stderr, "Patch to vbmeta image: [%s]\n", out_img);
+            header->flags = __builtin_bswap32(3);
+
+            auto vbmeta_size = calculate_size(header);
+
+            // Create new image
+            int fd = creat(out_img, 0644);
+            xwrite(fd, header, vbmeta_size);
+            close(fd);
+        } else if (flags == 3) {
+            return PATCHED;
+        } else {
+            return OTHER;
+        }
+    } else {
+        return INVALID;
+    }
+    return 0;
+}

--- a/native/jni/magiskvbmeta/vbmeta.hpp
+++ b/native/jni/magiskvbmeta/vbmeta.hpp
@@ -1,0 +1,11 @@
+#define AVB_VBMETA_IMAGE_HEADER_SIZE 256
+#define AVB_VBMETA_IMAGE_BLOCK_SIZE  4096
+
+struct vbmeta_img {
+    // Memory map of the whole image
+    uint8_t *map_addr;
+    size_t map_size;
+
+    vbmeta_img(const char *);
+    ~vbmeta_img();
+};

--- a/native/jni/magiskvbmeta/vbmeta.hpp
+++ b/native/jni/magiskvbmeta/vbmeta.hpp
@@ -1,11 +1,2 @@
 #define AVB_VBMETA_IMAGE_HEADER_SIZE 256
 #define AVB_VBMETA_IMAGE_BLOCK_SIZE  4096
-
-struct vbmeta_img {
-    // Memory map of the whole image
-    uint8_t *map_addr;
-    size_t map_size;
-
-    vbmeta_img(const char *);
-    ~vbmeta_img();
-};

--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -104,6 +104,7 @@ main() {
   fi
 
   find_boot_image
+  find_vbmeta_image
 
   [ -z $BOOTIMAGE ] && abort "! Unable to detect target image"
   ui_print "- Target image: $BOOTIMAGE"

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -15,11 +15,15 @@
 # boot_patch.sh      script    A script to patch boot image for Magisk.
 #                  (this file) The script will use files in its same
 #                              directory to complete the patching process
+# vbmeta_patch.sh    script    A script to patch vbmeta image for Magisk.
+#                              The script will use files in its same
+#                              directory to complete the patching process
 # util_functions.sh  script    A script which hosts all functions required
 #                              for this script to work properly
 # magiskinit         binary    The binary to replace /init
 # magisk(32/64)      binary    The magisk binaries
 # magiskboot         binary    A tool to manipulate boot images
+# magiskvbmeta       binary    A tool to manipulate vbmeta images
 # chromeos           folder    This folder includes the utility and keys to sign
 #                  (optional)  chromeos boot images. Only used for Pixel C.
 #

--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -41,6 +41,7 @@ mount_partitions
 check_data
 get_flags
 find_boot_image
+find_vbmeta_image
 
 [ -z $BOOTIMAGE ] && abort "! Unable to detect target image"
 ui_print "- Target image: $BOOTIMAGE"

--- a/scripts/uninstaller.sh
+++ b/scripts/uninstaller.sh
@@ -115,7 +115,7 @@ case $((STATUS & 3)) in
     if [ -d $BACKUPDIR ]; then
       ui_print "- Restoring stock boot image"
       flash_image $BACKUPDIR/boot.img.gz $BOOTIMAGE
-      for name in dtb dtbo dtbs; do
+      for name in dtb dtbo dtbs vbmeta; do
         [ -f $BACKUPDIR/${name}.img.gz ] || continue
         IMAGE=$(find_block $name$SLOT)
         [ -z $IMAGE ] && continue

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -426,6 +426,9 @@ find_vbmeta_image() {
   VBMETAIMAGE=
   if [ ! -z $SLOT ]; then
     VBMETAIMAGE=`find_block vbmeta$SLOT`
+    if [ ! -z $VBMETAIMAGE ]; then
+      export KEEPVBMETAFLAG=true
+    fi
   fi
 }
 
@@ -482,18 +485,20 @@ install_magisk() {
       ;;
   esac
 
-  . ./vbmeta_patch.sh "$VBMETAIMAGE"
+  if [ ! -z $VBMETAIMAGE ]; then
+    . ./vbmeta_patch.sh "$VBMETAIMAGE"
 
-  ui_print "- Flashing new vbmeta image"
-  flash_image new-vbmeta.img "$VBMETAIMAGE"
-  case $? in
-    1)
-      abort "! Insufficient partition size"
-      ;;
-    2)
-      abort "! $VBMETAIMAGE is read only"
-      ;;
-  esac
+    ui_print "- Flashing new vbmeta image"
+    flash_image new-vbmeta.img "$VBMETAIMAGE"
+    case $? in
+      1)
+        abort "! Insufficient partition size"
+        ;;
+      2)
+        abort "! $VBMETAIMAGE is read only"
+        ;;
+    esac
+  fi
 
   ./magiskboot cleanup
   rm -f new-boot.img

--- a/scripts/vbmeta_patch.sh
+++ b/scripts/vbmeta_patch.sh
@@ -1,0 +1,105 @@
+#!/system/bin/sh
+#######################################################################################
+# Magisk Vbmeta Image Patcher
+#######################################################################################
+#
+# Usage: vbmeta_patch.sh <vbmetaimage>
+#
+# This script should be placed in a directory with the following files:
+#
+# File name          Type      Description
+#
+# vbmeta_patch.sh    script    A script to patch vbmeta image for Magisk.
+#                  (this file) The script will use files in its same
+#                              directory to complete the patching process
+# boot_patch.sh      script    A script to patch boot image for Magisk.
+#                              The script will use files in its same
+#                              directory to complete the patching process
+# util_functions.sh  script    A script which hosts all functions required
+#                              for this script to work properly
+# magiskinit         binary    The binary to replace /init
+# magisk(32/64)      binary    The magisk binaries
+# magiskboot         binary    A tool to manipulate boot images
+# magiskvbmeta       binary    A tool to manipulate vbmeta images
+# chromeos           folder    This folder includes the utility and keys to sign
+#                  (optional)  chromeos boot images. Only used for Pixel C.
+#
+#######################################################################################
+
+############
+# Functions
+############
+
+# Pure bash dirname implementation
+getdir() {
+  case "$1" in
+    */*)
+      dir=${1%/*}
+      if [ -z $dir ]; then
+        echo "/"
+      else
+        echo $dir
+      fi
+    ;;
+    *) echo "." ;;
+  esac
+}
+
+#################
+# Initialization
+#################
+
+if [ -z $SOURCEDMODE ]; then
+  # Switch to the location of the script file
+  cd "$(getdir "${BASH_SOURCE:-$0}")"
+  # Load utility functions
+  . ./util_functions.sh
+  # Check if 64-bit
+  api_level_arch_detect
+fi
+
+VBMETAIMAGE="$1"
+[ -e "$VBMETAIMAGE" ] || ui_print "- vbmeta image $VBMETAIMAGE does not exist!"
+
+chmod -R 755 .
+
+########
+# Check
+########
+
+# Test patch status
+ui_print "- Checking vbmeta status"
+./magiskvbmeta test "$VBMETAIMAGE"
+case $? in
+  0 )  # Stock vbmeta
+    ui_print "- Stock vbmeta image detected"
+    SIZE=$(./magiskvbmeta size "$VBMETAIMAGE" 2>/dev/null)
+    dd if=$VBMETAIMAGE of=stock_vbmeta.img bs=1 count=$SIZE 2>/dev/null
+    ;;
+  1 )  # Magisk patched
+    ui_print "! Patched vbmeta image detected"
+    rm -f stock_vbmeta.img
+    abort "! Please restore back to stock vbmeta image"
+    ;;
+  2 )  # Other patched
+    ui_print "! Unexpected vbmeta image flags detected"
+    abort "! Please restore back to stock vbmeta image"
+    ;;
+  4 )  # Invalid
+    abort "! Invalid vbmeta image detected"
+    ;;
+esac
+
+########
+# Patch
+########
+
+ui_print "- Patching vbmeta"
+./magiskvbmeta patch "$VBMETAIMAGE"
+
+########
+# Flash
+########
+
+# Reset any error code
+true


### PR DESCRIPTION
Note: All mentions of `vbmeta` below are in reference to the dedicated partition, not the segment of the `boot` partition.

- This is currently just a POC. I did just enough to make it work in ideal conditions on at least a Pixel 6. If nothing else, some checks are needed to detect if patching `vbmeta` is even necessary.
- `find_vbmeta_image` isn't needed in `uninstaller.sh` or `restore_imgs`, as `vbmeta` would be restored from backup, if it exists.
- This does nothing in `processTar`.
- I added `find_vbmeta_image` to `addon.d.sh`, as it is needed by `install_magisk`, for now, but I have no idea if it makes sense to leave it there once some checks are added.
- This uses the default block size (4096) to determine the padding size when backing up the stock `vbmeta` partition. This is not strictly necessary, since Magisk will write zeroes when flashing it on restore, but it is nice if the SHA1 matches the one from the factory image.
- Should this use the `KEEPVBMETAFLAG` env variable?
- Would it be better to add AVB 2.0 signing support? Would that even eliminate the need to patch `vbmeta`?

Related to #4955, but this does nothing to address the need for an updated `bootctl` binary