### PR TITLE
Revert "magisk: README: Correct string path for stub"

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,7 +59,7 @@ For each action, use `-h` to access help (e.g. `./build.py all -h`)
 Default string resources for the Magisk app and its stub APK are located here:
 
 - `app/src/main/res/values/strings.xml`
-- `stub/res/values/strings.xml`
+- `stub/src/main/res/values/strings.xml`
 
 Translate each and place them in the respective locations (`[module]/src/main/res/values-[lang]/strings.xml`).
 


### PR DESCRIPTION

Fixes 

>  @This reverts commit 0f71edee964a9225c82d7ccb184bf825367bd796.