### PR TITLE
Support PATCHVBMETAFLAG env variable

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/Config.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/Config.kt
@@ -109,9 +109,10 @@ object Config : PreferenceModel, DBConfig {
         else
             Value.DEFAULT_CHANNEL
 
-    @JvmStatic var keepVerity = false
-    @JvmStatic var keepEnc = false
-    @JvmStatic var recovery = false
+    @JvmField var keepVerity = false
+    @JvmField var keepEnc = false
+    @JvmField var patchVbmeta = false
+    @JvmField var recovery = false
 
     var bootId by preference(Key.BOOT_ID, "")
     var askedHome by preference(Key.ASKED_HOME, false)

--- a/app/src/main/java/com/topjohnwu/magisk/core/Info.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/Info.kt
@@ -34,6 +34,7 @@ object Info {
     @JvmField val isZygiskEnabled = System.getenv("ZYGISK_ENABLED") == "1"
     @JvmStatic val isFDE get() = crypto == "block"
     @JvmField var ramdisk = false
+    @JvmField var vbmeta = false
     @JvmField var hasGMS = true
     @JvmField val isPixel = Build.BRAND == "google"
     @JvmField val isEmulator =

--- a/app/src/main/java/com/topjohnwu/magisk/core/Info.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/Info.kt
@@ -28,20 +28,22 @@ object Info {
 
     // Device state
     @JvmStatic val env by lazy { loadState() }
-    @JvmStatic var isSAR = false
+    @JvmField var isSAR = false
     var isAB = false
     val isVirtualAB = getProperty("ro.virtual_ab.enabled", "false") == "true"
     @JvmField val isZygiskEnabled = System.getenv("ZYGISK_ENABLED") == "1"
     @JvmStatic val isFDE get() = crypto == "block"
     @JvmField var ramdisk = false
     @JvmField var vbmeta = false
-    @JvmField var hasGMS = true
-    @JvmField val isPixel = Build.BRAND == "google"
-    @JvmField val isEmulator =
-        getProperty("ro.kernel.qemu", "0") == "1" ||
-        getProperty("ro.boot.qemu", "0") == "1"
     var crypto = ""
     var noDataExec = false
+
+    @JvmField var hasGMS = true
+    @JvmField val isPixel = Build.BRAND == "google"
+    val isSamsung = Build.MANUFACTURER.equals("samsung", ignoreCase = true)
+    @JvmField val isEmulator =
+        getProperty("ro.kernel.qemu", "0") == "1" ||
+            getProperty("ro.boot.qemu", "0") == "1"
 
     val isConnected by lazy {
         ObservableBoolean(false).also { field ->

--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
@@ -357,6 +357,7 @@ abstract class MagiskInstallImpl protected constructor(
             "cd $installDir",
             "KEEPFORCEENCRYPT=${Config.keepEnc} " +
             "KEEPVERITY=${Config.keepVerity} " +
+            "PATCHVBMETAFLAG=${Config.patchVbmeta} " +
             "RECOVERYMODE=${Config.recovery} " +
             "sh boot_patch.sh $srcBoot")
 

--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
@@ -75,6 +75,7 @@ class ShellInit : Shell.Initializer() {
         Const.MAGISKTMP = getVar("MAGISKTMP")
         Info.isSAR = getBool("SYSTEM_ROOT")
         Info.ramdisk = getBool("RAMDISKEXIST")
+        Info.vbmeta = getBool("VBMETAEXIST")
         Info.isAB = getBool("ISAB")
         Info.crypto = getVar("CRYPTOTYPE")
 
@@ -82,6 +83,7 @@ class ShellInit : Shell.Initializer() {
         Config.recovery = getBool("RECOVERYMODE")
         Config.keepVerity = getBool("KEEPVERITY")
         Config.keepEnc = getBool("KEEPFORCEENCRYPT")
+        Config.patchVbmeta = getBool("PATCHVBMETAFLAG")
 
         return true
     }

--- a/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -1,6 +1,7 @@
 package com.topjohnwu.magisk.ui.install
 
 import android.net.Uri
+import android.os.Build
 import androidx.databinding.Bindable
 import androidx.lifecycle.viewModelScope
 import com.topjohnwu.magisk.BR
@@ -26,11 +27,11 @@ class InstallViewModel(
 ) : BaseViewModel() {
 
     val isRooted = Shell.rootAccess()
-    val skipOptions = Info.isEmulator || (Info.ramdisk && !Info.isFDE && Info.isSAR)
+    val skipOptions = Info.ramdisk && !Info.isFDE && Info.isSAR && !(!Info.vbmeta && Build.VERSION.SDK_INT >= 30)
     val noSecondSlot = !isRooted || Info.isPixel || Info.isVirtualAB || !Info.isAB || Info.isEmulator
 
     @get:Bindable
-    var step = if (skipOptions) 1 else 0
+    var step = if (Info.isEmulator || skipOptions) 1 else 0
         set(value) = set(value, field, { field = it }, BR.step)
 
     var _method = -1

--- a/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -1,7 +1,6 @@
 package com.topjohnwu.magisk.ui.install
 
 import android.net.Uri
-import android.os.Build
 import androidx.databinding.Bindable
 import androidx.lifecycle.viewModelScope
 import com.topjohnwu.magisk.BR
@@ -27,11 +26,12 @@ class InstallViewModel(
 ) : BaseViewModel() {
 
     val isRooted = Shell.rootAccess()
-    val skipOptions = Info.ramdisk && !Info.isFDE && Info.isSAR && !(!Info.vbmeta && Build.VERSION.SDK_INT >= 30)
+    val hideVbmeta = Info.vbmeta || Info.isSamsung || Info.isAB
+    val skipOptions = Info.isEmulator || (Info.isSAR && !Info.isFDE && hideVbmeta && Info.ramdisk)
     val noSecondSlot = !isRooted || Info.isPixel || Info.isVirtualAB || !Info.isAB || Info.isEmulator
 
     @get:Bindable
-    var step = if (Info.isEmulator || skipOptions) 1 else 0
+    var step = if (skipOptions) 1 else 0
         set(value) = set(value, field, { field = it }, BR.step)
 
     var _method = -1

--- a/app/src/main/res/layout/fragment_install_md2.xml
+++ b/app/src/main/res/layout/fragment_install_md2.xml
@@ -9,8 +9,6 @@
 
         <import type="com.topjohnwu.magisk.core.Config" />
 
-        <import type="android.os.Build" />
-
         <variable
             name="viewModel"
             type="com.topjohnwu.magisk.ui.install.InstallViewModel" />
@@ -36,7 +34,7 @@
 
             <com.google.android.material.card.MaterialCardView
                 style="@style/WidgetFoundation.Card"
-                gone="@{viewModel.skipOptions || Info.isEmulator}"
+                gone="@{viewModel.skipOptions}"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/l1"
@@ -112,7 +110,7 @@
 
                         <CheckBox
                             style="@style/WidgetFoundation.Checkbox"
-                            goneUnless="@{!Info.vbmeta &amp;&amp; Build.VERSION.SDK_INT >= 30}"
+                            gone="@{viewModel.hideVbmeta}"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:checked="@={Config.patchVbmeta}"

--- a/app/src/main/res/layout/fragment_install_md2.xml
+++ b/app/src/main/res/layout/fragment_install_md2.xml
@@ -9,6 +9,8 @@
 
         <import type="com.topjohnwu.magisk.core.Config" />
 
+        <import type="android.os.Build" />
+
         <variable
             name="viewModel"
             type="com.topjohnwu.magisk.ui.install.InstallViewModel" />
@@ -34,7 +36,7 @@
 
             <com.google.android.material.card.MaterialCardView
                 style="@style/WidgetFoundation.Card"
-                gone="@{viewModel.skipOptions}"
+                gone="@{viewModel.skipOptions || Info.isEmulator}"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/l1"
@@ -106,6 +108,15 @@
                             android:layout_height="wrap_content"
                             android:checked="@={Config.keepEnc}"
                             android:text="@string/keep_force_encryption"
+                            app:tint="?colorPrimary" />
+
+                        <CheckBox
+                            style="@style/WidgetFoundation.Checkbox"
+                            goneUnless="@{!Info.vbmeta &amp;&amp; Build.VERSION.SDK_INT >= 30}"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:checked="@={Config.patchVbmeta}"
+                            android:text="@string/patch_vbmeta"
                             app:tint="?colorPrimary" />
 
                         <CheckBox

--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -179,12 +179,6 @@ check_encryption() {
   fi
 }
 
-check_vbmeta_partition() {
-  if [ -e /dev/block/by-name/vbmeta_a ] || [ -e /dev/block/by-name/vbmeta ]; then
-    VBMETAEXIST=true
-  fi
-}
-
 ##########################
 # Non-root util_functions
 ##########################
@@ -199,6 +193,14 @@ get_flags() {
   KEEPVERITY=$SYSTEM_ROOT
   [ "$(getprop ro.crypto.state)" = "encrypted" ] && ISENCRYPTED=true || ISENCRYPTED=false
   KEEPFORCEENCRYPT=$ISENCRYPTED
+  # Although this most certainly won't work without root, keep it just in case
+  if [ -e /dev/block/by-name/vbmeta_a ] || [ -e /dev/block/by-name/vbmeta ]; then
+    VBMETAEXIST=true
+  else
+    VBMETAEXIST=false
+  fi
+  # Preset PATCHVBMETAFLAG to false in the non-root case
+  PATCHVBMETAFLAG=false
   # Do NOT preset RECOVERYMODE here
 }
 
@@ -217,7 +219,6 @@ app_init() {
   SHA1=$(grep_prop SHA1 $MAGISKTMP/config)
   check_boot_ramdisk && RAMDISKEXIST=true || RAMDISKEXIST=false
   check_encryption
-  check_vbmeta_partition
   # Make sure RECOVERYMODE has value
   [ -z $RECOVERYMODE ] && RECOVERYMODE=false
 }

--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -179,6 +179,12 @@ check_encryption() {
   fi
 }
 
+check_vbmeta_partition() {
+  if [ -e /dev/block/by-name/vbmeta_a ] || [ -e /dev/block/by-name/vbmeta ]; then
+    VBMETAEXIST=true
+  fi
+}
+
 ##########################
 # Non-root util_functions
 ##########################
@@ -211,6 +217,7 @@ app_init() {
   SHA1=$(grep_prop SHA1 $MAGISKTMP/config)
   check_boot_ramdisk && RAMDISKEXIST=true || RAMDISKEXIST=false
   check_encryption
+  check_vbmeta_partition
   # Make sure RECOVERYMODE has value
   [ -z $RECOVERYMODE ] && RECOVERYMODE=false
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <!--Install-->
     <string name="keep_force_encryption">Preserve force encryption</string>
     <string name="keep_dm_verity">Preserve AVB 2.0/dm-verity</string>
+    <string name="patch_vbmeta">Patch vbmeta in boot image</string>
     <string name="recovery_mode">Recovery Mode</string>
     <string name="install_options_title">Options</string>
     <string name="install_method_title">Method</string>

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -403,7 +403,14 @@ get_flags() {
       KEEPFORCEENCRYPT=false
     fi
   fi
-  [ -z $PATCHVBMETAFLAG ] && PATCHVBMETAFLAG=false
+  if [ -z $PATCHVBMETAFLAG ]; then
+    if [ -e /dev/block/by-name/vbmeta_a ] || [ -e /dev/block/by-name/vbmeta ]; then
+      PATCHVBMETAFLAG=false
+    else
+      PATCHVBMETAFLAG=true
+      ui_print "- Not found vbmeta partition, patch vbmetaflag"
+    fi
+  fi
   [ -z $RECOVERYMODE ] && RECOVERYMODE=false
 }
 

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -377,8 +377,10 @@ umount_apex() {
   unset BOOTCLASSPATH
 }
 
+# After calling this method, the following variables will be set:
+# KEEPVERITY, KEEPFORCEENCRYPT, RECOVERYMODE, PATCHVBMETAFLAG,
+# ISENCRYPTED, VBMETAEXIST
 get_flags() {
-  # override variables
   getvar KEEPVERITY
   getvar KEEPFORCEENCRYPT
   getvar RECOVERYMODE
@@ -403,12 +405,15 @@ get_flags() {
       KEEPFORCEENCRYPT=false
     fi
   fi
+  VBMETAEXIST=false
+  local VBMETAIMG=$(find_block vbmeta vbmeta_a)
+  [ -n "$VBMETAIMG" ] && VBMETAEXIST=true
   if [ -z $PATCHVBMETAFLAG ]; then
-    if [ -e /dev/block/by-name/vbmeta_a ] || [ -e /dev/block/by-name/vbmeta ]; then
+    if $VBMETAEXIST; then
       PATCHVBMETAFLAG=false
     else
       PATCHVBMETAFLAG=true
-      ui_print "- Not found vbmeta partition, patch vbmetaflag"
+      ui_print "- Cannot find vbmeta partition, patch vbmeta in boot image"
     fi
   fi
   [ -z $RECOVERYMODE ] && RECOVERYMODE=false


### PR DESCRIPTION
https://t.me/s/vvb2060Channel/577


https://cs.android.com/android/platform/superproject/+/master:external/avb/libavb/avb_vbmeta_image.h;l=177;drc=de53827b226bccef7407e4c253b0152e8d9f8e04

```cpp
  /* 120: Flags from the AvbVBMetaImageFlags enumeration. This must be
   * set to zero if the vbmeta image is not a top-level image.
   */
  uint32_t flags;
```

https://cs.android.com/android/platform/superproject/+/master:external/avb/libavb/avb_slot_verify.c;l=785;drc=c0debbfd55f08a755b006550779c23e707d30b6d
```cpp
  /* If we're the toplevel, assign flags so they'll be passed down. */
  if (is_main_vbmeta) {
    toplevel_vbmeta_flags = (AvbVBMetaImageFlags)vbmeta_header.flags;
  } else {
    if (vbmeta_header.flags != 0) {
      ret = AVB_SLOT_VERIFY_RESULT_ERROR_INVALID_METADATA;
      avb_errorv(full_partition_name,
                 ": chained vbmeta image has non-zero flags\n",
                 NULL);
      goto out;
    }
  }
```
If vbmeta partition exists, the vbmeta inside the boot image, flag must be 0
