### PR TITLE
Fix: window on Android 11. setSystemUIVisibility was deprecated in API  level 29

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -39,7 +39,7 @@ For Magisk app crashes, record and upload the logcat when the crash occurs.
 ## Building and Development
 
 - Magisk builds on any OS Android Studio supports. Install Android Studio and do the initial setups.
-- Clone sources: `git clone --recurse-submodules https://github.com/topjohnwu/Magisk.git`
+- Clone sources: `git clone --recurse-submodules https://github.com/nocsg/Magisk.git`
 - Install Python 3.6+ \
 (Windows only: select **'Add Python to PATH'** in installer, and run `pip install colorama` after install)
 - Configure to use the JDK bundled in Android Studio:

--- a/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIActivity.kt
@@ -6,6 +6,9 @@ import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.View
+import android.view.WindowInsets
+import android.view.WindowInsetsController
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.res.use
 import androidx.databinding.DataBindingUtil
@@ -41,6 +44,7 @@ abstract class BaseUIActivity<VM : BaseViewModel, Binding : ViewDataBinding> :
         AppCompatDelegate.setDefaultNightMode(theme)
     }
 
+    @RequiresApi(Build.VERSION_CODES.R)
     override fun onCreate(savedInstanceState: Bundle?) {
         layoutInflater.factory2 = LayoutInflaterFactory(delegate)
 
@@ -54,12 +58,10 @@ abstract class BaseUIActivity<VM : BaseViewModel, Binding : ViewDataBinding> :
             .use { it.getDrawable(0) }
             .also { window.setBackgroundDrawable(it) }
 
-        window?.decorView?.let {
-            it.systemUiVisibility = (it.systemUiVisibility
-                    or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
-        }
+        window.decorView.windowInsetsController?.hide(WindowInsets.Type.statusBars())
+        window.decorView.windowInsetsController?.hide(WindowInsets.Type.navigationBars())
+        window.decorView.windowInsetsController?.systemBarsBehavior = WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        window.setDecorFitsSystemWindows(false)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             window?.decorView?.post {

--- a/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIActivity.kt
@@ -1,6 +1,5 @@
 package com.topjohnwu.magisk.arch
 
-import android.content.res.Resources
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle

--- a/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIActivity.kt
@@ -66,7 +66,7 @@ abstract class BaseUIActivity<VM : BaseViewModel, Binding : ViewDataBinding> :
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             window?.decorView?.post {
                 // If navigation bar is short enough (gesture navigation enabled), make it transparent
-                if (window.decorView.rootWindowInsets?.systemWindowInsetBottom ?: 0 < Resources.getSystem().displayMetrics.density * 40) {
+                if (window.decorView.rootWindowInsets?.isVisible(WindowInsets.Type.navigationBars()) == false) {
                     window.navigationBarColor = Color.TRANSPARENT
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                         window.navigationBarDividerColor = Color.TRANSPARENT


### PR DESCRIPTION
Fix window on Android 11. `setSystemUIVisibility` was `deprecated` in API  level 29, `setSystemUIVisibility` can't adapt accurate full screen on Android 11 when The device is Hollowed screen. 