### PR TITLE
Explain how to extract boot.img from the ROM zip

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -34,7 +34,12 @@ Otherwise, continue to [Patching Images](#patching-images).
 If your device has boot ramdisk, you need a copy of the `boot.img`<br>
 If your device does **NOT** have boot ramdisk, you need a copy of the `recovery.img`.
 
-You should be able to extract the file you need from official firmware packages or your custom ROM zip (if using one). If you are still having trouble, go to [XDA-Developers](https://forum.xda-developers.com/) and look for resources, guides, discussions, or ask for help in your device's forum.
+You should be able to extract the file you need from official firmware packages or your custom ROM zip (if using one). You can use one of the following to extract these files from a system image file (`payload.bin` inside a system image zip):
+
+* [payload-dumper-go](https://github.com/ssut/payload-dumper-go) (binary downloads here: [payload-dumper-go downloads](https://github.com/ssut/payload-dumper-go/releases/latest))
+* [python payload_dumper](https://github.com/vm03/payload_dumper) (requires working installation of python, [python dumper instructions on XDA Developers](https://forum.xda-developers.com/t/guide-how-to-extract-payload-bin-from-ota.3830962/))
+
+If you are still having trouble, go to [XDA-Developers](https://forum.xda-developers.com/) and look for resources, guides, discussions, or ask for help in your device's forum.
 
 - Copy the boot/recovery image to your device
 - Press the **Install** button in the Magisk card


### PR DESCRIPTION
I had to do some googling to make the jump from "knowing I needed a `boot.img`" to the understanding that they were inside the zip I already had used to flash my LineageOS ROM. Hopefully this patch will make it easier for those who come after me.

The golang one is easier to use because it has prebuilt binaries that just work, whereas the second one requires a python + pip install and some additional setup which is a bit of a faff.

My entire journey is recorded at https://timwise.co.uk/2021/12/17/phone-setup-notes/#magisk if you're interested in more context.