### PR TITLE
Add an old cgroup path

### DIFF
--- a/native/jni/core/daemon.cpp
+++ b/native/jni/core/daemon.cpp
@@ -305,6 +305,7 @@ static void daemon_entry() {
     // Escape from cgroup
     int pid = getpid();
     switch_cgroup("/acct", pid);
+    switch_cgroup("/dev/memcg/apps", pid);
     switch_cgroup("/dev/cg2_bpf", pid);
     switch_cgroup("/sys/fs/cgroup", pid);
 


### PR DESCRIPTION
Fix topjohnwu#5125
cgroup root path might be mem cgroup instead of acct, especially on low-ram devices.
https://android.googlesource.com/platform/system/core/+/bc131c3244a6aa4961092ba08285f9d0435a8882%5E%21/#F0