### PR TITLE
Only store sepolicy rules into partitions in ext4 format

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -628,13 +628,13 @@ copy_sepolicy_rules() {
     RULESDIR=$NVBASE/modules
   elif [ -d /data/unencrypted ] && ! grep ' /data ' /proc/mounts | grep -qE 'dm-|f2fs'; then
     RULESDIR=/data/unencrypted/magisk
-  elif grep -q ' /cache ' /proc/mounts; then
+  elif grep ' /cache ' /proc/mounts | grep -q 'ext4' ; then
     RULESDIR=/cache/magisk
-  elif grep -q ' /metadata ' /proc/mounts; then
+  elif grep ' /metadata ' /proc/mounts | grep -q 'ext4' ; then
     RULESDIR=/metadata/magisk
-  elif grep -q ' /persist ' /proc/mounts; then
+  elif grep ' /persist ' /proc/mounts | grep -q 'ext4' ; then
     RULESDIR=/persist/magisk
-  elif grep -q ' /mnt/vendor/persist ' /proc/mounts; then
+  elif grep ' /mnt/vendor/persist ' /proc/mounts | grep -q 'ext4' ; then
     RULESDIR=/mnt/vendor/persist/magisk
   else
     ui_print "- Unable to find sepolicy rules dir"


### PR DESCRIPTION
Partially fix #5013
When installing from recovery, previous implementation may select f2fs partitions to store sepolicy rules, but magiskinit won't mount them and unable to load sepolicy rules.
This is not a complete fix because his device does not mount /persist partition in recovery mode, but I didn't mount it in this PR (see https://github.com/topjohnwu/Magisk/issues/5013#issuecomment-1003553933). I just submit this to make sure sepolicy.rule won't be installed to non-ext4 partitions.