### PR TITLE
Find suitable anchor view for SnackBar

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIActivity.kt
@@ -35,6 +35,7 @@ abstract class BaseUIActivity<VM : BaseViewModel, Binding : ViewDataBinding> :
 
     open val navHostId: Int = 0
     open val snackbarView get() = binding.root
+    open val snackbarAnchorView: View? get() = null
 
     init {
         val theme = Config.darkTheme

--- a/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/arch/BaseUIFragment.kt
@@ -22,6 +22,7 @@ abstract class BaseUIFragment<VM : BaseViewModel, Binding : ViewDataBinding> :
 
     override val viewRoot: View get() = binding.root
     private val navigation get() = activity.navigation
+    open val snackbarAnchorView: View? get() = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/topjohnwu/magisk/events/SnackbarEvent.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/events/SnackbarEvent.kt
@@ -30,13 +30,14 @@ class SnackbarEvent constructor(
 
     private fun snackbar(
         view: View,
+        anchor: View?,
         message: String,
         length: Int,
         builder: Snackbar.() -> Unit
-    ) = Snackbar.make(view, message, length).apply(builder).show()
+    ) = Snackbar.make(view, message, length).setAnchorView(anchor).apply(builder).show()
 
     override fun invoke(activity: BaseUIActivity<*, *>) {
-        snackbar(activity.snackbarView,
+        snackbar(activity.snackbarView, activity.snackbarAnchorView,
             msg.getText(activity.resources).toString(),
             length, builder)
     }

--- a/app/src/main/java/com/topjohnwu/magisk/ui/MainActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/MainActivity.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.WindowManager
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.view.forEach
+import androidx.core.view.isVisible
 import androidx.interpolator.view.animation.FastOutLinearInInterpolator
 import androidx.interpolator.view.animation.LinearOutSlowInInterpolator
 import androidx.navigation.NavDirections
@@ -36,6 +37,15 @@ class MainActivity : BaseMainActivity<MainViewModel, ActivityMainMd2Binding>() {
     override val layoutRes = R.layout.activity_main_md2
     override val viewModel by viewModel<MainViewModel>()
     override val navHostId: Int = R.id.main_nav_host
+    override val snackbarAnchorView: View?
+        get() {
+            val fragmentAnchor = currentFragment?.snackbarAnchorView
+            return when {
+                fragmentAnchor?.isVisible == true -> fragmentAnchor
+                binding.mainNavigation.isVisible -> return binding.mainNavigation
+                else -> null
+            }
+        }
 
     private var isRootFragment = true
 

--- a/app/src/main/java/com/topjohnwu/magisk/ui/log/LogFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/log/LogFragment.kt
@@ -20,6 +20,7 @@ class LogFragment : BaseUIFragment<LogViewModel, FragmentLogMd2Binding>() {
 
     override val layoutRes = R.layout.fragment_log_md2
     override val viewModel by viewModel<LogViewModel>()
+    override val snackbarAnchorView get() = binding.logFilterToggle
 
     private var actionSave: MenuItem? = null
     private var isMagiskLogVisible

--- a/app/src/main/java/com/topjohnwu/magisk/ui/module/ModuleFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/module/ModuleFragment.kt
@@ -22,6 +22,14 @@ class ModuleFragment : BaseUIFragment<ModuleViewModel, FragmentModuleMd2Binding>
 
     override val layoutRes = R.layout.fragment_module_md2
     override val viewModel by viewModel<ModuleViewModel>()
+    override val snackbarAnchorView: View
+        get() {
+            return if (isFilterVisible) {
+                binding.moduleFilterInclude.moduleFilterTitleSearch
+            } else {
+                binding.moduleFilterToggle
+            }
+        }
 
     private val listeners = hashSetOf<EndlessRecyclerScrollListener>()
 

--- a/app/src/main/res/layout/include_log_magisk.xml
+++ b/app/src/main/res/layout/include_log_magisk.xml
@@ -34,7 +34,7 @@
                     android:textAppearance="@style/AppearanceFoundation.Caption"
                     android:textSize="10sp"
                     android:paddingTop="@dimen/internal_action_bar_size"
-                    android:paddingBottom="120dp"
+                    android:paddingBottom="128dp"
                     app:layout_fitsSystemWindowsInsets="top|bottom"
                     tools:text="@tools:sample/lorem/random" />
 


### PR DESCRIPTION
This will fix the SnackBar position if BottomNav or FAB is visible.

Fix #5163
Fix #5135

![image](https://user-images.githubusercontent.com/12999176/148348291-4a3a0219-e0e1-4c69-a373-25af5c121262.png)
![image](https://user-images.githubusercontent.com/12999176/148348317-ab1b01f6-cf54-40b2-bb69-24b5930d7b86.png)

* According to [the guideline](https://material.io/components/snackbars#placement), Snackbar should show above FABs.