### PR TITLE
Enable installation to inactive slot on Pixel devices

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/Info.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/Info.kt
@@ -39,7 +39,6 @@ object Info {
     var noDataExec = false
 
     @JvmField var hasGMS = true
-    @JvmField val isPixel = Build.BRAND == "google"
     val isSamsung = Build.MANUFACTURER.equals("samsung", ignoreCase = true)
     @JvmField val isEmulator =
         getProperty("ro.kernel.qemu", "0") == "1" ||

--- a/app/src/main/java/com/topjohnwu/magisk/core/Info.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/Info.kt
@@ -30,7 +30,6 @@ object Info {
     @JvmStatic val env by lazy { loadState() }
     @JvmField var isSAR = false
     var isAB = false
-    val isVirtualAB = getProperty("ro.virtual_ab.enabled", "false") == "true"
     @JvmField val isZygiskEnabled = System.getenv("ZYGISK_ENABLED") == "1"
     @JvmStatic val isFDE get() = crypto == "block"
     @JvmField var ramdisk = false

--- a/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -28,7 +28,7 @@ class InstallViewModel(
     val isRooted = Shell.rootAccess()
     val hideVbmeta = Info.vbmeta || Info.isSamsung || Info.isAB
     val skipOptions = Info.isEmulator || (Info.isSAR && !Info.isFDE && hideVbmeta && Info.ramdisk)
-    val noSecondSlot = !isRooted || Info.isPixel || Info.isVirtualAB || !Info.isAB || Info.isEmulator
+    val noSecondSlot = !isRooted || Info.isVirtualAB || !Info.isAB || Info.isEmulator
 
     @get:Bindable
     var step = if (skipOptions) 1 else 0

--- a/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -28,7 +28,7 @@ class InstallViewModel(
     val isRooted = Shell.rootAccess()
     val hideVbmeta = Info.vbmeta || Info.isSamsung || Info.isAB
     val skipOptions = Info.isEmulator || (Info.isSAR && !Info.isFDE && hideVbmeta && Info.ramdisk)
-    val noSecondSlot = !isRooted || Info.isVirtualAB || !Info.isAB || Info.isEmulator
+    val noSecondSlot = !isRooted || !Info.isAB || Info.isEmulator
 
     @get:Bindable
     var step = if (skipOptions) 1 else 0


### PR DESCRIPTION
9c93fe6 updated the `bootctl` binary, which was the only thing preventing installation to the inactive slot from working on Pixel devices. This removes the check that hides the button on those devices.

Tested on a Pixel 5a and a Pixel 6.

Closes #4955