### PR TITLE
Fix classloader when restoring bottom nav state

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/widget/ConcealableBottomNavigationView.java
+++ b/app/src/main/java/com/topjohnwu/magisk/widget/ConcealableBottomNavigationView.java
@@ -7,10 +7,10 @@ import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.AttributeSet;
-import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.customview.view.AbsSavedState;
 import androidx.interpolator.view.animation.FastOutLinearInInterpolator;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
@@ -101,12 +101,12 @@ public class ConcealableBottomNavigationView extends BottomNavigationView {
         }
     }
 
-    static class SavedState extends View.BaseSavedState {
+    static class SavedState extends AbsSavedState {
 
         public boolean isHidden;
 
         public SavedState(Parcel source) {
-            super(source);
+            super(source, ConcealableBottomNavigationView.class.getClassLoader());
             isHidden = source.readByte() != 0;
         }
 
@@ -120,7 +120,7 @@ public class ConcealableBottomNavigationView extends BottomNavigationView {
             out.writeByte(isHidden ? (byte) 1 : (byte) 0);
         }
 
-        public static final Creator<SavedState> CREATOR = new Creator<SavedState>() {
+        public static final Creator<SavedState> CREATOR = new Creator<>() {
 
             @Override
             public SavedState createFromParcel(Parcel source) {


### PR DESCRIPTION
There is a regression since #5207:
```
android.os.BadParcelableException: ClassNotFoundException when unmarshalling: com.google.android.material.navigation.NavigationBarView$SavedState
        at android.os.Parcel.readParcelableCreator(Parcel.java:3042)
        at android.os.Parcel.readParcelable(Parcel.java:2964)
        at android.view.AbsSavedState.<init>(AbsSavedState.java:67)
        at android.view.View$BaseSavedState.<init>(View.java:28265)
        at android.view.View$BaseSavedState.<init>(View.java:28254)
        at com.topjohnwu.magisk.widget.ConcealableBottomNavigationView$SavedState.<init>(ConcealableBottomNavigationView.java:109)
        at com.topjohnwu.magisk.widget.ConcealableBottomNavigationView$SavedState$1.createFromParcel(ConcealableBottomNavigationView.java:127)
        at com.topjohnwu.magisk.widget.ConcealableBottomNavigationView$SavedState$1.createFromParcel(ConcealableBottomNavigationView.java:123)
        at android.os.Parcel.readParcelable(Parcel.java:2973)
        at android.os.Parcel.readValue(Parcel.java:2866)
        at android.os.Parcel.readSparseArrayInternal(Parcel.java:3327)
        at android.os.Parcel.readSparseArray(Parcel.java:2484)
        at android.os.Parcel.readValue(Parcel.java:2923)
        at android.os.Parcel.readArrayMapInternal(Parcel.java:3244)
        at android.os.BaseBundle.initializeFromParcelLocked(BaseBundle.java:292)
        at android.os.BaseBundle.unparcel(BaseBundle.java:236)
        at android.os.Bundle.getSparseParcelableArray(Bundle.java:1029)
        at com.android.internal.policy.PhoneWindow.restoreHierarchyState(PhoneWindow.java:2156)
        at android.app.Activity.onRestoreInstanceState(Activity.java:1570)
        at com.topjohnwu.magisk.core.base.BaseActivity.onRestoreInstanceState(BaseActivity.kt:80)
        at android.app.Activity.performRestoreInstanceState(Activity.java:1523)
        at android.app.Instrumentation.callActivityOnRestoreInstanceState(Instrumentation.java:1353)
        at android.app.ActivityThread.handleStartActivity(ActivityThread.java:3310)
        at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:221)
        at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:201)
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:173)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
```