### PR TITLE
Properly prevent fix env dialog from constantly showing

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/home/HomeViewModel.kt
@@ -80,7 +80,9 @@ class HomeViewModel(
         it.bindExtra(BR.viewModel, this)
     }
 
-    private var checkedEnv = false
+    companion object {
+        private var checkedEnv = false
+    }
 
     override fun refresh() = viewModelScope.launch {
         state = State.LOADING


### PR DESCRIPTION
ViewModel has been reconstructed when switching fragment so we lost previous state.