### PR TITLE
Fix crash when zip is malformat

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/ZipUtils.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/ZipUtils.kt
@@ -38,11 +38,7 @@ fun InputStream.unzip(folder: File, path: String, junkPath: Boolean) {
             }
             SuFileOutputStream.open(dest).use { out -> zin.copyTo(out) }
         }
-    } catch (e: IOException) {
-        e.printStackTrace()
-        throw e
-    } catch (e: Throwable) {
-        e.printStackTrace()
+    } catch (e: IllegalArgumentException) {
         throw IOException(e)
     }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/ZipUtils.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/ZipUtils.kt
@@ -41,5 +41,8 @@ fun InputStream.unzip(folder: File, path: String, junkPath: Boolean) {
     } catch (e: IOException) {
         e.printStackTrace()
         throw e
+    } catch (e: Throwable) {
+        e.printStackTrace()
+        throw IOException(e)
     }
 }


### PR DESCRIPTION
`getNextEntry` may also throw `IllegalArgumentException`