### PR TITLE
Clarify "show OS apps"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,7 +92,7 @@
 
     <!--MagiskHide-->
     <string name="show_system_app">Show system apps</string>
-    <string name="show_os_app">Show OS apps</string>
+    <string name="show_os_app">Show device-specific apps</string>
     <string name="hide_filter_hint">Filter by name</string>
     <string name="hide_search">Search</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,8 +91,8 @@
     <!--SafetyNet-->
 
     <!--MagiskHide-->
-    <string name="show_system_app">Show system apps</string>
-    <string name="show_os_app">Show device-specific apps</string>
+    <string name="show_system_app">Show updatable system apps</string>
+    <string name="show_os_app">Show fixed system apps</string>
     <string name="hide_filter_hint">Filter by name</string>
     <string name="hide_search">Search</string>
 


### PR DESCRIPTION
~Looking at how the "show OS apps" toggle works on Magisk 24.1, I think this is what you really meant - apps that are specific to a device model, added by the OEM.~
Clarification added by vvb2060, so maybe "updatable" vs "fixed" are better terms - updated the PR as well.

Right now the words "system" and "OS" are too similar and don't really convey the difference...