### PR TITLE
Make sure busybox can be executed recursively

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
@@ -42,7 +42,7 @@ class ShellInit : Shell.Initializer() {
             if (shell.isRoot) {
                 add("export MAGISKTMP=\$(magisk --path)/.magisk")
                 // Test if we can properly execute stuff in /data
-                Info.noDataExec = !shell.newJob().add("$localBB true").exec().isSuccess
+                Info.noDataExec = !shell.newJob().add("$localBB sh -c \"$localBB true\"").exec().isSuccess
             }
 
             if (Info.noDataExec) {


### PR DESCRIPTION
Busybox will execute itself. On some older Samsung devices, when it is located in /data, it will not have rights to execute other programs including itself. We should also relocate busybox in this case to workaround Samsung bullshit.
See also topjohnwu/ndk-busybox@bdc8655
Fix the "app doesn't detect installed Magisk" issue in #4174