### PR TITLE
Invalidate Samsung's persist.sys.zygote.early

### DIFF
--- a/native/jni/init/rootdir.cpp
+++ b/native/jni/init/rootdir.cpp
@@ -31,6 +31,12 @@ static void patch_init_rc(const char *src, const char *dest, const char *tmp_dir
             fprintf(rc, "service flash_recovery /system/bin/xxxxx\n");
             return true;
         }
+        // Samsung's persist.sys.zygote.early will start zygotes before actual post-fs-data phase
+        if (str_starts(line, "on property:persist.sys.zygote.early=")) {
+            LOGD("Invalidate persist.sys.zygote.early\n");
+            fprintf(rc, "on property:persist.sys.zygote.early.xxxxx=true\n");
+            return true;
+        }
         // Else just write the line
         fprintf(rc, "%s", line.data());
         return true;


### PR DESCRIPTION
Fix #5299, fix #5328, fix #5308
Samsung FDE devices with the "persist.sys.zygote.early=true" property will cause zygotes are started before actual post-fs-data phase, but according to the Magisk document, the post-fs-data phase always happened before Zygote is started. Features assume that behaviour (like Zygisk and modules that need to control zygote) will not work. To avoid breaking existing modules, we simply invalidate the property to avoid this and make the actual behaviour matches the document.

Co-authored-by: LoveSy <shana@zju.edu.cn>