### PR TITLE
Cleanup preload before unmounting with zygisk

### DIFF
--- a/native/jni/zygisk/deny/deny.hpp
+++ b/native/jni/zygisk/deny/deny.hpp
@@ -21,6 +21,7 @@ void ls_list(int client);
 bool is_deny_target(int uid, std::string_view process);
 
 void revert_unmount();
+void cleanup_preload();
 
 extern std::atomic<bool> denylist_enforced;
 extern std::atomic<int> cached_manager_app_id;

--- a/native/jni/zygisk/deny/revert.cpp
+++ b/native/jni/zygisk/deny/revert.cpp
@@ -2,6 +2,7 @@
 
 #include <magisk.hpp>
 #include <utils.hpp>
+#include <link.h>
 
 #include "deny.hpp"
 
@@ -38,4 +39,126 @@ void revert_unmount() {
 
     for (auto &s : reversed(targets))
         lazy_unmount(s.data());
+}
+
+void cleanup_preload() {
+    char buff[256];
+    off_t load_addr;
+#if defined(__LP64__)
+    std::string elf = "/linker64";
+#else
+    std::string elf = "/linker";
+#endif
+    bool found = false;
+    FILE *maps = fopen("/proc/self/maps", "r");
+    while (fgets(buff, sizeof(buff), maps)) {
+        if ((strstr(buff, "r-xp") || strstr(buff, "r--p")) && strstr(buff, elf.data())) {
+            std::string_view b = buff;
+            if (auto begin = b.find_last_of(' '); begin != std::string_view::npos && b[++begin] == '/') {
+                found = true;
+                elf = b.substr(begin);
+                if (elf.back() == '\n') elf.pop_back();
+                break;
+            }
+        }
+    }
+
+    fclose(maps);
+    char *next = buff;
+    load_addr = strtoul(buff, &next, 16);
+    if (!found || next == buff) {
+        return;
+    }
+
+    int fd = open(elf.data(), O_RDONLY);
+
+    if (fd < 0) {
+        return;
+    }
+    size_t header_size = lseek(fd, 0, SEEK_END);
+
+    if (header_size <= 0) {
+        close(fd);
+        return;
+    }
+
+    auto header_mmap = mmap(nullptr, header_size, PROT_READ, MAP_SHARED, fd, 0);
+    auto *header = reinterpret_cast<ElfW(Ehdr) *>(header_mmap);
+    auto header_diff = reinterpret_cast<uintptr_t>(header);
+
+    close(fd);
+
+    auto *section_header = reinterpret_cast<ElfW(Shdr) *>(header_diff + header->e_shoff);
+
+    auto shoff = reinterpret_cast<uintptr_t>(section_header);
+    char *section_str = reinterpret_cast<char *>(
+            header_diff +section_header[header->e_shstrndx].sh_offset);
+
+    off_t bias = -4396;
+
+    ElfW(Shdr) *strtab = nullptr;
+    ElfW(Shdr) *dynsym = nullptr;
+    ElfW(Sym) *symtab_start = nullptr;
+    ElfW(Off) symtab_count = 0;
+    ElfW(Off) symstr_offset_for_symtab = 0;
+    ElfW(Off) symtab_offset;
+    ElfW(Off) symtab_size;
+
+    for (int i = 0; i < header->e_shnum; i++, shoff += header->e_shentsize) {
+        auto *section_h = (ElfW(Shdr) *) shoff;
+        char *sname = section_h->sh_name + section_str;
+        auto entsize = section_h->sh_entsize;
+        switch (section_h->sh_type) {
+            case SHT_DYNSYM: {
+                if (bias == -4396) {
+                    dynsym = section_h;
+                }
+                break;
+            }
+            case SHT_SYMTAB: {
+                if (strcmp(sname, ".symtab") == 0) {
+                    symtab_offset = section_h->sh_offset;
+                    symtab_size = section_h->sh_size;
+                    symtab_count = symtab_size / entsize;
+                    symtab_start = reinterpret_cast<ElfW(Sym) *>(header_diff + symtab_offset);
+                }
+                break;
+            }
+            case SHT_STRTAB: {
+                if (bias == -4396) {
+                    strtab = section_h;
+                }
+                if (strcmp(sname, ".strtab") == 0) {
+                    symstr_offset_for_symtab = section_h->sh_offset;
+                }
+                break;
+            }
+            case SHT_PROGBITS: {
+                if (strtab == nullptr || dynsym == nullptr) break;
+                if (bias == -4396) {
+                    bias = (off_t) section_h->sh_addr - (off_t) section_h->sh_offset;
+                }
+                break;
+            }
+        }
+    }
+
+    if (symtab_start != nullptr && symstr_offset_for_symtab != 0) {
+        for (ElfW(Off) i = 0; i < symtab_count; i++) {
+            unsigned int st_type = ELF_ST_TYPE(symtab_start[i].st_info);
+            const char *st_name = reinterpret_cast<const char *>(
+                    header_diff + symstr_offset_for_symtab + symtab_start[i].st_name);
+            if ((st_type == STT_FUNC || st_type == STT_OBJECT) && symtab_start[i].st_size) {
+                if (strcmp(st_name, "__dl__ZL13g_ld_preloads") == 0) {
+                    auto *preloadVector = reinterpret_cast<std::vector<void *> *>(
+                            symtab_start[i].st_value + load_addr - bias);
+                    if (preloadVector != nullptr && !preloadVector->empty()) {
+                        preloadVector->clear();
+                    }
+                }
+            }
+        }
+    }
+
+    munmap(header_mmap, header_size);
 }

--- a/native/jni/zygisk/hook.cpp
+++ b/native/jni/zygisk/hook.cpp
@@ -156,6 +156,7 @@ DCL_HOOK_FUNC(int, unshare, int flags) {
     int res = old_unshare(flags);
     if (g_ctx && (flags & CLONE_NEWNS) != 0 && res == 0) {
         if (g_ctx->state[DO_UNMOUNT]) {
+            cleanup_preload();
             revert_unmount();
         } else {
             umount2("/system/bin/app_process64", MNT_DETACH);


### PR DESCRIPTION
This is pull request cleanup the preload register on the Andorid linker before unmount on a zygisk process.

The goal of DenyList is to avoid process tampering, and make zygisk unloads itself.
But the linker often still keep a zygisk `soinfo` reference inside the preload register.
This is not a problem if `zygisk` is still mounted on the device, but **it can be still a problem** if the `zygisk` binary is **not accessible**.

This code may not look the best and may need a bit more cleaning, but the code is working perfectly on my device.
Note: My device is OxygenOS (Stock) Android 11

Inspired from https://github.com/LSPosed/NativeDetector code, and used some elf reader (GPLv3) code.
The elf reader code was striped to the minimum and transformed for performance. (and stability)
(There was no tutorials on how to read elf properly, I wanted to make it my own reader from scratch but I couldn't)

I post this PR as a draft for the code to be revived and improved.
Please be kind as C++ is not my main programing language.