### PR TITLE
Refactor Zygisk loading

### DIFF
--- a/native/jni/utils/missing.hpp
+++ b/native/jni/utils/missing.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <sys/syscall.h>
+#include <linux/fcntl.h>
 #include <unistd.h>
+#include <cerrno>
+#include <cstdio>
 
 static inline int sigtimedwait(const sigset_t* set, siginfo_t* info, const timespec* timeout) {
     union {
@@ -10,4 +13,14 @@ static inline int sigtimedwait(const sigset_t* set, siginfo_t* info, const times
     } s{};
     s.set = *set;
     return syscall(__NR_rt_sigtimedwait, &s.set64, info, timeout, sizeof(sigset64_t));
+}
+
+static inline int fexecve(int fd, char* const* argv, char* const* envp) {
+    syscall(__NR_execveat, fd, "", argv, envp, AT_EMPTY_PATH);
+    if (errno == ENOSYS) {
+        char buf[256];
+        std::snprintf(buf, sizeof(buf), "/proc/self/fd/%d", fd);
+        execve(buf, argv, envp);
+    }
+    return -1;
 }

--- a/native/jni/zygisk/hook.cpp
+++ b/native/jni/zygisk/hook.cpp
@@ -1,3 +1,4 @@
+#include <android/dlext.h>
 #include <dlfcn.h>
 #include <sys/mount.h>
 #include <xhook.h>
@@ -147,7 +148,6 @@ DCL_HOOK_FUNC(int, jniRegisterNativeMethods,
 // Skip actual fork and return cached result if applicable
 // Also unload first stage zygisk if necessary
 DCL_HOOK_FUNC(int, fork) {
-    unload_first_stage();
     return (g_ctx && g_ctx->pid >= 0) ? g_ctx->pid : old_fork();
 }
 
@@ -360,15 +360,17 @@ uint32_t ZygiskModule::getFlags() {
 }
 
 void HookContext::run_modules_pre(const vector<int> &fds) {
-    char buf[256];
 
     // Since we directly use the pointer to elements in the vector, in order to prevent dangling
     // pointers, the vector has to be pre-allocated to ensure reallocation does not occur
     modules.reserve(fds.size());
 
     for (int i = 0; i < fds.size(); ++i) {
-        snprintf(buf, sizeof(buf), "/proc/self/fd/%d", fds[i]);
-        if (void *h = dlopen(buf, RTLD_LAZY)) {
+        android_dlextinfo info {
+                .flags = ANDROID_DLEXT_FORCE_LOAD | ANDROID_DLEXT_USE_LIBRARY_FD,
+                .library_fd = fds[i],
+        };
+        if (void *h = android_dlopen_ext("/jit-cache", RTLD_LAZY, &info)) {
             if (void *e = dlsym(h, "zygisk_module_entry")) {
                 modules.emplace_back(i, h, e);
             }

--- a/native/jni/zygisk/hook.cpp
+++ b/native/jni/zygisk/hook.cpp
@@ -1,8 +1,9 @@
 #include <android/dlext.h>
-#include <dlfcn.h>
 #include <sys/mount.h>
-#include <xhook.h>
+#include <dlfcn.h>
 #include <bitset>
+
+#include <xhook.h>
 
 #include <utils.hpp>
 #include <flags.h>
@@ -367,8 +368,8 @@ void HookContext::run_modules_pre(const vector<int> &fds) {
 
     for (int i = 0; i < fds.size(); ++i) {
         android_dlextinfo info {
-                .flags = ANDROID_DLEXT_FORCE_LOAD | ANDROID_DLEXT_USE_LIBRARY_FD,
-                .library_fd = fds[i],
+            .flags = ANDROID_DLEXT_USE_LIBRARY_FD,
+            .library_fd = fds[i],
         };
         if (void *h = android_dlopen_ext("/jit-cache", RTLD_LAZY, &info)) {
             if (void *e = dlsym(h, "zygisk_module_entry")) {

--- a/native/jni/zygisk/main.cpp
+++ b/native/jni/zygisk/main.cpp
@@ -87,6 +87,10 @@ int app_process_main(int argc, char *argv[]) {
 
             fcntl(app_proc_fd, F_SETFD, FD_CLOEXEC);
             syscall(__NR_execveat, app_proc_fd, "", argv, environ, AT_EMPTY_PATH);
+            if (errno == ENOSYS) {
+                snprintf(buf, sizeof(buf), "/proc/self/fd/%d", app_proc_fd);
+                execve(buf, argv, environ);
+            }
         } while (false);
 
         close(socket);

--- a/native/jni/zygisk/utils.cpp
+++ b/native/jni/zygisk/utils.cpp
@@ -13,9 +13,8 @@ struct map_info {
     uintptr_t off;
     int perms;
     unsigned long inode;
-    std::string path;
 
-    map_info() : start(0), end(0), off(0), perms(0), inode(0), path() {}
+    map_info() : start(0), end(0), off(0), perms(0), inode(0) {}
 };
 
 } // namespace
@@ -44,23 +43,21 @@ static void parse_maps(int pid, Func fn) {
         if (perm[2] != '-')
             info.perms |= PROT_EXEC;
 
-        info.path = line + path_off;
-
-        return fn(std::move(info));
+        return fn(info, line + path_off);
     });
 }
 
 static vector<map_info> find_maps(const char *name) {
     vector<map_info> maps;
-    parse_maps(getpid(), [=, &maps](map_info &&info) -> bool {
-        if (info.path == name)
-            maps.emplace_back(std::move(info));
+    parse_maps(getpid(), [=, &maps](const map_info &info, const char *path) -> bool {
+        if (strcmp(path, name) == 0)
+            maps.emplace_back(info);
         return true;
     });
     return maps;
 }
 
-std::tuple<void *, size_t> find_map_range(const char *name, unsigned long inode) {
+std::pair<void *, size_t> find_map_range(const char *name, unsigned long inode) {
     vector<map_info> maps = find_maps(name);
     uintptr_t start = 0u;
     uintptr_t end = 0u;
@@ -75,7 +72,7 @@ std::tuple<void *, size_t> find_map_range(const char *name, unsigned long inode)
         }
     }
     LOGD("found map %s with start = %zx, end = %zx\n", name, start, end);
-    return {reinterpret_cast<void *>(start), end - start};
+    return make_pair(reinterpret_cast<void *>(start), end - start);
 }
 
 void unmap_all(const char *name) {
@@ -110,10 +107,10 @@ void remap_all(const char *name) {
 
 uintptr_t get_function_off(int pid, uintptr_t addr, char *lib) {
     uintptr_t off = 0;
-    parse_maps(pid, [=, &off](map_info &&info) -> bool {
+    parse_maps(pid, [=, &off](const map_info &info, const char *path) -> bool {
         if (addr >= info.start && addr < info.end) {
             if (lib)
-                strcpy(lib, info.path.data());
+                strcpy(lib, path);
             off = addr - info.start + info.off;
             return false;
         }
@@ -124,8 +121,8 @@ uintptr_t get_function_off(int pid, uintptr_t addr, char *lib) {
 
 uintptr_t get_function_addr(int pid, const char *lib, uintptr_t off) {
     uintptr_t addr = 0;
-    parse_maps(pid, [=, &addr](map_info &&info) -> bool {
-        if (info.path == lib && (info.perms & PROT_EXEC)) {
+    parse_maps(pid, [=, &addr](const map_info &info, const char *path) -> bool {
+        if (strcmp(path, lib) == 0 && (info.perms & PROT_EXEC)) {
             addr = info.start - info.off + off;
             return false;
         }

--- a/native/jni/zygisk/zygisk.hpp
+++ b/native/jni/zygisk/zygisk.hpp
@@ -4,8 +4,10 @@
 #include <jni.h>
 #include <vector>
 
-#define INJECT_ENV_1 "MAGISK_INJ_1"
-#define INJECT_ENV_2 "MAGISK_INJ_2"
+#define INJECT_ENV_1   "MAGISK_INJ_1"
+#define INJECT_ENV_2   "MAGISK_INJ_2"
+#define MAGISKFD_ENV   "MAGISKFD"
+#define MAGISKTMP_ENV  "MAGISKTMP"
 
 enum : int {
     ZYGISK_SETUP,
@@ -25,6 +27,8 @@ enum : int {
 #define ZLOGI(...) LOGI("zygisk32: " __VA_ARGS__)
 #endif
 
+std::tuple<void*, size_t> find_map_range(const char *name, unsigned long inode);
+
 // Unmap all pages matching the name
 void unmap_all(const char *name);
 
@@ -39,7 +43,6 @@ uintptr_t get_function_addr(int pid, const char *lib, uintptr_t off);
 
 extern void *self_handle;
 
-void unload_first_stage();
 void hook_functions();
 int remote_get_info(int uid, const char *process, uint32_t *flags, std::vector<int> &fds);
 int remote_request_unmount();

--- a/native/jni/zygisk/zygisk.hpp
+++ b/native/jni/zygisk/zygisk.hpp
@@ -27,7 +27,8 @@ enum : int {
 #define ZLOGI(...) LOGI("zygisk32: " __VA_ARGS__)
 #endif
 
-std::tuple<void*, size_t> find_map_range(const char *name, unsigned long inode);
+// Find the memory address + size of the pages matching name + inode
+std::pair<void*, size_t> find_map_range(const char *name, unsigned long inode);
 
 // Unmap all pages matching the name
 void unmap_all(const char *name);


### PR DESCRIPTION
Fix #5353

Points of refactoring:
1. `LD_PRELOAD` is set to `/system/bin/app_process` since it's not umounted
2. Use a proper way to dlopen fd
3. Instead of munmaping `LD_PRELOAD`ed so file manually, use `ANDROID_DLEXT_RESERVED_ADDRESS` to dlopen on the same memory space to make `LD_PRELOAD`ed so file dlclosable.