### PR TITLE
Allow select file from file manager

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/events/ViewEvents.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/events/ViewEvents.kt
@@ -53,7 +53,7 @@ class MagiskInstallFileEvent(
 ) : ViewEvent(), ActivityExecutor {
     override fun invoke(activity: UIActivity<*>) {
         try {
-            activity.getContent("*/*", callback)
+            activity.getContent("application/*", callback)
             Utils.toast(R.string.patch_file_msg, Toast.LENGTH_LONG)
         } catch (e: ActivityNotFoundException) {
             Utils.toast(R.string.app_not_found, Toast.LENGTH_SHORT)


### PR DESCRIPTION
I found that if content type is `*/*` , I can't select a file in `File Manager` to patch. If content type is `application/*` , there is no problem.
![before](https://s3.bmp.ovh/imgs/2022/02/3b5bb078496e29b5.jpg)  
![after](https://s3.bmp.ovh/imgs/2022/02/0f0c2e8b0faee23b.jpg) 
My device: Redmi K40/MIUI12.5.19 , Redmi Note 7/MIUI 12.5.3