### PR TITLE
Make xmmap() returns nullptr when fails

### DIFF
--- a/native/jni/utils/xwrap.cpp
+++ b/native/jni/utils/xwrap.cpp
@@ -444,6 +444,7 @@ void *xmmap(void *addr, size_t length, int prot, int flags,
     void *ret = mmap(addr, length, prot, flags, fd, offset);
     if (ret == MAP_FAILED) {
         PLOGE("mmap");
+        return nullptr;
     }
     return ret;
 }


### PR DESCRIPTION
In the constructor of mmap_data, there are two possible values on failure: nullptr if fstat() failed, and MAP_FAILED if mmap() failed, but mmap_data treated MAP_FAILED as valid address and crashes.
