### PR TITLE
Do not apply rootfs patch on pre oreo devices. (Fix #5124)

### DIFF
--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -197,11 +197,15 @@ if [ -f kernel ]; then
   # After:  [mov w2, #-32768]
   ./magiskboot hexpatch kernel 821B8012 E2FF8F12
 
-  # Force kernel to load rootfs
-  # skip_initramfs -> want_initramfs
-  ./magiskboot hexpatch kernel \
-  736B69705F696E697472616D667300 \
-  77616E745F696E697472616D667300
+  # This patch is unneeded on pre-oreo devices
+  # and might boot loop them in some situations
+  if [ $API -ge 26 ]; then
+    # Force kernel to load rootfs
+    # skip_initramfs -> want_initramfs
+    ./magiskboot hexpatch kernel \
+    736B69705F696E697472616D667300 \
+    77616E745F696E697472616D667300
+  fi
 fi
 
 #################


### PR DESCRIPTION
This hexpatch was made for Android 10 system-as-root to force it to load `rootfs`. 
So this patch shouldn't be needed under Android 10

I chose to use Andorid 8 as a minimum instead because of project treble that may be weird in some rare cases.
Also Andorid 8 having project treble in mind reduce the chances of this patch causing a boot loop.

Any version under Andorid 8 doesn't support anything else except `rootfs` as a boot mechanism.

Issue #5124 use Android 7, and tested disabling the patch, and it allowed him to boot successfully with Magisk enabled.