### PR TITLE
Update ota.md

### DIFF
--- a/docs/ota.md
+++ b/docs/ota.md
@@ -1,9 +1,7 @@
-# NOTE: Install to Inactive Slot is disabled in newer builds of the Magisk app due to changes that Google introduced to the OTA process: https://twitter.com/topjohnwu/status/1303574238796808192
-
 ## OTA Upgrade Guides
 Magisk does not modify most read-only partitions, which means applying official OTAs is much simpler. Here are the tutorials for several different kind of devices to apply OTAs and preserve Magisk after the installation (if possible). This is just a general guide as procedures for each device may vary.
 
-**NOTE: In order to apply OTAs, you HAVE to make sure you haven't modified and read-only partitons yourself (such as `/system` or `/vendor`) in any way. Even remounting the partition to rw will tamper block verification!!**
+**NOTE: In order to apply OTAs, you HAVE to make sure you haven't modified and read-only partitons yourself (such as `/system` or `/vendor`) in any way. Even remounting the partition to rw will fail block verification!!**
 
 ### Prerequisites
 - Please disable *Automatic system updates* in developer options, so it won't install OTAs without your acknowledgement.


### PR DESCRIPTION
Update to reflect that "install to inactive slot" has been re-enabled as of Canary 23017.   Additional minor grammar correction.