### PR TITLE
Fix module installation being triggered twice on landscape devices

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/flash/FlashFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/flash/FlashFragment.kt
@@ -51,7 +51,9 @@ class FlashFragment : BaseFragment<FragmentFlashMd2Binding>() {
 
         defaultOrientation = activity?.requestedOrientation ?: -1
         activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_NOSENSOR
-        viewModel.startFlashing()
+        if (savedInstanceState == null) {
+            viewModel.startFlashing()
+        }
     }
 
     @SuppressLint("WrongConstant")


### PR DESCRIPTION
On some devices that default to landscape (such as some tablets), installing a module causes a transition from landscape to portrait, which results in the installation process being triggered twice, as shown in the screenshot below.

<img src="https://user-images.githubusercontent.com/71819243/158055636-839b8141-3aa4-445d-9d7d-a646c94ed9b5.png" width="320">

This behavior can also be reproduced on normal smartphones with “Lock orientation” off.

This patch fixes the problem by ensuring `savedInstanceState == null` before starting installation.