### PR TITLE
Log if failed to dlopen a zygisk module

### DIFF
--- a/native/jni/zygisk/hook.cpp
+++ b/native/jni/zygisk/hook.cpp
@@ -367,6 +367,8 @@ void HookContext::run_modules_pre(const vector<int> &fds) {
             if (void *e = dlsym(h, "zygisk_module_entry")) {
                 modules.emplace_back(i, h, e);
             }
+        } else if (g_ctx->state[SERVER_SPECIALIZE]) {
+            LOGW("Failed to dlopen zygisk module: %s\n", dlerror());
         }
         close(fds[i]);
     }


### PR DESCRIPTION
1. Log reason if failed to dlopen a zygisk module
2. Fix fd leak of zygisk companion
3. use dlopen_ext to dlopen zygisk module in zygisk companion