### PR TITLE
Fix selinux mock in Android 13 DP2

### DIFF
--- a/native/jni/utils/misc.hpp
+++ b/native/jni/utils/misc.hpp
@@ -198,3 +198,8 @@ void exec_command_async(Args &&...args) {
     };
     exec_command(exec);
 }
+
+template<typename T, size_t N>
+inline constexpr auto array_size(T (&a)[N]) {
+    return N;
+}


### PR DESCRIPTION
In Android 13 DP2, `SelinuxSetEnforcement` is no longer the first
operation after load policy. It will resetcon `/dev/selinux` first. So
we hijack file_contexts instead to let init wait for us to finish
sepolicy loading. It also allows us to extend file_contexts. So it also
fixes #2744

See https://cs.android.com/android/_/android/platform/system/core/+/baeece6d0c0ff72f667318ec365e5281955c8f42