### PR TITLE
Guard su request IPC

### DIFF
--- a/native/jni/core/socket.cpp
+++ b/native/jni/core/socket.cpp
@@ -158,11 +158,13 @@ void write_int_be(int fd, int val) {
     xwrite(fd, &nl, sizeof(nl));
 }
 
-void read_string(int fd, std::string &str) {
+bool read_string(int fd, std::string &str) {
     int len = read_int(fd);
     str.clear();
+    if (len < 0)
+        return false;
     str.resize(len);
-    xxread(fd, str.data(), len);
+    return xxread(fd, str.data(), len) == len;
 }
 
 string read_string(int fd) {

--- a/native/jni/include/socket.hpp
+++ b/native/jni/include/socket.hpp
@@ -21,5 +21,5 @@ int read_int_be(int fd);
 void write_int(int fd, int val);
 void write_int_be(int fd, int val);
 std::string read_string(int fd);
-void read_string(int fd, std::string &str);
+bool read_string(int fd, std::string &str);
 void write_string(int fd, std::string_view str);

--- a/native/jni/su/pts.cpp
+++ b/native/jni/su/pts.cpp
@@ -86,7 +86,7 @@ int pts_open(char *slave_name, size_t slave_name_size) {
         goto error;
 
     // Get the slave name
-    if (ptsname_r(fdm, slave_name, slave_name_size-1))
+    if (ptsname_r(fdm, slave_name, slave_name_size - 1))
         goto error;
 
     slave_name[slave_name_size - 1] = '\0';

--- a/native/jni/su/su_daemon.cpp
+++ b/native/jni/su/su_daemon.cpp
@@ -220,9 +220,13 @@ void su_daemon_handler(int client, const sock_cred *cred) {
     };
 
     // Read su_request
-    xxread(client, &ctx.req, sizeof(su_req_base));
-    read_string(client, ctx.req.shell);
-    read_string(client, ctx.req.command);
+    if (xxread(client, &ctx.req, sizeof(su_req_base)) < 0 || !read_string(client, ctx.req.shell) || !read_string(client, ctx.req.command)) {
+        LOGW("su: remote process probably died, abort\n");
+        ctx.info.reset();
+        write_int(client, DENY);
+        close(client);
+        return;
+    }
 
     // If still not determined, ask manager
     if (ctx.info->access.policy == QUERY) {


### PR DESCRIPTION
Previously `read_string()` calls `std::string.resize()` with a int read from remote process. When I/O error occurs (e.g. remote process died during IPC), -1 will be used for resizing the string, `std::bad_alloc` is thrown and since magisk is compiled with `-fno-exceptions`, it will crash the whole daemon process.

Fix #5681