### PR TITLE
Add "-Z" option to show property context

### DIFF
--- a/native/jni/external/systemproperties/include/_system_properties.h
+++ b/native/jni/external/systemproperties/include/_system_properties.h
@@ -128,6 +128,11 @@ int __system_property_update(prop_info* __pi, const char* __value, unsigned int 
 */
 uint32_t __system_property_serial(const prop_info* __pi);
 
+/* Get property of a property.
+** Added by resetprop.
+*/
+void __system_property_get_context(const char* prop, const char** context);
+
 /* Initialize the system properties area in read only mode.
  * Should be done by all processes that need to read system
  * properties.

--- a/native/jni/external/systemproperties/include/system_properties/contexts.h
+++ b/native/jni/external/systemproperties/include/system_properties/contexts.h
@@ -42,4 +42,7 @@ class Contexts {
   virtual void ForEach(void (*propfn)(const prop_info* pi, void* cookie), void* cookie) = 0;
   virtual void ResetAccess() = 0;
   virtual void FreeAndUnmap() = 0;
+
+  // resetprop added
+  virtual void GetContextForName(const char* name, const char** context) = 0;
 };

--- a/native/jni/external/systemproperties/include/system_properties/contexts_pre_split.h
+++ b/native/jni/external/systemproperties/include/system_properties/contexts_pre_split.h
@@ -64,6 +64,11 @@ class ContextsPreSplit : public Contexts {
     prop_area::unmap_prop_area(&pre_split_prop_area_);
   }
 
+  // resetprop added
+  virtual void GetContextForName(const char* name, const char** context) override {
+    if (context) *context = nullptr;
+  }
+
  private:
   prop_area* pre_split_prop_area_ = nullptr;
 };

--- a/native/jni/external/systemproperties/include/system_properties/contexts_serialized.h
+++ b/native/jni/external/systemproperties/include/system_properties/contexts_serialized.h
@@ -47,6 +47,10 @@ class ContextsSerialized : public Contexts {
   virtual void ResetAccess() override;
   virtual void FreeAndUnmap() override;
 
+  // resetprop added
+  virtual void GetContextForName(const char* name, const char** context) override;
+  ContextNode* GetContextNodeForName(const char* name);
+
  private:
   bool InitializeContextNodes();
   bool InitializeProperties();

--- a/native/jni/external/systemproperties/include/system_properties/contexts_split.h
+++ b/native/jni/external/systemproperties/include/system_properties/contexts_split.h
@@ -47,6 +47,10 @@ class ContextsSplit : public Contexts {
   virtual void ResetAccess() override;
   virtual void FreeAndUnmap() override;
 
+  // resetprop added
+  virtual void GetContextForName(const char* name, const char** context) override;
+  ContextListNode* GetContextNodeForName(const char* name);
+
  private:
   bool MapSerialPropertyArea(bool access_rw, bool* fsetxattr_failed);
   bool InitializePropertiesFromFile(const char* filename);

--- a/native/jni/external/systemproperties/include/system_properties/system_properties.h
+++ b/native/jni/external/systemproperties/include/system_properties/system_properties.h
@@ -75,6 +75,9 @@ class SystemProperties {
   const prop_info* FindNth(unsigned n);
   int Foreach(void (*propfn)(const prop_info* pi, void* cookie), void* cookie);
 
+  // Added by resetprop
+  void GetPropContext(const char* prop, const char** context);
+
  private:
   // We don't want to use new or malloc in properties (b/31659220), and we don't want to waste a
   // full page by using mmap(), so we set aside enough space to create any context of the three

--- a/native/jni/external/systemproperties/system_properties.cpp
+++ b/native/jni/external/systemproperties/system_properties.cpp
@@ -399,3 +399,12 @@ int SystemProperties::Foreach(void (*propfn)(const prop_info* pi, void* cookie),
 
   return 0;
 }
+
+// resetprop added
+void SystemProperties::GetPropContext(const char* prop, const char** context) {
+  if (!initialized_) {
+    if (context) *context = nullptr;
+    return;
+  }
+  contexts_->GetContextForName(prop, context);
+}

--- a/native/jni/external/systemproperties/system_property_api.cpp
+++ b/native/jni/external/systemproperties/system_property_api.cpp
@@ -110,6 +110,11 @@ uint32_t __system_property_serial(const prop_info* pi) {
 }
 
 __BIONIC_WEAK_FOR_NATIVE_BRIDGE
+void __system_property_get_context(const char* prop, const char** context) {
+  system_properties.GetPropContext(prop, context);
+}
+
+__BIONIC_WEAK_FOR_NATIVE_BRIDGE
 uint32_t __system_property_wait_any(uint32_t old_serial) {
   return system_properties.WaitAny(old_serial);
 }

--- a/native/jni/include/resetprop.hpp
+++ b/native/jni/include/resetprop.hpp
@@ -2,10 +2,12 @@
 
 #include <string>
 #include <functional>
+#include <map>
 
 int setprop(const char *name, const char *value, bool prop_svc = true);
 std::string getprop(const char *name, bool persist = false);
 void getprops(void (*callback)(const char *, const char *, void *),
-        void *cookie = nullptr, bool persist = false);
+        void *cookie = nullptr, bool persist = false, bool context = false);
 int delprop(const char *name, bool persist = false);
 void load_prop_file(const char *filename, bool prop_svc = true);
+void get_prop_context(const char* prop, const char** context);


### PR DESCRIPTION
The "-Z" option does exist in system's getprop but requires Android 7.0+ so I want to add this to magisk resetprop.