### PR TITLE
Support sepolicy.unlocked

### DIFF
--- a/native/jni/init/init.hpp
+++ b/native/jni/init/init.hpp
@@ -63,7 +63,7 @@ protected:
     bool avd_hack = false;
 #endif
 
-    void patch_sepolicy(const char *file);
+    void patch_sepolicy(const char *in, const char *out);
     bool hijack_sepolicy();
     void setup_tmp(const char *path);
     void patch_rw_root();

--- a/native/jni/init/rootdir.cpp
+++ b/native/jni/init/rootdir.cpp
@@ -235,8 +235,11 @@ void SARBase::patch_ro_root() {
         }
     }
 
-    if ((access(SPLIT_PLAT_CIL, F_OK) != 0 && access("/sepolicy", F_OK) == 0) || !hijack_sepolicy()) {
-        patch_sepolicy(ROOTOVL "/sepolicy");
+    // Oculus Go will use a special sepolicy if unlocked
+    if (access("/sepolicy.unlocked", F_OK) == 0) {
+        patch_sepolicy("/sepolicy.unlocked", ROOTOVL "/sepolicy.unlocked");
+    } else if ((access(SPLIT_PLAT_CIL, F_OK) != 0 && access("/sepolicy", F_OK) == 0) || !hijack_sepolicy()) {
+        patch_sepolicy("/sepolicy", ROOTOVL "/sepolicy");
     }
 
     // Mount rootdir
@@ -308,7 +311,7 @@ void MagiskInit::patch_rw_root() {
     }
 
     if ((!treble && access("/sepolicy", F_OK) == 0) || !hijack_sepolicy()) {
-        patch_sepolicy("/sepolicy");
+        patch_sepolicy("/sepolicy", "/sepolicy");
     }
 
     chdir("/");

--- a/native/jni/init/selinux.cpp
+++ b/native/jni/init/selinux.cpp
@@ -8,9 +8,9 @@
 
 using namespace std;
 
-void MagiskInit::patch_sepolicy(const char *file) {
+void MagiskInit::patch_sepolicy(const char *in, const char *out) {
     LOGD("Patching monolithic policy\n");
-    auto sepol = unique_ptr<sepolicy>(sepolicy::from_file("/sepolicy"));
+    auto sepol = unique_ptr<sepolicy>(sepolicy::from_file(in));
 
     sepol->magisk_rules();
 
@@ -27,8 +27,8 @@ void MagiskInit::patch_sepolicy(const char *file) {
         }
     }
 
-    LOGD("Dumping sepolicy to: [%s]\n", file);
-    sepol->to_file(file);
+    LOGD("Dumping sepolicy to: [%s]\n", out);
+    sepol->to_file(out);
 
     // Remove OnePlus stupid debug sepolicy and use our own
     if (access("/sepolicy_debug", F_OK) == 0) {


### PR DESCRIPTION
Oculus Go, a legacy SAR Nougat VR device, will use a special sepolicy if unlocked. This will cause Magisk.fails to inject sepolicy.

Fix #4914