### PR TITLE
Use Locale.ROOT in JcaX509v3CertificateBuilder (X509v3CertificateBuilder)

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/Keygen.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/Keygen.kt
@@ -4,8 +4,9 @@ import android.util.Base64
 import android.util.Base64OutputStream
 import com.topjohnwu.magisk.core.Config
 import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.cert.X509v3CertificateBuilder
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import java.io.ByteArrayOutputStream
 import java.math.BigInteger
@@ -56,8 +57,11 @@ class Keygen : CertKeyProvider {
         // Generate new private key and certificate
         val kp = KeyPairGenerator.getInstance("RSA").apply { initialize(4096) }.genKeyPair()
         val dname = X500Name(DNAME)
-        val builder = JcaX509v3CertificateBuilder(dname, BigInteger(160, Random()),
-            start.time, end.time, dname, kp.public)
+        val builder = X509v3CertificateBuilder(
+            dname, BigInteger(160, Random()),
+            start.time, end.time, Locale.ROOT, dname,
+            SubjectPublicKeyInfo.getInstance(kp.public.encoded)
+        )
         val signer = JcaContentSignerBuilder("SHA1WithRSA").build(kp.private)
         val cert = JcaX509CertificateConverter().getCertificate(builder.build(signer))
 


### PR DESCRIPTION
If not, in languages like Arabic, an "IllegalArgumentException: invalid date string" will be thrown. 

Since JcaX509v3CertificateBuilder does not accept Locale, we must switch to its super class, X509v3CertificateBuilder.