### PR TITLE
Ignore the response until showDialog done

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/surequest/SuRequestViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/surequest/SuRequestViewModel.kt
@@ -73,7 +73,8 @@ class SuRequestViewModel(
     val itemBinding = ItemBinding.of<String>(BR.item, R.layout.item_spinner)
 
     private val handler = SuRequestHandler(AppContext.packageManager, policyDB)
-    private var timer: CountDownTimer? = null
+    private lateinit var timer: CountDownTimer
+    private var initialized = false
 
     fun grantPressed() {
         cancelTimer()
@@ -122,10 +123,16 @@ class SuRequestViewModel(
 
         // Actually show the UI
         ShowUIEvent(if (Config.suTapjack) EmptyAccessibilityDelegate else null).publish()
+        initialized = true
     }
 
     private fun respond(action: Int) {
-        timer?.cancel()
+        if (!initialized) {
+            // ignore the response until showDialog done
+            return
+        }
+
+        timer.cancel()
 
         val pos = selectedItemPosition
         timeoutPrefs.edit().putInt(handler.pkgInfo.packageName, pos).apply()
@@ -138,7 +145,7 @@ class SuRequestViewModel(
     }
 
     private fun cancelTimer() {
-        timer?.cancel()
+        timer.cancel()
         denyText.seconds = 0
     }
 


### PR DESCRIPTION
#5285

```
04-26 11:56:43.035  2856  2856 E AndroidRuntime: FATAL EXCEPTION: main
04-26 11:56:43.035  2856  2856 E AndroidRuntime: Process: jqq.vnle.ie.a.rg, PID: 2856
04-26 11:56:43.035  2856  2856 E AndroidRuntime: java.lang.NullPointerException: Attempt to read from field 'java.lang.String android.content.pm.PackageInfo.packageName' on a null object reference
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at com.topjohnwu.magisk.ui.surequest.SuRequestViewModel.respond(SuRequestViewModel.kt:131)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at com.topjohnwu.magisk.ui.surequest.SuRequestViewModel.denyPressed(SuRequestViewModel.kt:92)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at com.topjohnwu.magisk.ui.surequest.SuRequestActivity.onBackPressed(SuRequestActivity.kt:28)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at android.app.Activity.onKeyUp(Unknown Source:24)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at android.view.KeyEvent.dispatch(Unknown Source:53)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at android.app.Activity.dispatchKeyEvent(Unknown Source:50)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at androidx.core.app.ComponentActivity.superDispatchKeyEvent(ComponentActivity.java:124)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at androidx.core.view.KeyEventDispatcher.dispatchKeyEvent(KeyEventDispatcher.java:86)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at androidx.core.app.ComponentActivity.dispatchKeyEvent(ComponentActivity.java:142)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at androidx.appcompat.app.AppCompatActivity.dispatchKeyEvent(AppCompatActivity.java:599)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at androidx.appcompat.view.WindowCallbackWrapper.dispatchKeyEvent(WindowCallbackWrapper.java:59)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.dispatchKeyEvent(AppCompatDelegateImpl.java:3090)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at com.android.internal.policy.DecorView.dispatchKeyEvent(Unknown Source:87)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(Unknown Source:22)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(Unknown Source:27)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at android.view.ViewRootImpl$InputStage.deliver(Unknown Source:26)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at android.view.ViewRootImpl$InputStage.onDeliverToNext(Unknown Source:4)
04-26 11:56:43.035  2856  2856 E AndroidRuntime: at android.view.ViewRootImpl$InputStage.forward(Unknown Source:0)
```