### PR TITLE
Fix preload happens on main thread

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/arch/BaseMainActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/arch/BaseMainActivity.kt
@@ -46,7 +46,7 @@ abstract class BaseMainActivity<Binding : ViewDataBinding> : NavigationActivity<
         }
 
         if (doPreload) {
-            Shell.getShell(null) {
+            Shell.getShell(Shell.EXECUTOR) {
                 if (isRunningAsStub && !it.isRoot) {
                     showInvalidStateMessage()
                     return@getShell


### PR DESCRIPTION
Since we now pre-heat Shell in Application.onCreate(), the GetShellCallback will get executed on the caller thread (in our case it's the main thread) immediately if we already have an available Shell, which will cause ANR and splash screen not showing.

Fix topjohnwu#5662