### PR TITLE
Make state and callbacks survive after activity recreation

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/arch/BaseViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/arch/BaseViewModel.kt
@@ -43,7 +43,7 @@ abstract class BaseViewModel(
     val isConnected get() = Info.isConnected
     val viewEvents: LiveData<ViewEvent> get() = _viewEvents
 
-    var state= initialState
+    var state = initialState
         set(value) = set(value, field, { field = it }, BR.loading, BR.loaded, BR.loadFailed)
 
     private val _viewEvents = MutableLiveData<ViewEvent>()

--- a/app/src/main/java/com/topjohnwu/magisk/core/base/BaseActivity.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/base/BaseActivity.kt
@@ -100,4 +100,8 @@ abstract class BaseActivity : AppCompatActivity() {
         startActivity(Intent(intent).setFlags(0))
         finish()
     }
+
+    fun updateContentCallback(callback: (Uri) -> Unit) {
+        contentCallback = callback
+    }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/events/ViewEvents.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/events/ViewEvents.kt
@@ -83,13 +83,11 @@ class AddHomeIconEvent : ViewEvent(), ContextExecutor {
     }
 }
 
-class SelectModuleEvent : ViewEvent(), FragmentExecutor {
+class SelectModuleEvent(val callback: (Uri) -> Unit) : ViewEvent(), FragmentExecutor {
     override fun invoke(fragment: BaseFragment<*>) {
         try {
             fragment.apply {
-                activity?.getContent("application/zip") {
-                    MainDirections.actionFlashFragment(Const.Value.FLASH_ZIP, it).navigate()
-                }
+                activity?.getContent("application/zip", callback)
             }
         } catch (e: ActivityNotFoundException) {
             Utils.toast(R.string.app_not_found, Toast.LENGTH_SHORT)

--- a/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import com.topjohnwu.magisk.R
 import com.topjohnwu.magisk.arch.BaseFragment
+import com.topjohnwu.magisk.core.base.BaseActivity
 import com.topjohnwu.magisk.databinding.FragmentInstallMd2Binding
 import com.topjohnwu.magisk.di.viewModel
 
@@ -24,15 +25,23 @@ class InstallFragment : BaseFragment<FragmentInstallMd2Binding>() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        viewModel.step = savedInstanceState?.getInt(KEY_CURRENT_STEP, viewModel.step) ?: viewModel.step
         viewModel._method = savedInstanceState?.getInt(KEY_CURRENT_METHOD, -1) ?: -1
+        if (savedInstanceState?.getBoolean(KEY_WAITING_FOR_FILE, viewModel.waitingForFile) == true)
+            (requireActivity() as BaseActivity).updateContentCallback(viewModel.selectFileCallback)
+
         return super.onCreateView(inflater, container, savedInstanceState)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
+        outState.putInt(KEY_CURRENT_STEP, viewModel.step)
         outState.putInt(KEY_CURRENT_METHOD, viewModel.method)
+        outState.putBoolean(KEY_WAITING_FOR_FILE, viewModel.waitingForFile)
     }
 
     companion object {
+        private const val KEY_CURRENT_STEP = "current_step"
         private const val KEY_CURRENT_METHOD = "current_method"
+        private const val KEY_WAITING_FOR_FILE = "waiting_for_file"
     }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -38,6 +38,11 @@ class InstallViewModel(
     var step = if (skipOptions) 1 else 0
         set(value) = set(value, field, { field = it }, BR.step)
 
+    var waitingForFile = false
+
+    val selectFileCallback : (Uri) -> Unit = { uri -> data = uri }
+        get() { waitingForFile = true; return field }
+
     var _method = -1
 
     @get:Bindable
@@ -46,7 +51,7 @@ class InstallViewModel(
         set(value) = set(value, _method, { _method = it }, BR.method) {
             when (it) {
                 R.id.method_patch -> {
-                    MagiskInstallFileEvent { uri -> data = uri }.publish()
+                    MagiskInstallFileEvent(selectFileCallback).publish()
                 }
                 R.id.method_inactive_slot -> {
                     SecondSlotWarningDialog().publish()
@@ -56,7 +61,7 @@ class InstallViewModel(
 
     @get:Bindable
     var data: Uri? = null
-        set(value) = set(value, field, { field = it }, BR.data)
+        set(value) = set(value, field, { field = it; waitingForFile = false }, BR.data)
 
     @get:Bindable
     var notes: Spanned = SpannableStringBuilder()

--- a/app/src/main/java/com/topjohnwu/magisk/ui/module/ModuleFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/module/ModuleFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import com.topjohnwu.magisk.R
 import com.topjohnwu.magisk.arch.BaseFragment
+import com.topjohnwu.magisk.core.base.BaseActivity
 import com.topjohnwu.magisk.databinding.FragmentModuleMd2Binding
 import com.topjohnwu.magisk.databinding.RvItem
 import com.topjohnwu.magisk.databinding.adapterOf
@@ -36,6 +37,20 @@ class ModuleFragment : BaseFragment<FragmentModuleMd2Binding>() {
         }
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putBoolean(KEY_WAITING_FOR_FILE, viewModel.waitingForFile)
+    }
+
+    override fun onViewStateRestored(savedInstanceState: Bundle?) {
+        if (savedInstanceState?.getBoolean(KEY_WAITING_FOR_FILE, viewModel.waitingForFile) == true) {
+            (requireActivity() as BaseActivity).updateContentCallback(viewModel.selectFileCallback)
+        }
+        super.onViewStateRestored(savedInstanceState)
+    }
+
     override fun onPreBind(binding: FragmentModuleMd2Binding) = Unit
 
+    companion object {
+        private const val KEY_WAITING_FOR_FILE = "waiting_for_file"
+    }
 }

--- a/app/src/main/java/com/topjohnwu/magisk/ui/module/ModuleViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/module/ModuleViewModel.kt
@@ -1,9 +1,12 @@
 package com.topjohnwu.magisk.ui.module
 
+import android.net.Uri
 import androidx.lifecycle.viewModelScope
 import com.topjohnwu.magisk.BR
+import com.topjohnwu.magisk.MainDirections
 import com.topjohnwu.magisk.R
 import com.topjohnwu.magisk.arch.BaseViewModel
+import com.topjohnwu.magisk.core.Const
 import com.topjohnwu.magisk.core.Info
 import com.topjohnwu.magisk.core.model.module.LocalModule
 import com.topjohnwu.magisk.core.model.module.OnlineModule
@@ -29,6 +32,13 @@ class ModuleViewModel : BaseViewModel() {
     val itemBinding = itemBindingOf<RvItem> {
         it.bindExtra(BR.viewModel, this)
     }
+
+    var waitingForFile = false
+    val selectFileCallback : (Uri) -> Unit = {
+        waitingForFile = false;
+        MainDirections.actionFlashFragment(Const.Value.FLASH_ZIP, it).navigate()
+    }
+        get() { waitingForFile = true; return field }
 
     init {
         if (Info.env.isActive) {
@@ -70,6 +80,6 @@ class ModuleViewModel : BaseViewModel() {
             SnackbarEvent(R.string.no_connection).publish()
         }
 
-    fun installPressed() = withExternalRW { SelectModuleEvent().publish() }
+    fun installPressed() = withExternalRW { SelectModuleEvent(selectFileCallback).publish() }
 
 }


### PR DESCRIPTION
- Save fragment state in onSaveInstanceState()
- Recreate callbacks after activity recreating since they are not Parcelable and cannot be put into Bundle

I don't know if this is a correct fix, but anyway it works 🤪 
Fix #5789