### PR TITLE
Fix sepolicy rules dir is not found in recovery

### DIFF
--- a/scripts/uninstaller.sh
+++ b/scripts/uninstaller.sh
@@ -40,12 +40,6 @@ is_mounted /data || mount /data || abort "! Unable to mount /data, please uninst
 mount_partitions
 check_data
 $DATA_DE || abort "! Cannot access /data, please uninstall with the Magisk app"
-if ! $BOOTMODE; then
-  # Mounting stuffs in recovery (best effort)
-  mount_name metadata /metadata
-  mount_name "cache cac" /cache
-  mount_name persist /persist
-fi
 get_flags
 find_boot_image
 

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -624,6 +624,12 @@ run_migrations() {
 }
 
 copy_sepolicy_rules() {
+  # mount required partitions in recovery
+  if [ $BOOTMODE == false ]; then
+    mount /persist
+    mount /metadata
+  fi
+
   # Remove all existing rule folders
   rm -rf /data/unencrypted/magisk /cache/magisk /metadata/magisk /persist/magisk /mnt/vendor/persist/magisk
 

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -624,12 +624,6 @@ run_migrations() {
 }
 
 copy_sepolicy_rules() {
-  # mount required partitions in recovery
-  if [ "$BOOTMODE" != true ]; then
-    mount /persist
-    mount /metadata
-  fi
-
   # Remove all existing rule folders
   rm -rf /data/unencrypted/magisk /cache/magisk /metadata/magisk /persist/magisk /mnt/vendor/persist/magisk
 
@@ -725,6 +719,12 @@ install_module() {
   cd $TMPDIR
 
   setup_flashable
+  if ! $BOOTMODE; then
+  # Mounting things in recovery (best effort)
+    mount_name metadata /metadata
+    mount_name "cache cac" /cache
+    mount_name persist /persist
+  fi
   mount_partitions
   api_level_arch_detect
 

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -295,6 +295,13 @@ mount_partitions() {
 
   # Allow /system/bin commands (dalvikvm) on Android 10+ in recovery
   $BOOTMODE || mount_apex
+
+  # Mounting things in recovery (best effort)
+  if ! $BOOTMODE; then
+    mount_name metadata /metadata
+    mount_name "cache cac" /cache
+    mount_name persist /persist
+  fi
 }
 
 # loop_setup <ext4_img>, sets LOOPDEV
@@ -719,12 +726,6 @@ install_module() {
   cd $TMPDIR
 
   setup_flashable
-  if ! $BOOTMODE; then
-  # Mounting things in recovery (best effort)
-    mount_name metadata /metadata
-    mount_name "cache cac" /cache
-    mount_name persist /persist
-  fi
   mount_partitions
   api_level_arch_detect
 

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -625,7 +625,7 @@ run_migrations() {
 
 copy_sepolicy_rules() {
   # mount required partitions in recovery
-  if [ $BOOTMODE == false ]; then
+  if [ "$BOOTMODE" != true ]; then
     mount /persist
     mount /metadata
   fi

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -296,10 +296,10 @@ mount_partitions() {
   # Allow /system/bin commands (dalvikvm) on Android 10+ in recovery
   $BOOTMODE || mount_apex
 
-  # Mounting things in recovery (best effort)
+  # Mount sepolicy rules dir locations in recovery (best effort)
   if ! $BOOTMODE; then
-    mount_name metadata /metadata
     mount_name "cache cac" /cache
+    mount_name metadata /metadata
     mount_name persist /persist
   fi
 }


### PR DESCRIPTION
- /persist and /metadata are not mounted in recovery by default causing sepolicy rules dir to not be detected
- recovery mounting appears to have been completely removed in error from util_functions.sh with https://github.com/topjohnwu/Magisk/commit/16e4c67992ead7705d6c8b10bd200f300aad451a#diff-f8cb6ae933f02a7a542c3f84299aaa23d8241aca56580fd7dcb64a92bce47692
- bring recovery mounts of sepolicy rules dir locations to mount_partitions from the uninstaller