### PR TITLE
Skip invalid slot_suffix argument

### DIFF
--- a/native/jni/init/getinfo.cpp
+++ b/native/jni/init/getinfo.cpp
@@ -163,6 +163,11 @@ void setup_klog() {
 void BootConfig::set(const kv_pairs &kv) {
     for (const auto &[key, value] : kv) {
         if (key == "androidboot.slot_suffix") {
+            // Many Amlogic devices are A-only but have slot_suffix...
+            if (value == "normal") {
+                LOGW("Skip invalid androidboot.slot_suffix=[normal]\n");
+                continue;
+            }
             strlcpy(slot, value.data(), sizeof(slot));
         } else if (key == "androidboot.slot") {
             slot[0] = '_';


### PR DESCRIPTION
Many Amlogic devices (e.g. FireTV 2nd gen Cube, Vero 4k+, MI Smart Speaker, etc.) are A-only with androidboot.slot_suffix=normal argument. I think "normal" actually means A-only in this case so just ignore it.

Fix topjohnwu#5806