### PR TITLE
Navigate only if user has not left the fragment

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/arch/BaseFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/arch/BaseFragment.kt
@@ -78,7 +78,7 @@ abstract class BaseFragment<Binding : ViewDataBinding> : Fragment(), ViewModelHo
     }
 
     fun NavDirections.navigate() {
-        navigation?.navigate(this)
+        navigation?.currentDestination?.getAction(actionId)?.let { navigation!!.navigate(this) }
     }
 
 }


### PR DESCRIPTION
Magisk app crashes if user clicks "Settings" and any button on bottom navigation bar at the same time.
```
java.lang.IllegalArgumentException: Navigation action/destination com.topjohnwu.magisk:id/action_homeFragment_to_settingsFragment cannot be found from the current destination Destination(com.topjohnwu.magisk:id/modulesFragment) label=ModuleFragment class=com.topjohnwu.magisk.ui.module.ModuleFragment
        at androidx.navigation.NavController.navigate(NavController.kt:1536)
        at androidx.navigation.NavController.navigate(NavController.kt:1468)
        at androidx.navigation.NavController.navigate(NavController.kt:1926)
        at com.topjohnwu.magisk.arch.BaseFragment.navigate(BaseFragment.kt:81)
        at com.topjohnwu.magisk.ui.home.HomeFragment.onOptionsItemSelected(HomeFragment.kt:66)
        at androidx.fragment.app.Fragment.performOptionsItemSelected(Fragment.java:3182)
        at androidx.fragment.app.FragmentManager.dispatchOptionsItemSelected(FragmentManager.java:2972)
        at androidx.fragment.app.Fragment.performOptionsItemSelected(Fragment.java:3186)
        at androidx.fragment.app.FragmentManager.dispatchOptionsItemSelected(FragmentManager.java:2972)
        at androidx.fragment.app.FragmentController.dispatchOptionsItemSelected(FragmentController.java:435)
        at androidx.fragment.app.FragmentActivity.onMenuItemSelected(FragmentActivity.java:320)
        at androidx.appcompat.app.AppCompatActivity.onMenuItemSelected(AppCompatActivity.java:264)
        at androidx.appcompat.view.WindowCallbackWrapper.onMenuItemSelected(WindowCallbackWrapper.java:109)
        at androidx.appcompat.app.ToolbarActionBar$2.onMenuItemClick(ToolbarActionBar.java:66)
        at androidx.appcompat.widget.Toolbar$1.onMenuItemClick(Toolbar.java:221)
        at androidx.appcompat.widget.ActionMenuView$MenuBuilderCallback.onMenuItemSelected(ActionMenuView.java:781)
        at androidx.appcompat.view.menu.MenuBuilder.dispatchMenuItemSelected(MenuBuilder.java:834)
        at androidx.appcompat.view.menu.MenuItemImpl.invoke(MenuItemImpl.java:158)
        at androidx.appcompat.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:985)
        at androidx.appcompat.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:975)
        at androidx.appcompat.widget.ActionMenuView.invokeItem(ActionMenuView.java:625)
        at androidx.appcompat.view.menu.ActionMenuItemView.onClick(ActionMenuItemView.java:151)
        at android.view.View.performClick(View.java:7441)
        at android.view.View.performClickInternal(View.java:7418)
        at android.view.View.access$3700(View.java:835)
        at android.view.View$PerformClick.run(View.java:28676)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7842)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:550)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```