### PR TITLE
Return empty on failure to get context

### DIFF
--- a/native/jni/core/socket.cpp
+++ b/native/jni/core/socket.cpp
@@ -27,7 +27,7 @@ bool get_client_cred(int fd, sock_cred *cred) {
     char buf[4096];
     len = sizeof(buf);
     if (getsockopt(fd, SOL_SOCKET, SO_PEERSEC, buf, &len) != 0)
-        return false;
+        len = 0;
     buf[len] = '\0';
     cred->context = buf;
     return true;


### PR DESCRIPTION
sock_cred.context is only used to make zygote skip verification