### PR TITLE
Bypass DexFile's security check for RootService

### DIFF
--- a/app/shared/src/main/java/com/topjohnwu/magisk/utils/DynamicClassLoader.java
+++ b/app/shared/src/main/java/com/topjohnwu/magisk/utils/DynamicClassLoader.java
@@ -1,22 +1,25 @@
 package com.topjohnwu.magisk.utils;
 
+import android.os.Process;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
 
-import dalvik.system.DexClassLoader;
+import dalvik.system.BaseDexClassLoader;
 
-public class DynamicClassLoader extends DexClassLoader {
+public class DynamicClassLoader extends BaseDexClassLoader {
 
     private static final ClassLoader base = Object.class.getClassLoader();
 
     public DynamicClassLoader(File apk) {
-        super(apk.getPath(), apk.getParent(), null, base);
+        this(apk, base);
     }
 
     public DynamicClassLoader(File apk, ClassLoader parent) {
-        super(apk.getPath(), apk.getParent(), null, parent);
+        // Set optimizedDirectory to null for RootService to bypass DexFile's security checks
+        super(apk.getPath(), Process.myUid() == 0 ? null : apk.getParentFile(), null, parent);
     }
 
     @Override

--- a/app/shared/src/main/java/com/topjohnwu/magisk/utils/DynamicClassLoader.java
+++ b/app/shared/src/main/java/com/topjohnwu/magisk/utils/DynamicClassLoader.java
@@ -1,7 +1,5 @@
 package com.topjohnwu.magisk.utils;
 
-import android.os.Process;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;

--- a/app/shared/src/main/java/com/topjohnwu/magisk/utils/DynamicClassLoader.java
+++ b/app/shared/src/main/java/com/topjohnwu/magisk/utils/DynamicClassLoader.java
@@ -18,8 +18,8 @@ public class DynamicClassLoader extends BaseDexClassLoader {
     }
 
     public DynamicClassLoader(File apk, ClassLoader parent) {
-        // Set optimizedDirectory to null for RootService to bypass DexFile's security checks
-        super(apk.getPath(), Process.myUid() == 0 ? null : apk.getParentFile(), null, parent);
+        // Set optimizedDirectory to null to bypass DexFile's security checks
+        super(apk.getPath(), null, null, parent);
     }
 
     @Override


### PR DESCRIPTION
Old Android (pre 8.0) enforces `optimizedDirectory` has the same uid with the process. If repackaged, root service (uid=0) will crash when trying to load current.apk. So we set `optimizedDirectory` to null for RootService to bypass the check. Since `DexClassLoader` didn't allow we to do this, we have to use `BaseDexClassLoader` instead.


```
E/IPC: Error in IPCMain
    java.lang.reflect.InvocationTargetException
        at java.lang.reflect.Method.invoke(Native Method)
        at com.topjohnwu.superuser.internal.RootServerMain.<init>(SourceFile:6)
        at com.topjohnwu.superuser.internal.RootServerMain.main(SourceFile)
        at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
        at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:262)
     Caused by: java.lang.IllegalArgumentException: Optimized data directory /data/user_de/0/ophbnepqcyfmfb.ds/dyn is not owned by the current user. Shared storage cannot protect your application from code injection attacks.
        at dalvik.system.DexFile.<init>(DexFile.java:139)
        at dalvik.system.DexFile.loadDex(DexFile.java:219)
        at dalvik.system.DexPathList.loadDexFile(DexPathList.java:362)
        at dalvik.system.DexPathList.makeElements(DexPathList.java:323)
        at dalvik.system.DexPathList.makeDexElements(DexPathList.java:263)
        at dalvik.system.DexPathList.<init>(DexPathList.java:126)
        at dalvik.system.BaseDexClassLoader.<init>(BaseDexClassLoader.java:48)
        at dalvik.system.DexClassLoader.<init>(DexClassLoader.java:57)
        at com.topjohnwu.magisk.utils.DynamicClassLoader.<init>(DynamicClassLoader.java:15)
        at com.topjohnwu.magisk.AppClassLoader.<init>(ClassLoaders.java:27)
        at com.topjohnwu.magisk.DynLoad.loadApk(DynLoad.java:81)
        at com.topjohnwu.magisk.DelegateRootService.attachBaseContext(DelegateRootService.java:23)
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.topjohnwu.superuser.internal.RootServerMain.<init>(SourceFile:6) 
        at com.topjohnwu.superuser.internal.RootServerMain.main(SourceFile) 
        at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method) 
        at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:262)
```