### PR TITLE
other fix for #5915

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/log/LogFragment.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/log/LogFragment.kt
@@ -21,12 +21,12 @@ class LogFragment : BaseFragment<FragmentLogMd2Binding>() {
     override val layoutRes = R.layout.fragment_log_md2
     override val viewModel by viewModel<LogViewModel>()
     override val snackbarView: View?
-        get() = if (isMagiskLogVisible) binding.logFilterSuperuser.snackbarContainer
+        get() = if (isSuperuserLogVisible) binding.logFilterSuperuser.snackbarContainer
                 else super.snackbarView
     override val snackbarAnchorView get() = binding.logFilterToggle
 
     private var actionSave: MenuItem? = null
-    private var isMagiskLogVisible
+    private var isSuperuserLogVisible
         get() = binding.logFilter.isVisible
         set(value) {
             MotionRevealHelper.withViews(binding.logFilter, binding.logFilterToggle, value)
@@ -47,7 +47,8 @@ class LogFragment : BaseFragment<FragmentLogMd2Binding>() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.logFilterToggle.setOnClickListener {
-            isMagiskLogVisible = true
+            isSuperuserLogVisible = true
+            binding.logFilter.requestFocus()
         }
 
         binding.logFilterSuperuser.logSuperuser.apply {
@@ -62,7 +63,7 @@ class LogFragment : BaseFragment<FragmentLogMd2Binding>() {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_log_md2, menu)
         actionSave = menu.findItem(R.id.action_save)?.also {
-            it.isVisible = !isMagiskLogVisible
+            it.isVisible = !isSuperuserLogVisible
         }
     }
 
@@ -70,7 +71,7 @@ class LogFragment : BaseFragment<FragmentLogMd2Binding>() {
         when (item.itemId) {
             R.id.action_save -> viewModel.saveMagiskLog()
             R.id.action_clear ->
-                if (!isMagiskLogVisible) viewModel.clearMagiskLog()
+                if (!isSuperuserLogVisible) viewModel.clearMagiskLog()
                 else viewModel.clearLog()
         }
         return super.onOptionsItemSelected(item)
@@ -81,7 +82,7 @@ class LogFragment : BaseFragment<FragmentLogMd2Binding>() {
 
     override fun onBackPressed(): Boolean {
         if (binding.logFilter.isVisible) {
-            isMagiskLogVisible = false
+            isSuperuserLogVisible = false
             return true
         }
         return super.onBackPressed()

--- a/app/src/main/res/layout/include_log_magisk.xml
+++ b/app/src/main/res/layout/include_log_magisk.xml
@@ -24,7 +24,9 @@
 
             <HorizontalScrollView
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:nextFocusUp="@id/log_filter_toggle"
+                android:nextFocusDown="@id/log_filter_toggle">
 
                 <TextView
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/include_log_magisk.xml
+++ b/app/src/main/res/layout/include_log_magisk.xml
@@ -25,6 +25,7 @@
             <HorizontalScrollView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:focusable="true"
                 android:nextFocusUp="@id/log_filter_toggle"
                 android:nextFocusDown="@id/log_filter_toggle">
 

--- a/app/src/main/res/layout/item_log_access_md2.xml
+++ b/app/src/main/res/layout/item_log_access_md2.xml
@@ -18,6 +18,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:focusable="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?listPreferredItemHeightSmall"


### PR DESCRIPTION
This PR add D-PAD navigation to logs Manager section and corrects LogFragment var meaning.
If requestFocus will also be added to HorizontalScrollView magisk log will scroll without toggle superuser log first.