### PR TITLE
Use noHistory attribute for SuRequestActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,10 +28,7 @@
         <activity
             android:name=".ui.surequest.SuRequestActivity"
             android:directBootAware="true"
-            android:excludeFromRecents="true"
-            android:exported="false"
-            android:taskAffinity=""
-            tools:ignore="AppLinkUrlError">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -40,7 +37,6 @@
 
         <receiver
             android:name=".core.Receiver"
-            android:directBootAware="true"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.LOCALE_CHANGED" />

--- a/buildSrc/src/main/java/Codegen.kt
+++ b/buildSrc/src/main/java/Codegen.kt
@@ -94,7 +94,6 @@ fun genStubManifest(srcDir: File, outDir: File): String {
         """
         |<receiver
         |    android:name="%s"
-        |    android:directBootAware="true"
         |    android:exported="false">
         |    <intent-filter>
         |        <action android:name="android.intent.action.LOCALE_CHANGED" />
@@ -127,10 +126,7 @@ fun genStubManifest(srcDir: File, outDir: File): String {
         |<activity
         |    android:name="%s"
         |    android:directBootAware="true"
-        |    android:excludeFromRecents="true"
-        |    android:exported="false"
-        |    android:taskAffinity=""
-        |    tools:ignore="AppLinkUrlError">
+        |    android:exported="false">
         |    <intent-filter>
         |        <action android:name="android.intent.action.VIEW"/>
         |        <category android:name="android.intent.category.DEFAULT"/>

--- a/native/jni/su/connect.cpp
+++ b/native/jni/su/connect.cpp
@@ -17,9 +17,10 @@ exe, "/system/bin", "com.android.commands.content.Content", \
 #define START_ACTIVITY \
 exe, "/system/bin", "com.android.commands.am.Am", \
 "start", "-p", target, "--user", user, "-a", "android.intent.action.VIEW", \
-"-f", "0x18000020", "--es", "action", action
+"-f", "0x58000020", "--es", "action", action
 
-// 0x18000020 = FLAG_ACTIVITY_NEW_TASK|FLAG_ACTIVITY_MULTIPLE_TASK|FLAG_INCLUDE_STOPPED_PACKAGES
+// 0x58000020 = FLAG_ACTIVITY_NEW_TASK|FLAG_ACTIVITY_MULTIPLE_TASK|
+//              FLAG_ACTIVITY_NO_HISTORY|FLAG_INCLUDE_STOPPED_PACKAGES
 
 #define get_cmd(to) \
 ((to).command.empty() ? \


### PR DESCRIPTION
FLAG_ACTIVITY_NO_HISTORY
Added in [API level 1](https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels)

public static final int FLAG_ACTIVITY_NO_HISTORY
If set, the new activity is not kept in the history stack. As soon as the user navigates away from it, the activity is finished. This may also be set with the [noHistory](https://developer.android.com/reference/android/R.styleable#AndroidManifestActivity_noHistory) attribute.

If set, [onActivityResult()](https://developer.android.com/reference/android/app/Activity#onActivityResult(int,%20int,%20android.content.Intent)) is never invoked when the current activity starts a new activity which sets a result and finishes.

Constant Value: 1073741824 (0x40000000)