### PR TITLE
Fix mv file when install module

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -723,6 +723,7 @@ is_legacy_script() {
 install_module() {
   rm -rf $TMPDIR
   mkdir -p $TMPDIR
+  chcon u:object_r:system_file:s0 $TMPDIR
   cd $TMPDIR
 
   setup_flashable


### PR DESCRIPTION
Close Magisk-Modules-Repo/xposed#2
```
mv: can't create '/data/adb/modules_update/xposed/system/framework/XposedBridge.jar': Permission denied
```
```
<36>[ 3317.431174] type=1400 audit(1654590598.058:96): avc: denied { associate } for pid=18830 comm="libbusybox.so" name="XposedBridge.jar" scontext=u:object_r:device:s0 tcontext=u:object_r:labeledfs:s0 tclass=filesystem permissive=0
```