### PR TITLE
Fix booting into recovery with Android 13 GKI kernels

### DIFF
--- a/native/jni/init/init.hpp
+++ b/native/jni/init/init.hpp
@@ -23,6 +23,7 @@ struct BootConfig {
 };
 
 #define DEFAULT_DT_DIR "/proc/device-tree/firmware/android"
+#define INIT_PATH  "/system/bin/init"
 
 extern std::vector<std::string> mount_list;
 
@@ -32,6 +33,7 @@ void load_kernel_info(BootConfig *config);
 bool check_two_stage();
 void setup_klog();
 const char *backup_init();
+void restore_ramdisk_init();
 int dump_manager(const char *path, mode_t mode);
 int dump_preload(const char *path, mode_t mode);
 

--- a/native/jni/init/twostage.cpp
+++ b/native/jni/init/twostage.cpp
@@ -8,7 +8,6 @@
 
 using namespace std;
 
-#define INIT_PATH  "/system/bin/init"
 #define REDIR_PATH "/data/magiskinit"
 
 void FirstStageInit::prepare() {
@@ -16,16 +15,7 @@ void FirstStageInit::prepare() {
     xmount("tmpfs", "/data", "tmpfs", 0, "mode=755");
     cp_afc("/init" /* magiskinit */, REDIR_PATH);
 
-    unlink("/init");
-    const char *orig_init = backup_init();
-    if (access(orig_init, F_OK) == 0) {
-        xrename(orig_init, "/init");
-    } else {
-        // If the backup init is missing, this means that the boot ramdisk
-        // was created from scratch, and the real init is in a separate CPIO,
-        // which is guaranteed to be placed at /system/bin/init.
-        xsymlink(INIT_PATH, "/init");
-    }
+    restore_ramdisk_init();
 
     {
         auto init = mmap_data("/init", true);


### PR DESCRIPTION
With Android 13 GKI kernels, the boot partition has no ramdisk, so Magisk constructs one from scratch. In this scenario, there's no backup init binary at `/.backup/init`. For normal boot, magiskinit will symlink `/init` -> `/system/bin/init` if needed. This commit implements the same for booting into recovery. Before, magiskinit would just exec itself over and over again because it couldn't restore the backup init.