### PR TITLE
Later check persistent_properties

### DIFF
--- a/native/jni/resetprop/prop.hpp
+++ b/native/jni/resetprop/prop.hpp
@@ -16,8 +16,6 @@ struct prop_cb {
     }
 };
 
-extern bool use_pb;
-
 using prop_list = std::map<std::string, std::string>;
 
 struct prop_collector : prop_cb {

--- a/native/jni/resetprop/resetprop.cpp
+++ b/native/jni/resetprop/resetprop.cpp
@@ -240,7 +240,6 @@ struct resetprop : public sysprop {
 static sysprop_stub *get_impl() {
     static sysprop_stub *impl = nullptr;
     if (impl == nullptr) {
-        use_pb = access(PERSISTENT_PROPERTY_DIR "/persistent_properties", R_OK) == 0;
 #ifdef APPLET_STUB_MAIN
         if (__system_properties_init()) {
             LOGE("resetprop: __system_properties_init error\n");


### PR DESCRIPTION
`daemon_entry` calls `getprop` which initializes sysprop impl and checks whether we need to load persistent property file. On FDE devices, magiskd starts before /data is actually decrypted, and the check always fails. Thus `persist_getprop("persist.sys.safemode")` will always fail on devices using persistent property file.