### PR TITLE
Use `ANDROID_DLEXT_FORCE_LOAD` to load second stage if possible

### DIFF
--- a/native/src/zygisk/entry.cpp
+++ b/native/src/zygisk/entry.cpp
@@ -51,16 +51,20 @@ static void *unload_first_stage(void *) {
     return nullptr;
 }
 
+#if defined(__LP64__)
+// Use symlink to workaround linker bug on old broken Android
+// https://issuetracker.google.com/issues/36914295
+#define SECOND_STAGE_PATH "/system/bin/app_process"
+#else
+#define SECOND_STAGE_PATH "/system/bin/app_process32"
+#endif
+
 static void second_stage_entry() {
     zygisk_logging();
     ZLOGD("inject 2nd stage\n");
 
     MAGISKTMP = getenv(MAGISKTMP_ENV);
-#if defined(__LP64__)
-    self_handle = dlopen("/system/bin/app_process", RTLD_NOLOAD);
-#else
-    self_handle = dlopen("/system/bin/app_process32", RTLD_NOLOAD);
-#endif
+    self_handle = dlopen(SECOND_STAGE_PATH, RTLD_NOLOAD);
     dlclose(self_handle);
 
     unsetenv(MAGISKTMP_ENV);
@@ -81,12 +85,20 @@ static void first_stage_entry() {
     }
 
     // Load second stage
+    android_dlextinfo info {
+        .flags = ANDROID_DLEXT_FORCE_LOAD
+    };
     setenv(INJECT_ENV_2, "1", 1);
-#if defined(__LP64__)
-    dlopen("/system/bin/app_process", RTLD_LAZY);
-#else
-    dlopen("/system/bin/app_process32", RTLD_LAZY);
-#endif
+    if (android_dlopen_ext(SECOND_STAGE_PATH, RTLD_LAZY, &info) == nullptr) {
+        // Android 5.x doesn't support ANDROID_DLEXT_FORCE_LOAD
+        ZLOGI("ANDROID_DLEXT_FORCE_LOAD is not supported, fallback to dlopen\n");
+        if (dlopen(SECOND_STAGE_PATH, RTLD_LAZY) == nullptr) {
+            // the second stage cannot be properly triggered,
+            // don't let it triggered in non-zygote process to avoid errors
+            ZLOGE("Cannot load the second stage\n");
+            unsetenv(INJECT_ENV_2);
+        }
+    }
 }
 
 [[gnu::constructor]] [[maybe_unused]]

--- a/native/src/zygisk/entry.cpp
+++ b/native/src/zygisk/entry.cpp
@@ -93,8 +93,6 @@ static void first_stage_entry() {
         // Android 5.x doesn't support ANDROID_DLEXT_FORCE_LOAD
         ZLOGI("ANDROID_DLEXT_FORCE_LOAD is not supported, fallback to dlopen\n");
         if (dlopen(SECOND_STAGE_PATH, RTLD_LAZY) == nullptr) {
-            // the second stage cannot be properly triggered,
-            // don't let it triggered in non-zygote process to avoid errors
             ZLOGE("Cannot load the second stage\n");
             unsetenv(INJECT_ENV_2);
         }


### PR DESCRIPTION
Fix #6095

The thing is, for some reason Zygisk 2nd stage fails to be triggered, leaves `MAGISK_INJ_2` in process environment. When app tries to exec `su` or any applet of `magisk`, its constructor detects that environment var and tries to do Zygisk 2nd stage setup. `magiskd` rejects request from the process because context mismatch, and makes the process crashes. (Fix is in #6172)