### PR TITLE
Do not delete $MAGISKTMP/.magisk/rootdir

### DIFF
--- a/native/src/core/daemon.cpp
+++ b/native/src/core/daemon.cpp
@@ -367,7 +367,6 @@ static void daemon_entry() {
             return true;
         });
     }
-    rm_rf((MAGISKTMP + "/" ROOTOVL).data());
 
     // Load config status
     auto config = MAGISKTMP + "/" INTLROOT "/config";


### PR DESCRIPTION
Why does Magisk delete `$MAGISKTMP/.magisk/rootdir` while it is good for some case such as debugging overlay.d :)

https://github.com/topjohnwu/Magisk/issues/6093