### PR TITLE
Always cleanup init LD_PRELOAD hooks

### DIFF
--- a/native/src/init/preload.c
+++ b/native/src/init/preload.c
@@ -3,11 +3,14 @@
 #include <unistd.h>
 #include <dlfcn.h>
 
-int security_load_policy(void *data, size_t len) {
+__attribute__((constructor))
+static void preload_init() {
     // Make sure our next exec won't get bugged
     unsetenv("LD_PRELOAD");
     unlink("/dev/preload.so");
+}
 
+int security_load_policy(void *data, size_t len) {
     int (*load_policy)(void *, size_t) = dlsym(RTLD_NEXT, "security_load_policy");
     // Skip checking errors, because if we cannot find the symbol, there
     // isn't much we can do other than crashing anyways.

--- a/native/src/init/preload.c
+++ b/native/src/init/preload.c
@@ -3,7 +3,7 @@
 #include <unistd.h>
 #include <dlfcn.h>
 
-__attribute__((constructor))
+[[gnu::constructor]]
 static void preload_init() {
     // Make sure our next exec won't get bugged
     unsetenv("LD_PRELOAD");

--- a/native/src/init/preload.c
+++ b/native/src/init/preload.c
@@ -3,7 +3,7 @@
 #include <unistd.h>
 #include <dlfcn.h>
 
-[[gnu::constructor]]
+__attribute__((constructor))
 static void preload_init() {
     // Make sure our next exec won't get bugged
     unsetenv("LD_PRELOAD");


### PR DESCRIPTION
Fix #6296