### PR TITLE
Support for installation of Github action artifacts

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -739,8 +739,19 @@ install_module() {
 
   # Extract prop file
   unzip -o "$ZIPFILE" module.prop -d $TMPDIR >&2
-  [ ! -f $TMPDIR/module.prop ] && abort "! Unable to extract zip file!"
+  if [ ! -f $TMPDIR/module.prop ]
+  then
+	  SUBFILE=$(zipinfo -1 $ZIPFILE)
+	  shopt -s nocasematch
+	  if [[ $SUBFILE =~ .*\.zip ]]
+	  then
+		  unzip -o "$ZIPFILE" $SUBFILE -d $TMPDIR >&2
+		  ZIPFILE="$TMPDIR/$SUBFILE"
+	  fi
+	  shopt -u nocasematch
+	 [ ! -f $TMPDIR/module.prop ] && abort "! Unable to extract zip file!"
 
+fi
   local MODDIRNAME=modules
   $BOOTMODE && MODDIRNAME=modules_update
   local MODULEROOT=$NVBASE/$MODDIRNAME


### PR DESCRIPTION
Github actions delivers the artifact files as zip files, even if they're zipped already.

This makes installation of the modules downloaded from Github actions confusing for users when they receive the "Unable to extract zip file" error.

This commit checks whether the zip file contains a nested zip, and uses that nested file a the installable module. The rest of the process is untouched