### PR TITLE
Update README.md to specify python version 3.8+

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -41,7 +41,7 @@ For Magisk app crashes, record and upload the logcat when the crash occurs.
 
 - Magisk builds on any OS Android Studio supports. Install Android Studio and do the initial setups.
 - Clone sources: `git clone --recurse-submodules https://github.com/topjohnwu/Magisk.git`
-- Install Python 3.6+ \
+- Install Python 3.8+ \
   (Windows only: select **'Add Python to PATH'** in installer, and run `pip install colorama` after install)
 - Configure to use the JDK bundled in Android Studio:
   - macOS: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jre/Contents/Home"`


### PR DESCRIPTION
Current readme suggests python 3.6+
However, the file `build.py` on executing `build.py ndk` runs the command `shutil.copytree(src_dir, lib_dir, copy_function=cp, dirs_exist_ok=True)` This command errors out on python 3.7, because the `dirs_exist_ok` parameter is new in Python 3.8 (https://docs.python.org/3/library/shutil.html#shutil.copytree)

So the README should suggest python 3.8+