### PR TITLE
Restrict `xreadlinkat`, `xreadlink` and `xrealpath`

### DIFF
--- a/native/src/base/xwrap.hpp
+++ b/native/src/base/xwrap.hpp
@@ -40,8 +40,8 @@ int xfstatat(int dirfd, const char *pathname, struct stat *buf, int flags);
 int xdup(int fd);
 int xdup2(int oldfd, int newfd);
 int xdup3(int oldfd, int newfd, int flags);
-ssize_t xreadlink(const char *pathname, char *buf, size_t bufsiz);
-ssize_t xreadlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz);
+ssize_t xreadlink(const char * __restrict__ pathname, char * __restrict__ buf, size_t bufsiz);
+ssize_t xreadlinkat(int dirfd, const char * __restrict__ pathname, char * __restrict__ buf, size_t bufsiz);
 int xsymlink(const char *target, const char *linkpath);
 int xsymlinkat(const char *target, int newdirfd, const char *linkpath);
 int xlinkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, int flags);
@@ -58,7 +58,7 @@ void *xmmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset
 ssize_t xsendfile(int out_fd, int in_fd, off_t *offset, size_t count);
 pid_t xfork();
 int xpoll(pollfd *fds, nfds_t nfds, int timeout);
-ssize_t xrealpath(const char *path, char *buf, size_t bufsiz);
+ssize_t xrealpath(const char * __restrict__ path, char * __restrict__ buf, size_t bufsiz);
 int xmknod(const char *pathname, mode_t mode, dev_t dev);
 
 } // extern "C"

--- a/native/src/zygisk/entry.cpp
+++ b/native/src/zygisk/entry.cpp
@@ -161,8 +161,9 @@ static vector<int> get_module_fds(bool is_64_bit) {
 }
 
 static bool get_exe(int pid, char *buf, size_t sz) {
-    ssprintf(buf, sz, "/proc/%d/exe", pid);
-    return xreadlink(buf, buf, sz) > 0;
+    char exe_buf[40] = { '\0' };
+    ssprintf(exe_buf, sizeof(exe_buf), "/proc/%d/exe", pid);
+    return xreadlink(exe_buf, buf, sz) > 0;
 }
 
 static pthread_mutex_t zygiskd_lock = PTHREAD_MUTEX_INITIALIZER;


### PR DESCRIPTION
Fix #6353