### PR TITLE
Updated Russian Translation

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2,7 +2,7 @@
 
     <!--Sections-->
     <string name="modules">Модули</string>
-    <string name="superuser">Superuser</string> <!--Do not translate! #6016-->
+    <string name="superuser">Суперпользователь</string> <!--Do not translate! #6016-->
     <string name="logs">Лог</string>
     <string name="settings">Настройки</string>
     <string name="install">Установка</string>


### PR DESCRIPTION
The word "Superuser" has not been translated. I understand that its meaning will be clear to any Russian user who is able to install Magisk, but if you decided to translate the application into Russian, you should do it to the end