### PR TITLE
Fix `/proc/self/attr/prev` when zygisk enabled

### DIFF
--- a/native/src/sepolicy/rules.cpp
+++ b/native/src/sepolicy/rules.cpp
@@ -181,6 +181,8 @@ void sepolicy::magisk_rules() {
     allow("zygote", "zygote", "capability", "sys_resource");  // prctl PR_SET_MM
     allow("zygote", "zygote", "process", "execmem");
     allow("zygote", "fs_type", "filesystem", "unmount");
+    allow("zygote", "init", "process", "dyntransition");
+    allow("init", "zygote", "process", "noatsecure");
     allow("system_server", "system_server", "process", "execmem");
 
     // Shut llkd up


### PR DESCRIPTION
Previously, when zygisk is enabled, all apps'  `/proc/self/attr/prev` will become `u:r:zygote:s0`, but it should be `u:r:init:s0` (as zygisk is disabled).