### PR TITLE
Inject binaries into /system if sbin not accessible

### DIFF
--- a/native/src/core/module.cpp
+++ b/native/src/core/module.cpp
@@ -614,8 +614,7 @@ void magic_mount() {
         system->collect_files(module, fd);
         close(fd);
     }
-    string_view path_env = getenv("PATH");
-    if (MAGISKTMP != "/sbin" || path_env.find("/sbin") == string_view::npos) {
+    if (MAGISKTMP != "/sbin" || !str_contains(getenv("PATH") ?: "", "/sbin")) {
         // Need to inject our binaries into /system/bin
         inject_magisk_bins(system);
     }

--- a/native/src/core/module.cpp
+++ b/native/src/core/module.cpp
@@ -614,7 +614,8 @@ void magic_mount() {
         system->collect_files(module, fd);
         close(fd);
     }
-    if (MAGISKTMP != "/sbin") {
+    string_view path_env = getenv("PATH");
+    if (MAGISKTMP != "/sbin" || path_env.find("/sbin") == string_view::npos) {
         // Need to inject our binaries into /system/bin
         inject_magisk_bins(system);
     }


### PR DESCRIPTION
Some Android 11+ devices have the /sbin partition but not accessible by the global shell (`PATH` doesn't contain `/sbin`). Not only custom ROMs but also some stock ROMs have the same behavior so I believe it is something we need to deal with. 
Fix #6427, fix #4309, fix #5728, fix #3593