### PR TITLE
Refactor magic mount by unsharing magiskd

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -120,7 +120,7 @@ All files you want to replace/inject should be placed in this folder. This folde
 
 If you place a file named `.replace` in any of the folders, instead of merging its contents, that folder will directly replace the one in the real system. This can be very handy for swapping out an entire folder.
 
-If you want to replace files in `/vendor`, `/product`, or `/system_ext`, please place them under `system/vendor`, `system/product`, and `system/system_ext` respectively. Magisk will transparently handle whether these partitions are in a separate partition or not.
+If you want to replace files in `/vendor`, `/vendor_dlkm`, `/product`, `/system_ext`, `/system_dlkm`, `/odm`, or `/odm_dlkm`, please place them under `system/vendor`, `system/product`, and `system/system_ext` respectively. Magisk will transparently handle whether these partitions are in a separate partition or not.
 
 #### Zygisk
 

--- a/native/src/base/misc.cpp
+++ b/native/src/base/misc.cpp
@@ -95,6 +95,9 @@ int exec_command(exec_t &exec) {
     if (exec.pre_exec)
         exec.pre_exec();
 
+    if (exec.ns_pid > 0)
+        switch_mnt_ns(exec.ns_pid);
+
     execve(exec.argv[0], (char **) exec.argv, environ);
     PLOGE("execve %s", exec.argv[0]);
     exit(-1);
@@ -232,4 +235,93 @@ int ssprintf(char *dest, size_t size, const char *fmt, ...) {
 #undef strlcpy
 size_t strscpy(char *dest, const char *src, size_t size) {
     return std::min(strlcpy(dest, src, size), size - 1);
+}
+
+std::vector<MountInfo> ParseMountInfo(const char *pid) {
+    char buf[PATH_MAX] = {};
+    ssprintf(buf, sizeof(buf), "/proc/%s/mountinfo", pid);
+    auto mount_info = xopen_file(buf, "r");
+    char *line = nullptr;
+    run_finally free_line([&line] { free(line); });
+    size_t len = 0;
+    ssize_t nread;
+
+    std::vector<MountInfo> result;
+
+    while ((nread = getline(&line, &len, mount_info.get())) != -1) {
+        if (line[nread - 1] == '\n')
+            line[nread - 1] = '\0';
+        int root_start = 0, root_end = 0;
+        int target_start = 0, target_end = 0;
+        int vfs_option_start = 0, vfs_option_end = 0;
+        int type_start = 0, type_end = 0;
+        int source_start = 0, source_end = 0;
+        int fs_option_start = 0, fs_option_end = 0;
+        int optional_start = 0, optional_end = 0;
+        unsigned int id, parent, maj, min;
+        sscanf(line,
+               "%u "           // (1) id
+               "%u "           // (2) parent
+               "%u:%u "        // (3) maj:min
+               "%n%*s%n "      // (4) mountroot
+               "%n%*s%n "      // (5) target
+               "%n%*s%n"       // (6) vfs options (fs-independent)
+               "%n%*[^-]%n - " // (7) optional fields
+               "%n%*s%n "      // (8) FS type
+               "%n%*s%n "      // (9) source
+               "%n%*s%n",      // (10) fs options (fs specific)
+               &id, &parent, &maj, &min, &root_start, &root_end, &target_start,
+               &target_end, &vfs_option_start, &vfs_option_end,
+               &optional_start, &optional_end, &type_start, &type_end,
+               &source_start, &source_end, &fs_option_start, &fs_option_end);
+        std::string_view line_view(line, nread - 1);
+
+        auto root = line_view.substr(root_start, root_end - root_start);
+        auto target = line_view.substr(target_start, target_end - target_start);
+        auto vfs_option =
+                line_view.substr(vfs_option_start, vfs_option_end - vfs_option_start);
+        ++optional_start;
+        --optional_end;
+        auto optional = line_view.substr(
+                optional_start,
+                optional_end - optional_start > 0 ? optional_end - optional_start : 0);
+
+        auto type = line_view.substr(type_start, type_end - type_start);
+        auto source = line_view.substr(source_start, source_end - source_start);
+        auto fs_option =
+                line_view.substr(fs_option_start, fs_option_end - fs_option_start);
+
+        unsigned int shared = 0;
+        unsigned int master = 0;
+        unsigned int propagate_from = 0;
+        if (auto pos = optional.find("shared:"); pos != std::string_view::npos) {
+            shared = strtoul(optional.data() + pos + 7, nullptr, 10);
+        }
+        if (auto pos = optional.find("master:"); pos != std::string_view::npos) {
+            master = strtoul(optional.data() + pos + 7, nullptr, 10);
+        }
+        if (auto pos = optional.find("propagate_from:");
+                pos != std::string_view::npos) {
+            propagate_from = strtoul(optional.data() + pos + 15, nullptr, 10);
+        }
+
+        result.emplace_back(MountInfo{
+                .id = id,
+                .parent = parent,
+                .device = static_cast<dev_t>(makedev(maj, min)),
+                .root = std::string(root),
+                .target = std::string(target),
+                .vfs_option = std::string(vfs_option),
+                .optional =
+                        {
+                                .shared = shared,
+                                .master = master,
+                                .propagate_from = propagate_from,
+                        },
+                .type = std::string(type),
+                .source = std::string(source),
+                .fs_option = std::string(fs_option),
+        });
+    }
+    return result;
 }

--- a/native/src/base/misc.hpp
+++ b/native/src/base/misc.hpp
@@ -182,6 +182,7 @@ struct exec_t {
     void (*pre_exec)() = nullptr;
     int (*fork)() = xfork;
     const char **argv = nullptr;
+    pid_t ns_pid = -1;
 };
 
 int exec_command(exec_t &exec);
@@ -212,3 +213,22 @@ void exec_command_async(Args &&...args) {
     };
     exec_command(exec);
 }
+
+struct MountInfo {
+    unsigned int id;
+    unsigned int parent;
+    dev_t device;
+    std::string root;
+    std::string target;
+    std::string vfs_option;
+    struct {
+        unsigned int shared;
+        unsigned int master;
+        unsigned int propagate_from;
+    } optional;
+    std::string type;
+    std::string source;
+    std::string fs_option;
+};
+
+std::vector<MountInfo> ParseMountInfo(const char *pid);

--- a/native/src/core/core.hpp
+++ b/native/src/core/core.hpp
@@ -20,7 +20,6 @@ void remove_modules();
 void exec_module_scripts(const char *stage);
 
 // Scripting
-void exec_script(const char *script);
 void exec_common_scripts(const char *stage);
 void exec_module_scripts(const char *stage, const std::vector<std::string_view> &modules);
 void install_apk(const char *apk);

--- a/native/src/include/magisk.hpp
+++ b/native/src/include/magisk.hpp
@@ -13,13 +13,15 @@
 #define MODULEUPGRADE   SECURE_DIR "/modules_update"
 #define DATABIN         SECURE_DIR "/magisk"
 #define MAGISKDB        SECURE_DIR "/magisk.db"
+#define BLOCKBYNAMEDIR  "/dev/block/by-name"
 
 // tmpfs paths
 extern std::string  MAGISKTMP;
 #define INTLROOT    ".magisk"
 #define MIRRDIR     INTLROOT "/mirror"
-#define RULESDIR    MIRRDIR "/sepolicy.rules"
+#define RULESDIR    INTLROOT "/sepolicy.rules"
 #define BLOCKDIR    INTLROOT "/block"
+#define WORKERDIR   INTLROOT "/worker"
 #define MODULEMNT   INTLROOT "/modules"
 #define BBPATH      INTLROOT "/busybox"
 #define ROOTOVL     INTLROOT "/rootdir"
@@ -27,6 +29,7 @@ extern std::string  MAGISKTMP;
 #define ROOTMNT     ROOTOVL "/.mount_list"
 #define ZYGISKBIN   INTLROOT "/zygisk"
 #define SELINUXMOCK INTLROOT "/selinux"
+#define RULESENTRY  "/magisk"
 
 constexpr const char *applet_names[] = { "su", "resetprop", nullptr };
 

--- a/native/src/init/init.hpp
+++ b/native/src/init/init.hpp
@@ -60,8 +60,6 @@ class MagiskInit : public BaseInit {
 private:
     void mount_rules_dir();
 protected:
-    std::string custom_rules_dir;
-
 #if ENABLE_AVD_HACK
     // When this boolean is set, this means we are currently
     // running magiskinit on legacy SAR AVD emulator

--- a/native/src/su/su_daemon.cpp
+++ b/native/src/su/su_daemon.cpp
@@ -384,11 +384,14 @@ void su_daemon_handler(int client, const sock_cred *cred) {
     switch (ctx.info->cfg[SU_MNT_NS]) {
         case NAMESPACE_MODE_GLOBAL:
             LOGD("su: use global namespace\n");
+            switch_mnt_ns(1);
             break;
         case NAMESPACE_MODE_REQUESTER:
             LOGD("su: use namespace of pid=[%d]\n", ctx.pid);
-            if (switch_mnt_ns(ctx.pid))
+            if (switch_mnt_ns(ctx.pid)) {
+                switch_mnt_ns(1);
                 LOGD("su: setns failed, fallback to global\n");
+            }
             break;
         case NAMESPACE_MODE_ISOLATE:
             LOGD("su: use new isolated namespace\n");

--- a/native/src/zygisk/deny/deny.hpp
+++ b/native/src/zygisk/deny/deny.hpp
@@ -47,7 +47,10 @@ void ls_list(int client);
 
 // Utility functions
 bool is_deny_target(int uid, std::string_view process);
-void revert_unmount();
+
+// Revert
+void revert_daemon(int pid, int client);
+void revert_unmount(int pid = -1, const char *ref_pid = "self");
 
 extern int sys_ui_app_id;
 extern std::atomic<bool> denylist_enforced;

--- a/native/src/zygisk/entry.cpp
+++ b/native/src/zygisk/entry.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 
 void *self_handle = nullptr;
-
+pid_t magiskd_pid = -1;
 // Make sure /proc/self/environ is sanitized
 // Filter env and reset MM_ENV_END
 static void sanitize_environ() {
@@ -398,6 +398,10 @@ void zygisk_handler(int client, const sock_cred *cred) {
         break;
     case ZygiskRequest::GET_MODDIR:
         get_moddir(client);
+        break;
+    case ZygiskRequest::ZYGISK_UNMOUNT:
+        LOGD("zygisk: cleanup mount namespace for pid=[%d]\n", cred->pid);
+        revert_daemon(cred->pid, client);
         break;
     default:
         // Unknown code

--- a/native/src/zygisk/zygisk.hpp
+++ b/native/src/zygisk/zygisk.hpp
@@ -18,6 +18,7 @@ enum : int {
     CONNECT_COMPANION,
     GET_MODDIR,
     PASSTHROUGH,
+    ZYGISK_UNMOUNT,
     END
 };
 }

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -641,7 +641,7 @@ copy_sepolicy_rules() {
 
   # Find current active RULESDIR
   local RULESDIR
-  local ACTIVEDIR=$(magisk --path)/.magisk/mirror/sepolicy.rules
+  local ACTIVEDIR=$(magisk --path)/.magisk/sepolicy.rules
   if [ -L $ACTIVEDIR ]; then
     RULESDIR=$(readlink $ACTIVEDIR)
     [ "${RULESDIR:0:1}" != "/" ] && RULESDIR="$(magisk --path)/.magisk/mirror/$RULESDIR"


### PR DESCRIPTION
Previously, magic mount creates its own mirror devices and mount mirror mount points. With these mirror mount points, magic mount can get the original files and directory trees. However, some devices use overlayfs to modify some mount points, and thus after magic mount, the overlayed files are missing because the mirror mount points do not contain the overlayed files. To address this issue and make magic mount more compatible, this patch refactors how magic mount works.

The new workflows are as follows:
1. unshare magiskd so that we can create some private mount points
2. make MAGISKTMP a private mount point so that we can create the private mount points there
3. for mirror mount points, we instead of creating our own mirror devices and mount the mirror mount points, we "copy" the original mount points by recursively mounting /
4. to prevent magic mount affecting the mirror mount points, we recursively set the mirror mount points private
5. to trace the mount points we created for reverting mounts, we again make the mirror mount points shared, and by this way we create a new peer group for each mirror mount points
6. as for tracing the newly created tmpfs mount point by magic mount, we create a dedicated tmpfs mount point for them, namely worker mount point, and obviously, it is shared as in a newly created peer group for tracing
7. when reverting mount points by magic mount, we can then trace the peer group id and unmount the mount points whose peer group ids are created by us

The advantages are as follows:
1. it is more compatible, (e.g., with overlayfs, fix #2359)
2. it can mount more partitions for which previous implementation cannot create mirror mount points (fix #3338)