### PR TITLE
run module uninstall.sh on Magisk uninstallation

### DIFF
--- a/native/src/core/daemon.cpp
+++ b/native/src/core/daemon.cpp
@@ -158,12 +158,14 @@ static void handle_request_async(int client, int code, const sock_cred &cred) {
     case MainRequest::SQLITE_CMD:
         exec_sql(client);
         break;
-    case MainRequest::REMOVE_MODULES:
+    case MainRequest::REMOVE_MODULES: {
+        int do_reboot = read_int(client);
         remove_modules();
         write_int(client, 0);
         close(client);
-        reboot();
+        if (do_reboot) reboot();
         break;
+    }
     case MainRequest::ZYGISK:
     case MainRequest::ZYGISK_PASSTHROUGH:
         zygisk_handler(client, &cred);

--- a/native/src/core/magisk.cpp
+++ b/native/src/core/magisk.cpp
@@ -23,7 +23,7 @@ Options:
    -v                        print running daemon version
    -V                        print running daemon version code
    --list                    list all available applets
-   --remove-modules [-n]     remove all modules and reboot if -n is not given
+   --remove-modules [-n]     remove all modules, reboot if -n is not provided
    --install-module ZIP      install a module zip file
 
 Advanced Options (Internal APIs):

--- a/native/src/core/magisk.cpp
+++ b/native/src/core/magisk.cpp
@@ -23,7 +23,7 @@ Options:
    -v                        print running daemon version
    -V                        print running daemon version code
    --list                    list all available applets
-   --remove-modules          remove all modules and reboot
+   --remove-modules [-n]     remove all modules and reboot if -n is not given
    --install-module ZIP      install a module zip file
 
 Advanced Options (Internal APIs):
@@ -114,7 +114,17 @@ int magisk_main(int argc, char *argv[]) {
             printf("%s\n", res.data());
         }
     } else if (argv[1] == "--remove-modules"sv) {
+        int do_reboot;
+        if (argc == 3 && argv[2] == "-n"sv) {
+            do_reboot = 0;
+        } else if (argc == 2) {
+            do_reboot = 1;
+        } else {
+            usage();
+            exit(1);
+        }
         int fd = connect_daemon(MainRequest::REMOVE_MODULES);
+        write_int(fd, do_reboot);
         return read_int(fd);
     } else if (argv[1] == "--path"sv) {
         int fd = connect_daemon(MainRequest::GET_PATH);

--- a/scripts/uninstaller.sh
+++ b/scripts/uninstaller.sh
@@ -137,6 +137,11 @@ case $((STATUS & 3)) in
     ;;
 esac
 
+if $BOOTMODE; then
+  ui_print "- Removing modules"
+  magisk --remove-modules -n
+fi
+
 ui_print "- Removing Magisk files"
 rm -rf \
 /cache/*magisk* /cache/unblock /data/*magisk* /data/cache/*magisk* /data/property/*magisk* \


### PR DESCRIPTION
Currently Magisk does not run `uninstall.sh` script of modules when running Magisk's `uninstaller.sh`