### PR TITLE
Reuse tmpfs for magic mount skeleton

### DIFF
--- a/native/src/core/bootstages.cpp
+++ b/native/src/core/bootstages.cpp
@@ -88,6 +88,12 @@ static void mount_mirrors() {
     char buf1[4096];
     char buf2[4096];
 
+    LOGI("* Prepare worker\n");
+
+    ssprintf(buf1, sizeof(buf1), "%s/" WORKERDIR, MAGISKTMP.data());
+    xmount(buf1, buf1, nullptr, MS_BIND, nullptr);
+    xmount(nullptr, buf1, nullptr, MS_PRIVATE, nullptr);
+
     LOGI("* Mounting mirrors\n");
 
     parse_mnt("/proc/mounts", [&](mntent *me) {

--- a/native/src/core/module.cpp
+++ b/native/src/core/module.cpp
@@ -31,10 +31,10 @@ class module_node;
 class root_node;
 
 template<class T> static bool isa(node_entry *node);
-static int bind_mount(const char *from, const char *to) {
+static int bind_mount(const char *reason, const char *from, const char *to) {
     int ret = xmount(from, to, nullptr, MS_BIND, nullptr);
     if (ret == 0)
-        VLOGD("bind_mnt", from, to);
+        VLOGD(reason, from, to);
     return ret;
 }
 
@@ -78,7 +78,7 @@ protected:
     template<class T>
     explicit node_entry(T*) : _file_type(0), node_type(type_id<T>()) {}
 
-    void create_and_mount(const string &src);
+    void create_and_mount(const char *reason, const string &src);
 
     // Use top bit of _file_type for node exist status
     bool exist() { return static_cast<bool>(_file_type & (1 << 7)); }
@@ -254,7 +254,7 @@ class mirror_node : public node_entry {
 public:
     explicit mirror_node(dirent *entry) : node_entry(entry->d_name, entry->d_type, this) {}
     void mount() override {
-        create_and_mount(mirror_path());
+        create_and_mount("mirror", mirror_path());
     }
 };
 
@@ -413,7 +413,7 @@ bool dir_node::prepare() {
             // Tell parent to upgrade self to tmpfs
             to_tmpfs = true;
             // If child is inter_node and it does not (need to) exist, upgrade to module
-            if (auto dn = dyn_cast<inter_node>(it->second); dn) {
+            if (auto dn = dyn_cast<inter_node>(it->second)) {
                 if (!dn->exist()) {
                     if (auto nit = upgrade<module_node, inter_node>(it); nit != children.end()) {
                         it = nit;
@@ -467,7 +467,7 @@ bool dir_node::collect_files(const char *module, int dfd) {
  * Mount Implementations
  ************************/
 
-void node_entry::create_and_mount(const string &src) {
+void node_entry::create_and_mount(const char *reason, const string &src) {
     const string &dest = node_path();
     if (is_lnk()) {
         VLOGD("cp_link", src.data(), dest.data());
@@ -479,7 +479,7 @@ void node_entry::create_and_mount(const string &src) {
             close(xopen(dest.data(), O_RDONLY | O_CREAT | O_CLOEXEC, 0));
         else
             return;
-        bind_mount(src.data(), dest.data());
+        bind_mount(reason, src.data(), dest.data());
     }
 }
 
@@ -488,9 +488,9 @@ void module_node::mount() {
     if (exist())
         clone_attr(mirror_path().data(), src.data());
     if (isa<tmpfs_node>(parent()))
-        create_and_mount(src);
+        create_and_mount("module", src);
     else if (is_dir() || is_reg())
-        bind_mount(src.data(), node_path().data());
+        bind_mount("module", src.data(), node_path().data());
 }
 
 void tmpfs_node::mount() {
@@ -503,11 +503,13 @@ void tmpfs_node::mount() {
         getattr(src.data(), &a);
     else
         getattr(parent()->node_path().data(), &a);
-    mkdir(dest.data(), 0);
     if (!isa<tmpfs_node>(parent())) {
         // We don't need another layer of tmpfs if parent is skel
-        xmount("tmpfs", dest.data(), "tmpfs", 0, nullptr);
-        VLOGD("mnt_tmp", "tmpfs", dest.data());
+        auto worker_dir = MAGISKTMP + "/" WORKERDIR + dest;
+        mkdirs(worker_dir.data(), 0);
+        create_and_mount("tmpfs", worker_dir);
+    } else {
+        mkdir(dest.data(), 0);
     }
     setattr(dest.data(), &a);
     dir_node::mount();
@@ -538,7 +540,7 @@ public:
             VLOGD("create", "./magiskpolicy", dest.data());
             xsymlink("./magiskpolicy", dest.data());
         }
-        create_and_mount(src);
+        create_and_mount("magisk", src);
     }
 };
 
@@ -574,7 +576,7 @@ if (access("/system/bin/app_process" #bit, F_OK) == 0) {                        
     close(out);                                                                         \
     close(src);                                                                         \
     clone_attr("/system/bin/app_process" #bit, zbin.data());                            \
-    bind_mount(zbin.data(), "/system/bin/app_process" #bit);                            \
+    bind_mount("zygisk", zbin.data(), "/system/bin/app_process" #bit);                  \
 }
 
 void magic_mount() {
@@ -672,7 +674,7 @@ static void prepare_modules() {
     auto src = MAGISKTMP + "/" MIRRDIR MODULEROOT;
     auto dest = MAGISKTMP + "/" MODULEMNT;
     xmkdir(dest.data(), 0755);
-    bind_mount(src.data(), dest.data());
+    bind_mount("mod_mnt", src.data(), dest.data());
 
     restorecon();
     chmod(SECURE_DIR, 0700);

--- a/native/src/include/magisk.hpp
+++ b/native/src/include/magisk.hpp
@@ -20,11 +20,12 @@ extern std::string  MAGISKTMP;
 #define MIRRDIR     INTLROOT "/mirror"
 #define RULESDIR    MIRRDIR "/sepolicy.rules"
 #define BLOCKDIR    INTLROOT "/block"
+#define WORKERDIR   INTLROOT "/worker"
 #define MODULEMNT   INTLROOT "/modules"
 #define BBPATH      INTLROOT "/busybox"
 #define ROOTOVL     INTLROOT "/rootdir"
 #define SHELLPTS    INTLROOT "/pts"
-#define ROOTMNT     ROOTOVL "/.mount_list"
+#define ROOTMNT     ROOTOVL  "/.mount_list"
 #define ZYGISKBIN   INTLROOT "/zygisk"
 #define SELINUXMOCK INTLROOT "/selinux"
 

--- a/native/src/init/mount.cpp
+++ b/native/src/init/mount.cpp
@@ -311,6 +311,7 @@ void MagiskInit::setup_tmp(const char *path) {
     xmkdir(INTLROOT, 0755);
     xmkdir(MIRRDIR, 0);
     xmkdir(BLOCKDIR, 0);
+    xmkdir(WORKERDIR, 0);
 
     mount_rules_dir();
 


### PR DESCRIPTION
As we already have a tmpfs (magisktmp), we can reuse them for magic mount.

I also refine the log so that we can trace each bind mount more clearly.