### PR TITLE
Fix busybox filename

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
@@ -53,8 +53,8 @@ class ShellInit : Shell.Initializer() {
                     "  cp -af $localBB \$MAGISKTMP/busybox/busybox",
                     "  exec \$MAGISKTMP/busybox/busybox sh",
                     "else",
-                    "  cp -af $localBB /dev/.busybox",
-                    "  exec /dev/.busybox sh",
+                    "  cp -af $localBB /dev/busybox",
+                    "  exec /dev/busybox sh",
                     "fi"
                 )
             } else {


### PR DESCRIPTION
Tested on Samsung Galaxy J3109. App showed "N/A" in incomplete environment.
```
root@j3ltectc:/ # /dev/.busybox sh
.busybox: applet not found
```