### PR TITLE
Isolate `optimizedDirectory` between app and root service

### DIFF
--- a/app/shared/src/main/java/com/topjohnwu/magisk/utils/DynamicClassLoader.java
+++ b/app/shared/src/main/java/com/topjohnwu/magisk/utils/DynamicClassLoader.java
@@ -1,5 +1,7 @@
 package com.topjohnwu.magisk.utils;
 
+import android.os.Process;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -14,8 +16,8 @@ public class DynamicClassLoader extends BaseDexClassLoader {
     }
 
     public DynamicClassLoader(File apk, ClassLoader parent) {
-        // Set optimizedDirectory to null to bypass DexFile's security checks
-        super(apk.getPath(), null, null, parent);
+        // Set optimizedDirectory to null for RootService to bypass DexFile's security checks
+        super(apk.getPath(), Process.myUid() == 0 ? null : apk.getParentFile(), null, parent);
     }
 
     @Override


### PR DESCRIPTION
#5911
Since we set `optimizedDirectory` to null, art tries to load oat file from `/data/dalvik-cache`. The app process cannot write to write `dalvik-cache` due to insufficient permissions, but the root process can. The app process will try to use the oat file generated by root service, which may cause permission issues. 


```
java.lang.ClassNotFoundException: com.topjohnwu.magisk.core.App
                                                                                                    	at java.lang.ClassLoader.findClass(ClassLoader.java:344)
                                                                                                    	at java.lang.ClassLoader.loadClass(ClassLoader.java:511)
                                                                                                    	at com.topjohnwu.magisk.AppClassLoader.loadClass(ClassLoaders.java:34)
                                                                                                    	at java.lang.ClassLoader.loadClass(ClassLoader.java:469)
                                                                                                    	at com.topjohnwu.magisk.DynLoad.createAndSetupApp(DynLoad.java:147)
                                                                                                    	at com.topjohnwu.magisk.DelegateApplication.attachBaseContext(DelegateApplication.java:17)
                                                                                                    	at android.app.Application.attach(Application.java:205)
                                                                                                    	at android.app.Instrumentation.newApplication(Instrumentation.java:1019)
                                                                                                    	at android.app.Instrumentation.newApplication(Instrumentation.java:1003)
                                                                                                    	at android.app.LoadedApk.makeApplication(LoadedApk.java:651)
                                                                                                    	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:5985)
                                                                                                    	at android.app.ActivityThread.access$1700(ActivityThread.java:218)
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1779)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:102)
                                                                                                    	at android.os.Looper.loop(Looper.java:145)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:6917)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at java.lang.reflect.Method.invoke(Method.java:372)
                                                                                                    	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1404)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1199)
                                                                                                    	Suppressed: java.lang.ClassNotFoundException: Didn't find class "com.topjohnwu.magisk.core.App" on path: DexPathList[[zip file "/data/data/yfjkvqsxwqy.hmefq.e/dyn/current.apk"],nativeLibraryDirectories=[/vendor/lib, /system/lib]]
                                                                                                    		at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:56)
                                                                                                    		at com.topjohnwu.magisk.utils.DynamicClassLoader.loadClass(DynamicClassLoader.java:36)
                                                                                                    		at java.lang.ClassLoader.loadClass(ClassLoader.java:504)
                                                                                                    		... 18 more
                                                                                                    		Suppressed: java.io.IOException: Failed to open oat file from dex location '/data/data/yfjkvqsxwqy.hmefq.e/dyn/current.apk'
                                                                                                    			at dalvik.system.DexFile.openDexFileNative(Native Method)
                                                                                                    			at dalvik.system.DexFile.openDexFile(DexFile.java:295)
                                                                                                    			at dalvik.system.DexFile.<init>(DexFile.java:80)
                                                                                                    			at dalvik.system.DexFile.<init>(DexFile.java:59)
                                                                                                    			at dalvik.system.DexPathList.loadDexFile(DexPathList.java:262)
                                                                                                    			at dalvik.system.DexPathList.makeDexElements(DexPathList.java:231)
                                                                                                    			at dalvik.system.DexPathList.<init>(DexPathList.java:109)
                                                                                                    			at dalvik.system.BaseDexClassLoader.<init>(BaseDexClassLoader.java:48)
                                                                                                    			at com.topjohnwu.magisk.utils.DynamicClassLoader.<init>(DynamicClassLoader.java:20)
                                                                                                    			at com.topjohnwu.magisk.utils.DynamicClassLoader.<init>(DynamicClassLoader.java:15)
                                                                                                    			at com.topjohnwu.magisk.AppClassLoader.<init>(ClassLoaders.java:27)
                                                                                                    			at com.topjohnwu.magisk.DynLoad.loadApk(DynLoad.java:85)
                                                                                                    			at com.topjohnwu.magisk.DynLoad.createAndSetupApp(DynLoad.java:131)
                                                                                                    			... 15 more
                                                                                                    		Caused by: java.io.IOException: Failed to open oat file from /data/data/yfjkvqsxwqy.hmefq.e/dyn/arm/current.odex (error Failed to open oat filename for reading: No such file or directory) (no dalvik_cache availible) and relocation failed.
                                                                                                    			... 28 more
                                                                                                    		Caused by: java.io.IOException: 
                                                                                                    			... 28 more
                                                                                                    		Caused by: java.io.IOException: Failed to remove obsolete file from /data/dalvik-cache/arm/data@data@yfjkvqsxwqy.hmefq.e@dyn@current.apk@classes.dex when searching for dex file /data/data/yfjkvqsxwqy.hmefq.e/dyn/current.apk: Permission denied
                                                                                                    			... 28 more
```