### PR TITLE
Make changelog scrollable in module update dialog

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/events/dialog/ModuleInstallDialog.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/events/dialog/ModuleInstallDialog.kt
@@ -12,10 +12,8 @@ class ModuleInstallDialog(private val item: OnlineModule) : MarkDownDialog() {
 
     private val svc get() = ServiceLocator.networkService
 
-    override suspend fun getMarkdownText(): String {
-        val str = svc.fetchString(item.changelog)
-        return if (str.length > 1000) str.substring(0, 1000) else str
-    }
+    override suspend fun getMarkdownText(): String =
+        svc.fetchString(item.changelog)
 
     override fun build(dialog: MagiskDialog) {
         super.build(dialog)

--- a/app/src/main/res/layout/markdown_window_md2.xml
+++ b/app/src/main/res/layout/markdown_window_md2.xml
@@ -4,16 +4,20 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/md_txt"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="15dp"
-        android:layout_marginEnd="15dp"
-        android:breakStrategy="simple"
-        android:hyphenationFrequency="none"
-        android:paddingTop="10dp"
-        android:textAppearance="@style/AppearanceFoundation.Caption"
-        tools:ignore="UnusedAttribute" />
+        android:layout_height="wrap_content">
 
+        <TextView
+            android:id="@+id/md_txt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:layout_marginEnd="15dp"
+            android:breakStrategy="simple"
+            android:hyphenationFrequency="none"
+            android:paddingTop="10dp"
+            android:textAppearance="@style/AppearanceFoundation.Caption"
+            tools:ignore="UnusedAttribute" />
+    </ScrollView>
 </ScrollView>


### PR DESCRIPTION
This also removes the 1000 code point limit because the entire text is already loaded into memory and the truncation can sometimes break formatting.

When the changelog is short, the UI behavior is exactly the same as it is now (dialog with short height). When the changelog is long, the dialog expands to fill the screen, adding scrollbars if necessary (eg: [screenshot](https://user-images.githubusercontent.com/646253/212441443-f6c248cb-a98f-4a53-ad82-cac7928339d5.png)).
