### PR TITLE
Fix ResourcesProvider being closed

### DIFF
--- a/stub/src/main/java/com/topjohnwu/magisk/DownloadActivity.java
+++ b/stub/src/main/java/com/topjohnwu/magisk/DownloadActivity.java
@@ -177,9 +177,8 @@ public class DownloadActivity extends Activity {
                 decryptResources(new FileOutputStream(fd));
                 Os.lseek(fd, 0, OsConstants.SEEK_SET);
                 var loader = new ResourcesLoader();
-                try (var pfd = ParcelFileDescriptor.dup(fd);
-                     var provider = ResourcesProvider.loadFromTable(pfd, null)) {
-                    loader.addProvider(provider);
+                try (var pfd = ParcelFileDescriptor.dup(fd)) {
+                    loader.addProvider(ResourcesProvider.loadFromTable(pfd, null));
                     getResources().addLoaders(loader);
                 }
             } finally {


### PR DESCRIPTION
```
java.lang.IllegalStateException: Failed to close provider used by 1 ResourcesLoader instances
                                                                                                      at android.content.res.loader.ResourcesProvider.close(ResourcesProvider.java:268)
                                                                                                      at com.topjohnwu.magisk.DownloadActivity.loadResources(DownloadActivity.java:185)
                                                                                                      at com.topjohnwu.magisk.DownloadActivity.onCreate(DownloadActivity.java:79)
                                                                                                      at android.app.Activity.performCreate(Activity.java:8051)
                                                                                                      at android.app.Activity.performCreate(Activity.java:8031)
                                                                                                      at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1329)
                                                                                                      at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3612)
                                                                                                      at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3796)
                                                                                                      at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
                                                                                                      at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
                                                                                                      at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
                                                                                                      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2214)
                                                                                                      at android.os.Handler.dispatchMessage(Handler.java:106)
                                                                                                      at android.os.Looper.loopOnce(Looper.java:201)
                                                                                                      at android.os.Looper.loop(Looper.java:288)
                                                                                                      at android.app.ActivityThread.main(ActivityThread.java:7842)
                                                                                                      at java.lang.reflect.Method.invoke(Native Method)
                                                                                                      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:550)
                                                                                                      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```
#6274 