### PR TITLE
unshare magiskd

### DIFF
--- a/native/src/core/bootstages.cpp
+++ b/native/src/core/bootstages.cpp
@@ -291,9 +291,6 @@ static bool check_key_combo() {
 extern int disable_deny();
 
 static void post_fs_data() {
-    if (getenv("REMOUNT_ROOT"))
-        xmount(nullptr, "/", nullptr, MS_REMOUNT | MS_RDONLY, nullptr);
-
     if (!check_data())
         return;
 

--- a/native/src/sepolicy/rules.cpp
+++ b/native/src/sepolicy/rules.cpp
@@ -181,6 +181,11 @@ void sepolicy::magisk_rules() {
     allow("zygote", "zygote", "capability", "sys_resource");  // prctl PR_SET_MM
     allow("zygote", "zygote", "process", "execmem");
     allow("zygote", "fs_type", "filesystem", "unmount");
+    allow("zygote", SEPOL_PROC_DOMAIN, "dir", "getattr");
+    allow("zygote", SEPOL_PROC_DOMAIN, "dir", "search");
+    allow("zygote", SEPOL_PROC_DOMAIN, "lnk_file", "getattr");
+    allow("zygote", SEPOL_PROC_DOMAIN, "lnk_file", "read");
+    allow("zygote", SEPOL_PROC_DOMAIN, "file", "read");
     allow("system_server", "system_server", "process", "execmem");
 
     // Shut llkd up


### PR DESCRIPTION
su processes using the global namespace are not affected and still get the same file view as before and shared with other su processes.
zygisk modules may use files in magisktmp (new path is `/proc/magiskd/root/sbin`), so add selinux rules to allow.