### PR TITLE
Zygisk v4 module's plt commit should not use regex

### DIFF
--- a/native/src/zygisk/hook.cpp
+++ b/native/src/zygisk/hook.cpp
@@ -368,6 +368,7 @@ bool ZygiskModule::RegisterModuleImpl(ApiTable *api, long *module) {
         api->v2.getFlags = [](auto) { return ZygiskModule::getFlags(); };
     }
     if (api_version >= 4) {
+        api->v4.pltHookCommit = lsplt::CommitHook;
         api->v4.pltHookRegister = [](dev_t dev, ino_t inode, const char *symbol, void *fn, void **backup) {
             if (dev == 0 || inode == 0 || symbol == nullptr || fn == nullptr)
                 return;


### PR DESCRIPTION
and upgrade lsplt btw.