### PR TITLE
Add `init_boot.img` patching for Samsung tar firmware packages

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
@@ -238,14 +238,13 @@ abstract class MagiskInstallImpl protected constructor(
             }
             boot.delete()
         } else {
-            if (!initBoot.exists()) {
-                if (!boot.exists()) {
+            srcBoot = when {
+                initBoot.exists() -> initBoot
+                boot.exists() -> boot
+                else -> {
                     console.add("! No boot image found")
                     throw IOException()
                 }
-                srcBoot = boot
-            } else {
-                srcBoot = initBoot
             }
         }
         return tarOut
@@ -306,14 +305,13 @@ abstract class MagiskInstallImpl protected constructor(
         try {
             val newBoot = installDir.getChildFile("new-boot.img")
             if (outStream is TarOutputStream) {
-                val name =
-                    if (srcBoot.path.contains("recovery")) {
-                        "recovery.img"
-                    } else if (srcBoot.path.contains("init_boot")) {
-                        "init_boot.img"
-                    } else {
-                        "boot.img"
+                val name = with(srcBoot.path) {
+                    when {
+                        contains("recovery") -> "recovery.img"
+                        contains("init_boot") -> "init_boot.img"
+                        else -> "boot.img"
                     }
+                }
                 outStream.putNextEntry(newTarEntry(name, newBoot.length()))
             }
             newBoot.newInputStream().cleanPump(outStream)


### PR DESCRIPTION
As discussed in #6585, Samsung devices shipping with Android 13 (Eg. S23 family, A14 5G) follow Google guidelines for [generic boot partitions](https://source.android.com/docs/core/architecture/partitions/generic-boot?hl=en), thus moving the ramdisk from `boot.img` to `init_boot.img`. Since most of the users patch the tar firmware packages provided by Samsung rather than the single image individually, add support for `init_boot.img` patching in the `processTar` function.