### PR TITLE
No kernel repack if it isn't patched at all 

### DIFF
--- a/native/src/boot/bootimg.cpp
+++ b/native/src/boot/bootimg.cpp
@@ -601,6 +601,9 @@ void repack(const char *src_img, const char *out_img, bool skip_comp) {
             // zImage size shall remain the same
             hdr->kernel_size() = boot.hdr->kernel_size();
         }
+    } else if (boot.hdr->kernel_size() != 0) {
+        xwrite(fd, boot.kernel, boot.hdr->kernel_size());
+        hdr->kernel_size() = boot.hdr->kernel_size();
     }
     if (boot.flags[ZIMAGE_KERNEL]) {
         // Copy zImage tail and adjust size accordingly

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -222,7 +222,7 @@ if [ -f kernel ]; then
   736B69705F696E697472616D667300 \
   77616E745F696E697472616D667300 \
   && PATCHEDKERNEL=true
-  
+
   # If the kernel doesn't need to be patched at all,
   # keep raw kernel to avoid bootloops on some weird devices
   $PATCHEDKERNEL || rm -f kernel


### PR DESCRIPTION
It turns out that decompressing and recompressing the kernel is enough to break booting on many devices that use MT6763.
So don't repack the kernel if it isn't patched.
As the kernel contains "skip_initramfs" but actually the device uses rootfs, we also need to check if the device is SAR before applying the SAR patch

Fix #5124, fix #6204, fix #6566