### PR TITLE
Allow modifying denylist configuration without enabling zygisk in magisk app

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsItems.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsItems.kt
@@ -230,7 +230,6 @@ object Zygisk : BaseSettingsItem.Toggle() {
         set(value) {
             Config.zygisk = value
             DenyList.isEnabled = value
-            DenyListConfig.isEnabled = value
             notifyPropertyChanged(BR.description)
             DenyList.notifyPropertyChanged(BR.description)
         }
@@ -271,9 +270,6 @@ object DenyList : BaseSettingsItem.Toggle() {
 object DenyListConfig : BaseSettingsItem.Blank() {
     override val title = R.string.settings_denylist_config_title.asText()
     override val description = R.string.settings_denylist_config_summary.asText()
-    override fun refresh() {
-        isEnabled = Zygisk.value
-    }
 }
 
 // --- Superuser


### PR DESCRIPTION
I knew denylist can still be _configured in CLI_ or temporarily toggle Zygisk off. Why not allow it unconditionally? Please don't  just close PR without proper explanation