### PR TITLE
magiskboot: add basic support for vendor_boot v4

### DIFF
--- a/native/src/boot/bootimg.cpp
+++ b/native/src/boot/bootimg.cpp
@@ -482,6 +482,7 @@ bool boot_img::parse_image(const uint8_t *p, format_t type) {
             fprintf(stderr, "%-*s [%s]\n", PADDING, "NAME", r_hdr->name);
             ramdisk += sizeof(mtk_hdr);
             hdr->ramdisk_size() -= sizeof(mtk_hdr);
+            entry->ramdisk_size = hdr->ramdisk_size();
             fmt = check_fmt_lg(ramdisk, hdr->ramdisk_size());
         }
         for (const auto&[entry, fmt]: ramdisk_table_entries) {

--- a/native/src/boot/bootimg.cpp
+++ b/native/src/boot/bootimg.cpp
@@ -592,7 +592,7 @@ int unpack(const char *image, bool skip_decomp, bool hdr, bool accept_vendor) {
     if (boot.hdr->is_vendor() && boot.hdr->header_version() == 4 && !boot.ramdisk_table_entries.empty()) {
         char file_name[PATH_MAX] = {};
         for (const auto& [entry, fmt]: boot.ramdisk_table_entries) {
-            ssprintf(file_name, sizeof(file_name), VENDOR_RAMDISK_FILE, VENDOR_RAMDISK_NAME_SIZE, entry->ramdisk_name);
+            ssprintf(file_name, sizeof(file_name), VENDOR_RAMDISK_FILE, entry->ramdisk_name);
             dump_ramdisk(boot.ramdisk + entry->ramdisk_offset, entry->ramdisk_size, fmt, file_name, skip_decomp);
         }
     } else {
@@ -759,7 +759,7 @@ void repack(const char *src_img, const char *out_img, bool skip_comp) {
     if (hdr->is_vendor() && hdr->header_version() == 4 && !new_ramdisk_table_entries.empty()) {
         char file_name[PATH_MAX] = {};
         for (auto &[entry, fmt] : new_ramdisk_table_entries) {
-            ssprintf(file_name, sizeof(file_name), VENDOR_RAMDISK_FILE, VENDOR_RAMDISK_NAME_SIZE, entry.ramdisk_name);
+            ssprintf(file_name, sizeof(file_name), VENDOR_RAMDISK_FILE, entry.ramdisk_name);
             entry.ramdisk_size = repack_ramdisk(fd, fmt, file_name, skip_comp);
             entry.ramdisk_offset = hdr->ramdisk_size();
             hdr->ramdisk_size() += entry.ramdisk_size;

--- a/native/src/boot/bootimg.hpp
+++ b/native/src/boot/bootimg.hpp
@@ -3,8 +3,9 @@
 #include <stdint.h>
 #include <utility>
 #include <bitset>
+#include <vector>
 #include <cxx.h>
-#include <memory>
+
 #include "format.hpp"
 
 /******************
@@ -602,6 +603,7 @@ struct boot_img {
 
     // The format of kernel, ramdisk and extra
     format_t k_fmt = UNKNOWN;
+    format_t r_fmt = UNKNOWN;
     format_t e_fmt = UNKNOWN;
 
     /*************************************************************
@@ -652,7 +654,7 @@ struct boot_img {
     const uint8_t *vendor_ramdisk_table;
     const uint8_t *bootconfig;
 
-    std::vector<std::tuple<std::unique_ptr<vendor_ramdisk_table_entry_v4>, format_t>> ramdisk_table_entries;
+    std::vector<std::tuple<vendor_ramdisk_table_entry_v4*, format_t>> ramdisk_table_entries;
 
     // dtb embedded in kernel
     byte_view kernel_dtb;

--- a/native/src/boot/magiskboot.hpp
+++ b/native/src/boot/magiskboot.hpp
@@ -3,6 +3,8 @@
 #include <sys/types.h>
 
 #include <base.hpp>
+#include "bootimg.hpp"
+#include "flags.h"
 
 #define HEADER_FILE     "header"
 #define KERNEL_FILE     "kernel"
@@ -16,7 +18,7 @@
 #define BOOTCONFIG_FILE "bootconfig"
 #define VENDOR_RAMDISK_FILE_PREFIX  "vendor_ramdisk_"
 #define VENDOR_RAMDISK_FILE_SUFFIX  ".cpio"
-#define VENDOR_RAMDISK_FILE         VENDOR_RAMDISK_FILE_PREFIX "%.*s" VENDOR_RAMDISK_FILE_SUFFIX
+#define VENDOR_RAMDISK_FILE         VENDOR_RAMDISK_FILE_PREFIX "%." str(VENDOR_RAMDISK_NAME_SIZE) "s" VENDOR_RAMDISK_FILE_SUFFIX
 
 int unpack(const char *image, bool skip_decomp = false, bool hdr = false, bool accept_vendor = false);
 void repack(const char *src_img, const char *out_img, bool skip_comp = false);

--- a/native/src/boot/magiskboot.hpp
+++ b/native/src/boot/magiskboot.hpp
@@ -4,17 +4,19 @@
 
 #include <base.hpp>
 
-#define HEADER_FILE     "header"
-#define KERNEL_FILE     "kernel"
-#define RAMDISK_FILE    "ramdisk.cpio"
-#define SECOND_FILE     "second"
-#define EXTRA_FILE      "extra"
-#define KER_DTB_FILE    "kernel_dtb"
-#define RECV_DTBO_FILE  "recovery_dtbo"
-#define DTB_FILE        "dtb"
-#define NEW_BOOT        "new-boot.img"
+#define HEADER_FILE         "header"
+#define KERNEL_FILE         "kernel"
+#define RAMDISK_FILE        "ramdisk.cpio"
+#define SECOND_FILE         "second"
+#define EXTRA_FILE          "extra"
+#define KER_DTB_FILE        "kernel_dtb"
+#define RECV_DTBO_FILE      "recovery_dtbo"
+#define DTB_FILE            "dtb"
+#define VENDOR_RAMDISK_FILE "vendor_ramdisk_%.*s.cpio"
+#define BOOTCONFIG_FILE     "bootconfig"
+#define NEW_BOOT            "new-boot.img"
 
-int unpack(const char *image, bool skip_decomp = false, bool hdr = false);
+int unpack(const char *image, bool skip_decomp = false, bool hdr = false, bool vendor = false);
 void repack(const char *src_img, const char *out_img, bool skip_comp = false);
 int verify(const char *image, const char *cert);
 int sign(const char *image, const char *name, const char *cert, const char *key);

--- a/native/src/boot/magiskboot.hpp
+++ b/native/src/boot/magiskboot.hpp
@@ -4,19 +4,21 @@
 
 #include <base.hpp>
 
-#define HEADER_FILE         "header"
-#define KERNEL_FILE         "kernel"
-#define RAMDISK_FILE        "ramdisk.cpio"
-#define SECOND_FILE         "second"
-#define EXTRA_FILE          "extra"
-#define KER_DTB_FILE        "kernel_dtb"
-#define RECV_DTBO_FILE      "recovery_dtbo"
-#define DTB_FILE            "dtb"
-#define VENDOR_RAMDISK_FILE "vendor_ramdisk_%.*s.cpio"
-#define BOOTCONFIG_FILE     "bootconfig"
-#define NEW_BOOT            "new-boot.img"
+#define HEADER_FILE     "header"
+#define KERNEL_FILE     "kernel"
+#define RAMDISK_FILE    "ramdisk.cpio"
+#define SECOND_FILE     "second"
+#define EXTRA_FILE      "extra"
+#define KER_DTB_FILE    "kernel_dtb"
+#define RECV_DTBO_FILE  "recovery_dtbo"
+#define DTB_FILE        "dtb"
+#define NEW_BOOT        "new-boot.img"
+#define BOOTCONFIG_FILE "bootconfig"
+#define VENDOR_RAMDISK_FILE_PREFIX  "vendor_ramdisk_"
+#define VENDOR_RAMDISK_FILE_SUFFIX  ".cpio"
+#define VENDOR_RAMDISK_FILE         VENDOR_RAMDISK_FILE_PREFIX "%.*s" VENDOR_RAMDISK_FILE_SUFFIX
 
-int unpack(const char *image, bool skip_decomp = false, bool hdr = false, bool vendor = false);
+int unpack(const char *image, bool skip_decomp = false, bool hdr = false, bool accept_vendor = false);
 void repack(const char *src_img, const char *out_img, bool skip_comp = false);
 int verify(const char *image, const char *cert);
 int sign(const char *image, const char *name, const char *cert, const char *key);

--- a/native/src/boot/main.cpp
+++ b/native/src/boot/main.cpp
@@ -1,9 +1,9 @@
-#include <fnmatch.h>
 #include <base.hpp>
 
 #include "boot-rs.hpp"
 #include "magiskboot.hpp"
 #include "compress.hpp"
+#include <string>
 
 using namespace std;
 
@@ -146,11 +146,18 @@ int main(int argc, char *argv[]) {
         unlink(RECV_DTBO_FILE);
         unlink(DTB_FILE);
         unlink(BOOTCONFIG_FILE);
-        char file_name[sizeof(VENDOR_RAMDISK_FILE)];
-        ssprintf(file_name, sizeof(file_name), VENDOR_RAMDISK_FILE, 2, "*");
+
+        char file_namen_pattern[sizeof(VENDOR_RAMDISK_FILE)];
+        ssprintf(file_namen_pattern, sizeof(file_namen_pattern), VENDOR_RAMDISK_FILE, 3, ",");
+        string file_name(file_namen_pattern);
+        size_t split_pos = file_name.find(",");
+        string start_match = file_name.substr(0, split_pos);
+        string end_match = file_name.substr(split_pos + 1);
+
         sDIR d = xopen_dir(".");
         while (struct dirent *dir = xreaddir(d.get())) {
-            if (dir->d_type == DT_REG && !fnmatch(file_name, dir->d_name, 0))
+            string s(dir->d_name);
+            if (dir->d_type == DT_REG && s.starts_with(start_match) && s.ends_with(end_match))
                 unlink(dir->d_name);
         }
     } else if (argc > 2 && action == "sha1") {

--- a/native/src/boot/main.cpp
+++ b/native/src/boot/main.cpp
@@ -3,7 +3,6 @@
 #include "boot-rs.hpp"
 #include "magiskboot.hpp"
 #include "compress.hpp"
-#include <string>
 
 using namespace std;
 
@@ -147,18 +146,14 @@ int main(int argc, char *argv[]) {
         unlink(DTB_FILE);
         unlink(BOOTCONFIG_FILE);
 
-        char file_namen_pattern[sizeof(VENDOR_RAMDISK_FILE)];
-        ssprintf(file_namen_pattern, sizeof(file_namen_pattern), VENDOR_RAMDISK_FILE, 3, ",");
-        string file_name(file_namen_pattern);
-        size_t split_pos = file_name.find(",");
-        string start_match = file_name.substr(0, split_pos);
-        string end_match = file_name.substr(split_pos + 1);
-
         sDIR d = xopen_dir(".");
         while (struct dirent *dir = xreaddir(d.get())) {
-            string s(dir->d_name);
-            if (dir->d_type == DT_REG && s.starts_with(start_match) && s.ends_with(end_match))
+            string_view file_name(dir->d_name);
+            if (dir->d_type == DT_REG &&
+                file_name.starts_with(VENDOR_RAMDISK_FILE_PREFIX) &&
+                file_name.ends_with(VENDOR_RAMDISK_FILE_SUFFIX)) {
                 unlink(dir->d_name);
+            }
         }
     } else if (argc > 2 && action == "sha1") {
         uint8_t sha1[20];

--- a/native/src/boot/main.cpp
+++ b/native/src/boot/main.cpp
@@ -1,3 +1,4 @@
+#include <fnmatch.h>
 #include <base.hpp>
 
 #include "boot-rs.hpp"
@@ -24,7 +25,7 @@ R"EOF(MagiskBoot - Boot Image Modification Tool
 Usage: %s <action> [args...]
 
 Supported actions:
-  unpack [-n] [-h] <bootimg>
+  unpack [-n] [-h] [--vendor] <bootimg>
     Unpack <bootimg> to its individual components, each component to
     a file with its corresponding file name in the current directory.
     Supported components: kernel, kernel_dtb, ramdisk.cpio, second,
@@ -35,6 +36,8 @@ Supported actions:
     If '-h' is provided, the boot image header information will be
     dumped to the file 'header', which can be used to modify header
     configurations during repacking.
+    If '--vendor' is provided, magiskboot will accept vendor boot images.
+    Otherwise, vendor boot images will be rejected.
     Return values:
     0:valid    1:error    2:chromeos
 
@@ -142,6 +145,14 @@ int main(int argc, char *argv[]) {
         unlink(EXTRA_FILE);
         unlink(RECV_DTBO_FILE);
         unlink(DTB_FILE);
+        unlink(BOOTCONFIG_FILE);
+        char file_name[sizeof(VENDOR_RAMDISK_FILE)];
+        ssprintf(file_name, sizeof(file_name), VENDOR_RAMDISK_FILE, 2, "*");
+        sDIR d = xopen_dir(".");
+        while (struct dirent *dir = xreaddir(d.get())) {
+            if (dir->d_type == DT_REG && !fnmatch(file_name, dir->d_name, 0))
+                unlink(dir->d_name);
+        }
     } else if (argc > 2 && action == "sha1") {
         uint8_t sha1[20];
         {
@@ -163,22 +174,27 @@ int main(int argc, char *argv[]) {
         int idx = 2;
         bool nodecomp = false;
         bool hdr = false;
+        bool vendor = false;
         for (;;) {
             if (idx >= argc)
                 usage(argv[0]);
             if (argv[idx][0] != '-')
                 break;
             for (char *flag = &argv[idx][1]; *flag; ++flag) {
-                if (*flag == 'n')
+                if (*flag == 'n') {
                     nodecomp = true;
-                else if (*flag == 'h')
+                } else if (*flag == 'h') {
                     hdr = true;
-                else
+                } else if (flag == "-vendor"sv) {
+                    vendor = true;
+                    break;
+                } else {
                     usage(argv[0]);
+                }
             }
             ++idx;
         }
-        return unpack(argv[idx], nodecomp, hdr);
+        return unpack(argv[idx], nodecomp, hdr, vendor);
     } else if (argc > 2 && action == "repack") {
         if (argv[2] == "-n"sv) {
             if (argc == 3)


### PR DESCRIPTION
This PR addresses Issue #6460 and adds the following functionalities:
        * un- and repack multiple ramdisks
	* un- and repack bootconfig

There is currently no support for adding or removing ramdisk fragments.