### PR TITLE
Add support for getting property context

### DIFF
--- a/native/src/external/systemproperties/contexts_serialized.cpp
+++ b/native/src/external/systemproperties/contexts_serialized.cpp
@@ -144,6 +144,12 @@ prop_area* ContextsSerialized::GetPropAreaForName(const char* name) {
   return context_node->pa();
 }
 
+const char* ContextsSerialized::GetContextForName(const char* name) {
+  const char* context;
+  property_info_area_file_->GetPropertyInfo(name, &context, nullptr);
+  return context;
+}
+
 void ContextsSerialized::ForEach(void (*propfn)(const prop_info* pi, void* cookie), void* cookie) {
   for (size_t i = 0; i < num_context_nodes_; ++i) {
     if (context_nodes_[i].CheckAccessAndOpen()) {

--- a/native/src/external/systemproperties/contexts_split.cpp
+++ b/native/src/external/systemproperties/contexts_split.cpp
@@ -344,6 +344,16 @@ prop_area* ContextsSplit::GetPropAreaForName(const char* name) {
   return cnode->pa();
 }
 
+const char* ContextsSplit::GetContextForName(const char* name) {
+  auto entry = ListFind(prefixes_, [name](PrefixNode* l) {
+      return l->prefix[0] == '*' || !strncmp(l->prefix, name, l->prefix_len);
+  });
+  if (!entry) {
+    return nullptr;
+  }
+  return entry->context->context();
+}
+
 void ContextsSplit::ForEach(void (*propfn)(const prop_info* pi, void* cookie), void* cookie) {
   ListForEach(contexts_, [propfn, cookie](ContextListNode* l) {
     if (l->CheckAccessAndOpen()) {

--- a/native/src/external/systemproperties/include/_system_properties.h
+++ b/native/src/external/systemproperties/include/_system_properties.h
@@ -111,6 +111,12 @@ int __system_property_add(const char* __name, unsigned int __name_length, const 
 */
 int __system_property_delete(const char *__name, bool __trim_node);
 
+/* Get context of a property. Added in resetprop
+**
+** Returns the context on success, nullptr if fail.
+**/
+const char* __system_property_get_context(const char* __name);
+
 /* Update the value of a system property returned by
 ** __system_property_find.  Can only be done by a single process
 ** that has write access to the property area, and that process

--- a/native/src/external/systemproperties/include/system_properties/contexts.h
+++ b/native/src/external/systemproperties/include/system_properties/contexts.h
@@ -38,6 +38,8 @@ class Contexts {
 
   virtual bool Initialize(bool writable, const char* filename, bool* fsetxattr_failed) = 0;
   virtual prop_area* GetPropAreaForName(const char* name) = 0;
+  // resetprop added
+  virtual const char* GetContextForName(const char* name) = 0;
   virtual prop_area* GetSerialPropArea() = 0;
   virtual void ForEach(void (*propfn)(const prop_info* pi, void* cookie), void* cookie) = 0;
   virtual void ResetAccess() = 0;

--- a/native/src/external/systemproperties/include/system_properties/contexts_pre_split.h
+++ b/native/src/external/systemproperties/include/system_properties/contexts_pre_split.h
@@ -47,6 +47,10 @@ class ContextsPreSplit : public Contexts {
     return pre_split_prop_area_;
   }
 
+  virtual const char* GetContextForName(const char* name) override {
+    return nullptr;
+  }
+
   virtual prop_area* GetSerialPropArea() override {
     return pre_split_prop_area_;
   }

--- a/native/src/external/systemproperties/include/system_properties/contexts_serialized.h
+++ b/native/src/external/systemproperties/include/system_properties/contexts_serialized.h
@@ -40,6 +40,7 @@ class ContextsSerialized : public Contexts {
 
   virtual bool Initialize(bool writable, const char* filename, bool* fsetxattr_failed) override;
   virtual prop_area* GetPropAreaForName(const char* name) override;
+  virtual const char* GetContextForName(const char* name) override;
   virtual prop_area* GetSerialPropArea() override {
     return serial_prop_area_;
   }

--- a/native/src/external/systemproperties/include/system_properties/contexts_split.h
+++ b/native/src/external/systemproperties/include/system_properties/contexts_split.h
@@ -40,6 +40,7 @@ class ContextsSplit : public Contexts {
 
   virtual bool Initialize(bool writable, const char* filename, bool* fsetxattr_failed) override;
   virtual prop_area* GetPropAreaForName(const char* name) override;
+  virtual const char* GetContextForName(const char* name) override;
   virtual prop_area* GetSerialPropArea() override {
     return serial_prop_area_;
   }

--- a/native/src/external/systemproperties/include/system_properties/system_properties.h
+++ b/native/src/external/systemproperties/include/system_properties/system_properties.h
@@ -68,6 +68,7 @@ class SystemProperties {
   int Update(prop_info* pi, const char* value, unsigned int len);
   int Add(const char* name, unsigned int namelen, const char* value, unsigned int valuelen);
   int Delete(const char *name, bool trim_node);
+  const char* GetContext(const char* name);
   uint32_t Serial(const prop_info* pi);
   uint32_t WaitAny(uint32_t old_serial);
   bool Wait(const prop_info* pi, uint32_t old_serial, uint32_t* new_serial_ptr,

--- a/native/src/external/systemproperties/system_properties.cpp
+++ b/native/src/external/systemproperties/system_properties.cpp
@@ -325,6 +325,13 @@ int SystemProperties::Delete(const char *name, bool trim_node) {
   return 0;
 }
 
+const char* SystemProperties::GetContext(const char* name) {
+  if (!initialized_) {
+    return nullptr;
+  }
+  return contexts_->GetContextForName(name);
+}
+
 // Wait for non-locked serial, and retrieve it with acquire semantics.
 uint32_t SystemProperties::Serial(const prop_info* pi) {
   uint32_t serial = load_const_atomic(&pi->serial, memory_order_acquire);

--- a/native/src/external/systemproperties/system_property_api.cpp
+++ b/native/src/external/systemproperties/system_property_api.cpp
@@ -105,6 +105,11 @@ int __system_property_delete(const char *name, bool trim_node) {
 }
 
 __BIONIC_WEAK_FOR_NATIVE_BRIDGE
+const char* __system_property_get_context(const char *name) {
+  return system_properties.GetContext(name);
+}
+
+__BIONIC_WEAK_FOR_NATIVE_BRIDGE
 uint32_t __system_property_serial(const prop_info* pi) {
   return system_properties.Serial(pi);
 }

--- a/native/src/include/resetprop.hpp
+++ b/native/src/include/resetprop.hpp
@@ -5,6 +5,7 @@
 
 int setprop(const char *name, const char *value, bool prop_svc = true);
 std::string getprop(const char *name, bool persist = false);
+const char* getpropcontext(const char *name);
 void getprops(void (*callback)(const char *, const char *, void *),
         void *cookie = nullptr, bool persist = false);
 int delprop(const char *name, bool persist = false);

--- a/native/src/resetprop/resetprop.cpp
+++ b/native/src/resetprop/resetprop.cpp
@@ -118,6 +118,7 @@ static void read_prop(const prop_info *pi, void *cb) {
 struct sysprop_stub {
     virtual int setprop(const char *name, const char *value, bool trigger) { return 1; }
     virtual string getprop(const char *name, bool persist) { return string(); }
+    virtual const char* getcontext(const char *name) { return nullptr; }
     virtual void getprops(void (*callback)(const char *, const char *, void *),
             void *cookie, bool persist) {}
     virtual int delprop(const char *name, bool persist) { return 1; }
@@ -211,6 +212,10 @@ struct resetprop : public sysprop {
         return val;
     }
 
+    const char* getcontext(const char *name) override {
+        return __system_property_get_context(name);
+    }
+
     void getprops(void (*callback)(const char *, const char *, void *),
             void *cookie, bool persist) override {
         prop_list list;
@@ -272,6 +277,10 @@ static void print_props(bool persist) {
 
 string getprop(const char *name, bool persist) {
     return get_impl()->getprop(name, persist);
+}
+
+const char* getpropcontext(const char *name) {
+    return get_impl()->getcontext(name);
 }
 
 void getprops(void (*callback)(const char *, const char *, void *), void *cookie, bool persist) {


### PR DESCRIPTION
The planned `resetprop -Z` has been given up because it requires root privilege to run while `getprop` doesn't, and Android before 7.0 do not support property context.
But this is still useful for #6659