### PR TITLE
Make magic mount read only

### DIFF
--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -113,8 +113,8 @@ EOF
 
 add_hosts_module() {
   # Do not touch existing hosts module
-  [ -d $MAGISKTMP/modules/hosts ] && return
-  cd $MAGISKTMP/modules
+  [ -d $NVBASE/modules/hosts ] && return
+  cd $NVBASE/modules
   mkdir -p hosts/system/etc
   cat << EOF > hosts/module.prop
 id=hosts

--- a/native/src/core/bootstages.cpp
+++ b/native/src/core/bootstages.cpp
@@ -69,7 +69,7 @@ static void mount_mirrors() {
     LOGI("* Mounting module root\n");
     if (access(SECURE_DIR, F_OK) == 0 || (SDK_INT < 24 && xmkdir(SECURE_DIR, 0700))) {
         if (auto dest = MAGISKTMP + "/" MODULEMNT; mount_mirror(MODULEROOT, dest)) {
-            xmount(nullptr, dest.data(), nullptr, MS_REMOUNT | MS_BIND, nullptr);
+            xmount(nullptr, dest.data(), nullptr, MS_REMOUNT | MS_BIND | MS_RDONLY, nullptr);
             restorecon();
             chmod(SECURE_DIR, 0700);
         }

--- a/native/src/core/module.cpp
+++ b/native/src/core/module.cpp
@@ -305,6 +305,9 @@ void load_modules() {
         mount_zygisk(32)
         mount_zygisk(64)
     }
+
+    auto worker_dir = MAGISKTMP + "/" WORKERDIR;
+    xmount(nullptr, worker_dir.data(), nullptr, MS_REMOUNT | MS_RDONLY, nullptr);
 }
 
 /************************


### PR DESCRIPTION
Only write to the safe `/data/adb/modules`, make the f2fs partition mounted with empty parameters read only, fix #3171