### PR TITLE
Remove support of partitions w/o symlink in /system

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -120,7 +120,7 @@ All files you want to replace/inject should be placed in this folder. This folde
 
 If you place a file named `.replace` in any of the folders, instead of merging its contents, that folder will directly replace the one in the real system. This can be very handy for swapping out an entire folder.
 
-If you want to replace files in `/vendor`, `/vendor_dlkm`, `/product`, `/system_ext`, `/system_dlkm`, `/odm`, or `/odm_dlkm`, please place them under `system/vendor`, `system/product`, and `system/system_ext` respectively. Magisk will transparently handle whether these partitions are in a separate partition or not.
+If you want to replace files in `/vendor`, `/product`, or `/system_ext`, please place them under `system/vendor`, `system/product`, and `system/system_ext` respectively. Magisk will transparently handle whether these partitions are in a separate partition or not.
 
 #### Zygisk
 

--- a/native/src/core/module.cpp
+++ b/native/src/core/module.cpp
@@ -283,9 +283,7 @@ void load_modules() {
 
     if (!system->is_empty()) {
         // Handle special read-only partitions
-        for (const char *part : { "/vendor", "/vendor_dlkm","/product",
-                                  "/system_ext", "/system_dlkm",
-                                  "/odm", "/odm_dlkm" }) {
+        for (const char *part : { "/vendor", "/product", "/system_ext" }) {
             struct stat st{};
             if (lstat(part, &st) == 0 && S_ISDIR(st.st_mode)) {
                 if (auto old = system->extract(part + 1)) {


### PR DESCRIPTION
Since the current support of mounting more partitions does not satisfy people (see #3338), we remove the support for the next stable release to keep the semantics of `/system` unchanged. 