### PR TITLE
Drop trailing garbage of gzip decompress

### DIFF
--- a/native/src/boot/compress.cpp
+++ b/native/src/boot/compress.cpp
@@ -86,7 +86,7 @@ private:
                 inflate(&strm, flush);
             } else {
                 mode = COPY;
-                bwrite(b, 1);
+                return true;
             }
         }
         strm.next_in = (Bytef *) buf;
@@ -103,7 +103,7 @@ private:
                     code = deflate(&strm, flush);
                     break;
                 case COPY:
-                    return bwrite(buf, len);
+                    return true;
                 default:
                     // should have been handled
                     return false;
@@ -137,7 +137,7 @@ private:
                 }
                 // There is still data in the stream, we need to copy it
                 mode = COPY;
-                bwrite(strm.next_in, strm.avail_in);
+                return true;
             }
         } while (strm.avail_out == 0);
         return true;


### PR DESCRIPTION
I previously refered to minigzip from libz which copies all trailing data to the output when decompressing. However, gzip, on the other hand, drop trailing garbage by default. Consider ZIMAGE append the kernel size with zero padding, we should drop trailing garbage as well.