### PR TITLE
Remove meaningless umount in magiskinit

### DIFF
--- a/native/src/init/twostage.cpp
+++ b/native/src/init/twostage.cpp
@@ -34,7 +34,6 @@ void LegacySARInit::first_stage_prep() {
 
 bool SecondStageInit::prepare() {
     umount2("/init", MNT_DETACH);
-    umount2("/proc/self/exe", MNT_DETACH);
     unlink("/data/init");
 
     // Make sure init dmesg logs won't get messed up


### PR DESCRIPTION
This is no longer required since we redirect to /data/magiskinit