### PR TITLE
Specify context, user and group for init.rc's exec

### DIFF
--- a/native/src/init/magiskrc.inc
+++ b/native/src/init/magiskrc.inc
@@ -29,14 +29,14 @@ constexpr char MAGISK_RC[] =
 "\n"
 
 "on property:sys.boot_completed=1\n"
-"    exec %1$s/magisk --boot-complete\n"
+"    exec u:r:" SEPOL_PROC_DOMAIN ":s0 0 0 -- %1$s/magisk --boot-complete\n"
 "\n"
 
 "on property:init.svc.zygote=restarting\n"
-"    exec %1$s/magisk --zygote-restart\n"
+"    exec u:r:" SEPOL_PROC_DOMAIN ":s0 0 0 -- %1$s/magisk --zygote-restart\n"
 "\n"
 
 "on property:init.svc.zygote=stopped\n"
-"    exec %1$s/magisk --zygote-restart\n"
+"    exec u:r:" SEPOL_PROC_DOMAIN ":s0 0 0 -- %1$s/magisk --zygote-restart\n"
 "\n"
 ;

--- a/native/src/sepolicy/rules.cpp
+++ b/native/src/sepolicy/rules.cpp
@@ -64,7 +64,7 @@ void sepolicy::magisk_rules() {
         }
 
         // Allow these processes to access MagiskSU
-        vector<const char *> clients{ "init", "shell", "update_engine", "appdomain" };
+        vector<const char *> clients{ "shell", "update_engine", "appdomain" };
         for (auto type : clients) {
             if (!exists(type))
                 continue;
@@ -137,6 +137,10 @@ void sepolicy::magisk_rules() {
     // Let init run stuffs
     allow("kernel", SEPOL_PROC_DOMAIN, "fd", "use");
     allow("init", SEPOL_PROC_DOMAIN, "process", ALL);
+    allow("init", SEPOL_EXEC_TYPE, "file", "read");
+    allow("init", SEPOL_EXEC_TYPE, "file", "open");
+    allow("init", SEPOL_EXEC_TYPE, "file", "getattr");
+    allow("init", SEPOL_EXEC_TYPE, "file", "execute");
 
     // suRights
     allow("servicemanager", SEPOL_PROC_DOMAIN, "dir", "search");


### PR DESCRIPTION
Note that in Android 5.0 there's no `exec` support thus we don't have to care about the `exec` doc of Android 5.0.

https://cs.android.com/android/platform/superproject/+/android-5.1.1_r38:system/core/init/builtins.c;drc=d26135b34d4ee9d983931d64c8cb18dd2562b938;l=257