### PR TITLE
Use app_dir to detect systemui instead

### DIFF
--- a/native/src/zygisk/deny/deny.hpp
+++ b/native/src/zygisk/deny/deny.hpp
@@ -49,5 +49,4 @@ void ls_list(int client);
 bool is_deny_target(int uid, std::string_view process);
 void revert_unmount();
 
-extern int sys_ui_app_id;
 extern std::atomic<bool> denylist_enforced;

--- a/native/src/zygisk/deny/utils.cpp
+++ b/native/src/zygisk/deny/utils.cpp
@@ -27,8 +27,6 @@ static unique_ptr<map<string, set<string, StringCmp>, StringCmp>> pkg_to_procs_;
 static unique_ptr<map<int, set<string_view>>> app_id_to_pkgs_;
 #define app_id_to_pkgs (*app_id_to_pkgs_)
 
-int sys_ui_app_id = -1;
-
 // Locks the data structures above
 static pthread_mutex_t data_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -58,8 +56,6 @@ static void rescan_apps() {
                 if (auto it = pkg_to_procs.find(entry->d_name); it != pkg_to_procs.end()) {
                     app_id_to_pkgs[app_id].insert(it->first);
                 }
-                if (entry->d_name == "com.android.systemui"sv)
-                    sys_ui_app_id = app_id;
             }
         } else {
             close(dfd);

--- a/native/src/zygisk/entry.cpp
+++ b/native/src/zygisk/entry.cpp
@@ -306,8 +306,6 @@ static void get_process_info(int client, const sock_cred *cred) {
     int manager_app_id = get_manager();
     if (to_app_id(uid) == manager_app_id) {
         flags |= PROCESS_IS_MAGISK_APP;
-    } else if (to_app_id(uid) == sys_ui_app_id) {
-        flags |= PROCESS_IS_SYS_UI;
     }
     if (denylist_enforced) {
         flags |= DENYLIST_ENFORCING;

--- a/native/src/zygisk/hook.cpp
+++ b/native/src/zygisk/hook.cpp
@@ -604,6 +604,13 @@ void HookContext::app_specialize_pre() {
 
     vector<int> module_fds;
     int fd = remote_get_info(args.app->uid, process, &info_flags, module_fds);
+    if (args.app->app_data_dir) {
+        const auto *app_data_dir = env->GetStringUTFChars(args.app->app_data_dir, nullptr);
+        if (std::string_view(app_data_dir).ends_with("/com.android.systemui")) {
+            info_flags |= PROCESS_IS_SYS_UI;
+        }
+        env->ReleaseStringUTFChars(args.app->app_data_dir, app_data_dir);
+    }
     if ((info_flags & UNMOUNT_MASK) == UNMOUNT_MASK) {
         ZLOGI("[%s] is on the denylist\n", process);
         flags[DO_REVERT_UNMOUNT] = true;


### PR DESCRIPTION
uid may be shared by other apps (e.g., in MIUI, systemui's uid is 1000 and shared by many system apps).

Note that we don't use process names because any app can name its process `com.android.systemui`.