### PR TITLE
Avoid crash when calling `abandonSession`

### DIFF
--- a/app/shared/src/main/java/com/topjohnwu/magisk/utils/APKInstall.java
+++ b/app/shared/src/main/java/com/topjohnwu/magisk/utils/APKInstall.java
@@ -115,7 +115,10 @@ public final class APKInstall {
                             var installer = context.getPackageManager().getPackageInstaller();
                             var info = installer.getSessionInfo(id);
                             if (info != null) {
-                                installer.abandonSession(info.getSessionId());
+                                try {
+                                    installer.abandonSession(info.getSessionId());
+                                } catch (Throwable ignored) {
+                                }
                             }
                         }
                         if (onFailure != null) {


### PR DESCRIPTION
```
04-05 01:22:31.106 24936 24936 E AndroidRuntime: Caused by: java.lang.SecurityException: Caller has no access to session 779542906
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at android.os.Parcel.createExceptionOrNull(Parcel.java:3011)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at android.os.Parcel.createException(Parcel.java:2995)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at android.os.Parcel.readException(Parcel.java:2978)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at android.os.Parcel.readException(Parcel.java:2920)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at android.content.pm.IPackageInstaller$Stub$Proxy.abandonSession(IPackageInstaller.java:511)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at android.content.pm.PackageInstaller.abandonSession(PackageInstaller.java:581)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at a.e.onReceive(SourceFile:98)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$0$android-app-LoadedApk$ReceiverDispatcher$Args(LoadedApk.java:1790)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	... 9 more
04-05 01:22:31.106 24936 24936 E AndroidRuntime: Caused by: android.os.RemoteException: Remote stack trace:
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at com.android.server.pm.PackageInstallerService.abandonSession(PackageInstallerService.java:927)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at android.content.pm.IPackageInstaller$Stub.onTransact(IPackageInstaller.java:257)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at android.os.Binder.execTransactInternal(Binder.java:1280)
04-05 01:22:31.106 24936 24936 E AndroidRuntime: 	at android.os.Binder.execTransact(Binder.java:1244)
```