### PR TITLE
Fix scripts

### DIFF
--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -44,7 +44,6 @@ fix_env() {
   rm -rf $MAGISKBIN/*
   mkdir -p $MAGISKBIN 2>/dev/null
   chmod 700 $NVBASE
-  rm $1/stub.apk 2>/dev/null
   cp_readlink $1 $MAGISKBIN
   rm -rf $1
   chown -R 0:0 $MAGISKBIN

--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -80,8 +80,6 @@ main() {
   mkdir -p $TMPDIR
   cd $TMPDIR
 
-  $BOOTMODE || recovery_actions
-
   if echo $MAGISK_VER | grep -q '\.'; then
     PRETTY_VER=$MAGISK_VER
   else
@@ -104,13 +102,14 @@ main() {
   fi
 
   find_boot_image
-
   [ -z $BOOTIMAGE ] && abort "! Unable to detect target image"
   ui_print "- Target image: $BOOTIMAGE"
 
+  api_level_arch_detect
+  ui_print "- Device platform: $ABI"
+
   remove_system_su
   find_magisk_apk
-  api_level_arch_detect
   install_magisk
 
   # Cleanups

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -186,9 +186,10 @@ echo "RANDOMSEED=0x$RANDOMSEED" >> config
 "patch" \
 "backup ramdisk.cpio.orig" \
 "mkdir 000 .backup" \
-"add 000 .backup/.magisk config"
+"add 000 .backup/.magisk config" \
+|| abort "! Unable to patch ramdisk"
 
-rm -f ramdisk.cpio.orig config magisk*.xz stub.xz stub.apk
+rm -f ramdisk.cpio.orig config magisk*.xz stub.xz
 
 #################
 # Binary Patches

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -273,8 +273,8 @@ mount_partitions() {
 
   # Mount ro partitions
   if is_mounted /system_root; then
-    umount /system 2&>/dev/null
-    umount /system_root 2&>/dev/null
+    umount /system 2>/dev/null
+    umount /system_root 2>/dev/null
   fi
   mount_ro_ensure "system$SLOT app$SLOT" /system
   if [ -f /system/init -o -L /system/init ]; then
@@ -329,7 +329,7 @@ mount_apex() {
       [ -f /apex/original_apex ] && APEX=/apex/original_apex # unzip doesn't do return codes
       # APEX APKs, extract and loop mount
       unzip -qo $APEX apex_payload.img -d /apex
-      DEST=$(unzip -qp $APEX apex_manifest.pb | strings | head -n 1 | tr -dc [:alnum:].-_'\n')
+      DEST=$(unzip -qp $APEX apex_manifest.pb | strings | head -n 1 | tr -dc '[:alnum:].-_\n')
       [ -z $DEST ] && DEST=$(unzip -qp $APEX apex_manifest.json | sed -n $PATTERN)
       [ -z $DEST ] && continue
       DEST=/apex/$DEST
@@ -345,7 +345,7 @@ mount_apex() {
       if [ -f $APEX/apex_manifest.json ]; then
         DEST=/apex/$(sed -n $PATTERN $APEX/apex_manifest.json)
       elif [ -f $APEX/apex_manifest.pb ]; then
-        DEST=/apex/$(strings $APEX/apex_manifest.pb | head -n 1 | tr -dc [:alnum:].-_'\n')
+        DEST=/apex/$(strings $APEX/apex_manifest.pb | head -n 1 | tr -dc '[:alnum:].-_\n')
       else
         continue
       fi


### PR DESCRIPTION
manager.sh + boot_patch.sh:
- all listed files from boot_patch.sh header are required for boot patching, but stub.apk was being removed so install_magisk via addon.d.sh would fail without it; leave it in place

addon.d.sh:
- remove old redundant recovery_actions call (it's also performed by setup_flashable in initialize)
- print ABI to match flash_script.sh output

boot_patch.sh:
- catch and abort on any errors from ramdisk.cpio patching in the future

util_functions.sh:
- fix hiding of mount_partitions /system_root umount stderr
- quote mount_apex .pb DEST name parsing charset for safety even though both work

Fixes #6828