### PR TITLE
Fix config file path to avoid 'Stock backup does not exist' error

### DIFF
--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -229,7 +229,7 @@ app_init() {
   check_boot_ramdisk && RAMDISKEXIST=true
   get_flags
   run_migrations
-  SHA1=$(grep_prop SHA1 $MAGISKTMP/config)
+  SHA1=$(grep_prop SHA1 $MAGISKTMP/.magisk/config)
   check_encryption
 }
 


### PR DESCRIPTION
When attempting to restore the stock boot image from within the Magisk app, an error occurs stating 'Stock backup does not exist!'.

This pull request fixes the underlying cause.