### PR TITLE
Add missing OTA link to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,6 @@
 - [Frequently Asked Questions](faq.md)
 - [Release Notes](releases/index.md)
 - [Magisk Changelog](changes.md)
-- [Magisk Manager Changelog](app_changes.md)
 
 The following sections are for developers
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,11 @@
 # Magisk Documentation
 
 - [Installation Instructions](install.md)
+- [OTA Updates](ota.md)
 - [Frequently Asked Questions](faq.md)
 - [Release Notes](releases/index.md)
 - [Magisk Changelog](changes.md)
+- [Magisk Manager Changelog](app_changes.md)
 
 The following sections are for developers
 


### PR DESCRIPTION
`Magisk/docs/README.md` was missing a reference to `ota.md`. This commit adds it.