### PR TITLE
Add INTERNALDIR

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
@@ -42,6 +42,7 @@ class ShellInit : Shell.Initializer() {
 
             if (shell.isRoot) {
                 add("export MAGISKTMP=\$(magisk --path)")
+                add("export INTERNALDIR=\$MAGISKTMP/.magisk")
                 // Test if we can properly execute stuff in /data
                 Info.noDataExec = !shell.newJob().add("$localBB sh -c \"$localBB true\"").exec().isSuccess
             }


### PR DESCRIPTION
In commit 4e2b88b, '.magisk' was removed from MAGISKTMP and INTERNALDIR was added in the documentation of the replacement for what it was. However, INTERNALDIR isn't defined in magisk manager and so module expecting it will fail.
Either it needs added like in this pull or removed from the documentation