### PR TITLE
Clean up unrooted boot patching log errors

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
@@ -456,10 +456,7 @@ abstract class MagiskInstallImpl protected constructor(
             return false
         }
 
-        // Fix up binaries
         srcBoot.delete()
-        "cp_readlink $installDir".sh()
-
         return true
     }
 


### PR DESCRIPTION
Clean up unrooted boot patching cp errors in log

- remove call since cp_readlink shouldn't be necessary with installDir getting cleaned up regularly

    cp: can't preserve ownership of 'busybox': Operation not permitted
    cp: can't preserve ownership of 'magisk32': Operation not permitted
    cp: can't preserve ownership of 'magisk64': Operation not permitted
    cp: can't preserve ownership of 'magiskboot': Operation not permitted
    cp: can't preserve ownership of 'magiskinit': Operation not permitted
    cp: can't preserve ownership of 'magiskpolicy': Operation not permitted

See: [magisk_install_log_2023-06-04T20.03.33.log](https://github.com/topjohnwu/Magisk/files/11647630/magisk_install_log_2023-06-04T20.03.33.log)