### PR TITLE
Don't patch devices that use dynamic partitions

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/Info.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/Info.kt
@@ -33,6 +33,7 @@ object Info {
     @JvmStatic val isFDE get() = crypto == "block"
     @JvmField var ramdisk = false
     @JvmField var vbmeta = false
+    @JvmField var dynamicPartitions = false
     var crypto = ""
     var noDataExec = false
     var isRooted = false

--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
@@ -493,6 +493,7 @@ abstract class MagiskInstallImpl protected constructor(
             "KEEPVERITY=${Config.keepVerity} " +
             "PATCHVBMETAFLAG=${Config.patchVbmeta} " +
             "RECOVERYMODE=${Config.recovery} " +
+            "DYNAMIC_PARTITIONS=${Info.dynamicPartitions} " +
             "SYSTEM_ROOT=${Info.isSAR} " +
             "sh boot_patch.sh $srcBoot")
 

--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
@@ -78,6 +78,7 @@ class ShellInit : Shell.Initializer() {
         Info.vbmeta = getBool("VBMETAEXIST")
         Info.isAB = getBool("ISAB")
         Info.crypto = getVar("CRYPTOTYPE")
+        Info.dynamicPartitions = getBool("DYNAMIC_PARTITIONS")
 
         // Default presets
         Config.recovery = getBool("RECOVERYMODE")

--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -212,6 +212,7 @@ get_flags() {
   PATCHVBMETAFLAG=false
   # Make sure RECOVERYMODE has value
   [ -z $RECOVERYMODE ] && RECOVERYMODE=false
+  [ "$(getprop ro.boot.dynamic_partitions)" = "true" ] && DYNAMIC_PARTITIONS=true
 }
 
 run_migrations() { return; }

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -380,7 +380,7 @@ umount_apex() {
 
 # After calling this method, the following variables will be set:
 # KEEPVERITY, KEEPFORCEENCRYPT, RECOVERYMODE, PATCHVBMETAFLAG,
-# ISENCRYPTED, VBMETAEXIST
+# ISENCRYPTED, VBMETAEXIST, DYNAMIC_PARTITIONS
 get_flags() {
   getvar KEEPVERITY
   getvar KEEPFORCEENCRYPT
@@ -418,6 +418,14 @@ get_flags() {
     fi
   fi
   [ -z $RECOVERYMODE ] && RECOVERYMODE=false
+  if [ -z $DYNAMIC_PARTITIONS ]; then
+    DYNAMIC_PARTITIONS=$(getprop ro.boot.dynamic_partitions)
+    if [ "$DYNAMIC_PARTITIONS" = "true" ]; then
+      ui_print "- Dynamic partitions, don't force ramdisk"
+    else
+      DYNAMIC_PARTITIONS=false
+    fi
+  fi
 }
 
 find_boot_image() {


### PR DESCRIPTION
Devices that use dynamic partitions always have a ramdisk, while they should not be using skip_initramfs at all and use androidboot.force_normal_boot=1 instead, some vendors decided to patch their kernel instead of updating their bootloader when retrofitting dynamic partitions.

See also:
https://source.android.com/docs/core/ota/dynamic_partitions/implement#system-as-root-changes https://gerrit-public.fairphone.software/plugins/gitiles/kernel/msm-4.9/+/refs/heads/rel/11/fp3/8901.4.A.0022/fs/proc/cmdline.c

Fixes #6786