### PR TITLE
Remove /dev/urandom from ramdisk

### DIFF
--- a/scripts/avd_patch.sh
+++ b/scripts/avd_patch.sh
@@ -82,6 +82,7 @@ fi
 ./magiskboot compress=xz stub.apk stub.xz
 
 ./magiskboot cpio ramdisk.cpio \
+"rm dev/urandom" \
 "add 0750 init magiskinit" \
 "mkdir 0750 overlay.d" \
 "mkdir 0750 overlay.d/sbin" \

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -188,6 +188,7 @@ RANDOMSEED=$(tr -dc 'a-f0-9' < /dev/urandom | head -c 16)
 echo "RANDOMSEED=0x$RANDOMSEED" >> config
 
 ./magiskboot cpio ramdisk.cpio \
+"rm dev/urandom" \
 "add 0750 $INIT magiskinit" \
 "mkdir 0750 overlay.d" \
 "mkdir 0750 overlay.d/sbin" \


### PR DESCRIPTION
```
[    0.262631][    T1] Run /init as init process
getentropy failed: No such device or address
libc: getentropy failed: No such device or address
[    0.263853][    T1] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00007f00
[    0.264510][    T1] CPU: 2 PID: 1 Comm: init Not tainted 6.1.23-android14-4-00257-g7e35917775b8-ab9964412 #1
[    0.265287][    T1] Hardware name: linux,ranchu (DT)
[    0.265678][    T1] Call trace:
[    0.265928][    T1]  dump_backtrace+0x104/0x128
[    0.266286][    T1]  show_stack+0x20/0x30
[    0.266596][    T1]  dump_stack_lvl+0x6c/0x8c
[    0.266920][    T1]  dump_stack+0x20/0x48
[    0.267223][    T1]  panic+0x180/0x3a4
[    0.267521][    T1]  do_exit+0x870/0xa5c
[    0.267824][    T1]  do_group_exit+0xa0/0xa4
[    0.268159][    T1]  __arm64_sys_exit_group+0x20/0x24
[    0.268557][    T1]  invoke_syscall+0x60/0x130
[    0.268895][    T1]  el0_svc_common+0xbc/0x100
[    0.269235][    T1]  do_el0_svc+0x34/0xd0
[    0.269542][    T1]  el0_svc+0x34/0xc4
[    0.269830][    T1]  el0t_64_sync_handler+0x8c/0xfc
[    0.270199][    T1]  el0t_64_sync+0x1a0/0x1a4
[    0.270529][    T1] SMP: stopping secondary CPUs
[    0.270945][    T1] Kernel Offset: disabled
[    0.271543][    T1] CPU features: 0x00000,00050091,66927723
[    0.272450][    T1] Memory Limit: none
```

https://cs.android.com/android/platform/superproject/+/master:bionic/libc/upstream-openbsd/lib/libc/crypt/arc4random.c;drc=b364683ea65e24070c77f1673a8c155665eb894e;l=91


Dont know why but AVD 14 beta3's ramdisk (system-images;android-34;google_apis;r06) has `/dev/urandom` and causes kernel panic. Thus, we remove /dev/urandom unconditionally just in case.