### PR TITLE
Add `boot.img` in Android 13-shipped Samsung tar packages

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
@@ -250,7 +250,15 @@ abstract class MagiskInstallImpl protected constructor(
             return recovery
         } else {
             return when {
-                initBoot.exists() -> initBoot
+                initBoot.exists() -> {
+                    boot.newInputStream().use {
+                        tarOut.putNextEntry(newTarEntry("boot.img", boot.length()))
+                        it.copyTo(tarOut)
+                    }
+                    boot.delete()
+                    // Install to init_boot
+                    initBoot
+                }
                 boot.exists() -> boot
                 else -> {
                     throw NoBootException()


### PR DESCRIPTION
#6586 causes the `processTar` function to provide `init_boot.img` instead of `boot.img` to support Samsung devices shipping with Android 13 and above. Add the stock `boot.img` in the patched tar generated by the app to avoid issues caused by mismatched kernel images when updating to a newer firmware

Fixes #7132