### PR TITLE
Avoid using IconCompat.createFromIcon() that doesn't support bitmap icons

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/view/Shortcuts.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/view/Shortcuts.kt
@@ -31,7 +31,7 @@ object Shortcuts {
         val info = ShortcutInfoCompat.Builder(context, Const.Nav.HOME)
             .setShortLabel(context.getString(R.string.magisk))
             .setIntent(intent)
-            .setIcon(IconCompat.createFromIcon(context, context.getIcon(R.drawable.ic_launcher)))
+            .setIcon(context.getIconCompat(R.drawable.ic_launcher))
             .build()
         ShortcutManagerCompat.requestPinShortcut(context, info, null)
     }
@@ -44,6 +44,18 @@ object Shortcuts {
                 Icon.createWithBitmap(getBitmap(id))
         } else {
             Icon.createWithResource(this, id)
+        }
+    }
+
+    private fun Context.getIconCompat(id: Int): IconCompat {
+        return if (isRunningAsStub) {
+            val bitmap = getBitmap(id)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                IconCompat.createWithAdaptiveBitmap(bitmap)
+            else
+                IconCompat.createWithBitmap(bitmap)
+        } else {
+            IconCompat.createWithResource(this, id)
         }
     }
 


### PR DESCRIPTION
This is a regression introduced in e9b76b6aa53f26808dfdae18c1832abc10d9e54d:

From the source code of `IconCompat.createFromIcon()`, bitmap icons will be treated as `TYPE_UNKNOWN`:
https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:core/core/src/main/java/androidx/core/graphics/drawable/IconCompat.java;l=1110
<img width="511" alt="image" src="https://github.com/topjohnwu/Magisk/assets/31466456/0ca98f8a-d1f6-48a7-b1b9-140182b7a8bf">

And `IconCompat.addToShortcutIntent()` does not support `TYPE_UNKNOWN`:
https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:core/core/src/main/java/androidx/core/graphics/drawable/IconCompat.java;l=698
<img width="593" alt="image" src="https://github.com/topjohnwu/Magisk/assets/31466456/4d00220f-dc8a-47c4-92a3-c22bdf881205">

So it will crash on Android before 8.0:
```
 java.lang.IllegalArgumentException: Icon type not supported for intent shortcuts
    at androidx.core.graphics.drawable.IconCompat.addToShortcutIntent(IconCompat.java:754)
    at androidx.core.content.pm.ShortcutInfoCompat.addToIntent(ShortcutInfoCompat.java:213)
    at androidx.core.content.pm.ShortcutManagerCompat.requestPinShortcut(ShortcutManagerCompat.java:204)
    at com.topjohnwu.magisk.view.Shortcuts.addHomeIcon(Shortcuts.kt:36)
    at com.topjohnwu.magisk.ui.MainActivity$askForHomeShortcut$1$2$1.invoke(MainActivity.kt:227)
    at com.topjohnwu.magisk.ui.MainActivity$askForHomeShortcut$1$2$1.invoke(MainActivity.kt:226)
    at com.topjohnwu.magisk.view.MagiskDialog$ButtonViewModel.clicked(MagiskDialog.kt:122)
    at com.topjohnwu.magisk.databinding.DialogMagiskBaseBindingImpl._internalCallbackOnClick(DialogMagiskBaseBindingImpl.java:562)
    at com.topjohnwu.magisk.generated.callback.OnClickListener.onClick(OnClickListener.java:11)
    at android.view.View.performClick(View.java:5205)
                                                           
```
