### PR TITLE
Fix $BOOTMODE set by manager.sh being incorrectly overridden

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -9,7 +9,7 @@
 ###################
 
 # True if the script is running on booted Android, not something like recovery
-BOOTMODE=
+[ -z "$BOOTMODE" ] && BOOTMODE=
 
 # The path to store temporary files that don't need to persist
 TMPDIR=


### PR DESCRIPTION
`manager.sh` sets `$BOOTMODE` to true, but `util_functions.sh` unconditionally sets it to empty. 16d728f
This regression causes the following bugs:
- `ui_print` prints message to `/proc/self/fd` instead of the manager console if not rooted
- `boot_patch.sh` thinks we are in recovery mode and preinit device resolving being incorrectly skipped
- maybe more?