### PR TITLE
Patch vbmeta flags in Samsung tar firmware packages optionally

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
@@ -206,7 +206,7 @@ abstract class MagiskInstallImpl protected constructor(
 
                 val extract = installDir.getChildFile(name)
                 decompressedStream().copyAndCloseOut(extract.newOutputStream())
-            } else if (entry.name.contains("vbmeta.img")) {
+            } else if (Config.patchVbmeta && entry.name.contains("vbmeta.img")) {
                 val rawData = decompressedStream().readBytes()
                 // Valid vbmeta.img should be at least 256 bytes
                 if (rawData.size < 256)
@@ -490,7 +490,7 @@ abstract class MagiskInstallImpl protected constructor(
             "cd $installDir",
             "KEEPFORCEENCRYPT=${Config.keepEnc} " +
             "KEEPVERITY=${Config.keepVerity} " +
-            "PATCHVBMETAFLAG=${Config.patchVbmeta} " +
+            "PATCHVBMETAFLAG=${!Info.isSamsung && Config.patchVbmeta} " +
             "RECOVERYMODE=${Config.recovery} " +
             "SYSTEM_ROOT=${Info.isSAR} " +
             "sh boot_patch.sh $srcBoot")

--- a/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -37,8 +37,8 @@ import java.io.IOException
 class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() {
 
     val isRooted get() = Info.isRooted
-    val hideVbmeta = Info.vbmeta || Info.isSamsung || Info.isAB
-    val skipOptions = Info.isEmulator || (Info.isSAR && !Info.isFDE && hideVbmeta && Info.ramdisk)
+    val hideVbmeta = !Info.isSamsung && (Info.vbmeta || Info.isAB)
+    val skipOptions = Info.isEmulator || (!Info.isSamsung && Info.isSAR && !Info.isFDE && hideVbmeta && Info.ramdisk)
     val noSecondSlot = !isRooted || !Info.isAB || Info.isEmulator
 
     @get:Bindable


### PR DESCRIPTION
As reported by multiple users (https://github.com/topjohnwu/Magisk/issues/6230#issuecomment-1430131565, https://github.com/topjohnwu/Magisk/issues/6990#issuecomment-1627467840) and as per my tests in two different devices (Galaxy A52s 5G, Galaxy A54 5G), a patched vbmeta image **may not** be required when installing Magisk in a Samsung device. This is possible because the bootloader will pass the `AVB_SLOT_VERIFY_FLAGS_ALLOW_VERIFICATION_ERROR` flag in `avb_slot_verify` ([avb_slot_verify.h#97](https://android.googlesource.com/platform/external/avb/+/f6fbb68838cabad2e007b146e6bf3ca6ea30f310/libavb/avb_slot_verify.h#97)) if unlocked. To still let the end user decide, let's make the vbmeta flags patch optional. This might need more tests to make sure the behaviour is the same for all the Samsung devices.