### PR TITLE
SuperuserViewModel: fix updatePolicy

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/events/BiometricEvent.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/events/BiometricEvent.kt
@@ -4,7 +4,6 @@ import com.topjohnwu.magisk.arch.ActivityExecutor
 import com.topjohnwu.magisk.arch.UIActivity
 import com.topjohnwu.magisk.arch.ViewEvent
 import com.topjohnwu.magisk.core.di.ServiceLocator
-import com.topjohnwu.magisk.core.utils.BiometricHelper
 
 class BiometricEvent(
     builder: Builder.() -> Unit

--- a/app/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsItems.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsItems.kt
@@ -15,7 +15,6 @@ import com.topjohnwu.magisk.core.Info
 import com.topjohnwu.magisk.core.di.ServiceLocator
 import com.topjohnwu.magisk.core.ktx.activity
 import com.topjohnwu.magisk.core.tasks.HideAPK
-import com.topjohnwu.magisk.core.utils.BiometricHelper
 import com.topjohnwu.magisk.core.utils.MediaStoreUtils
 import com.topjohnwu.magisk.core.utils.availableLocales
 import com.topjohnwu.magisk.core.utils.currentLocale

--- a/app/src/main/java/com/topjohnwu/magisk/ui/superuser/PolicyRvItem.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/superuser/PolicyRvItem.kt
@@ -73,6 +73,8 @@ class PolicyRvItem(
         viewModel.deletePressed(this)
     }
 
-    override fun itemSameAs(other: PolicyRvItem) = item.uid == other.item.uid
+    override fun itemSameAs(other: PolicyRvItem) = packageName == other.packageName
+
+    override fun contentSameAs(other: PolicyRvItem) = item.policy == other.item.policy
 
 }

--- a/app/src/main/java/com/topjohnwu/magisk/ui/superuser/SuperuserViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/superuser/SuperuserViewModel.kt
@@ -16,7 +16,6 @@ import com.topjohnwu.magisk.core.di.AppContext
 import com.topjohnwu.magisk.core.di.ServiceLocator
 import com.topjohnwu.magisk.core.ktx.getLabel
 import com.topjohnwu.magisk.core.model.su.SuPolicy
-import com.topjohnwu.magisk.core.utils.BiometricHelper
 import com.topjohnwu.magisk.core.utils.currentLocale
 import com.topjohnwu.magisk.databinding.*
 import com.topjohnwu.magisk.dialog.SuperuserRevokeDialog
@@ -107,7 +106,7 @@ class SuperuserViewModel(
         fun updateState() = viewModelScope.launch {
             db.delete(item.item.uid)
             val list = ArrayList(itemsPolicies)
-            list.removeAll { it.itemSameAs(item) }
+            list.removeAll { it.item.uid == item.item.uid }
             itemsPolicies.update(list)
             if (list.isEmpty() && itemsHelpers.isEmpty()) {
                 itemsHelpers.add(itemNoData)
@@ -156,15 +155,14 @@ class SuperuserViewModel(
     }
 
     fun togglePolicy(item: PolicyRvItem, enable: Boolean) {
+        val items = itemsPolicies.filter { it.item.uid == item.item.uid }
         fun updateState() {
             viewModelScope.launch {
                 val res = if (enable) R.string.su_snack_grant else R.string.su_snack_deny
                 item.item.policy = if (enable) SuPolicy.ALLOW else SuPolicy.DENY
                 db.update(item.item)
-                itemsPolicies.forEach {
-                    if (it.item.uid == item.item.uid) {
-                        it.notifyPropertyChanged(BR.enabled)
-                    }
+                items.forEach {
+                    it.notifyPropertyChanged(BR.enabled)
                 }
                 SnackbarEvent(res.asText(item.appName)).publish()
             }

--- a/app/src/main/java/com/topjohnwu/magisk/ui/surequest/SuRequestViewModel.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/ui/surequest/SuRequestViewModel.kt
@@ -28,7 +28,6 @@ import com.topjohnwu.magisk.core.ktx.toast
 import com.topjohnwu.magisk.core.model.su.SuPolicy.Companion.ALLOW
 import com.topjohnwu.magisk.core.model.su.SuPolicy.Companion.DENY
 import com.topjohnwu.magisk.core.su.SuRequestHandler
-import com.topjohnwu.magisk.core.utils.BiometricHelper
 import com.topjohnwu.magisk.databinding.set
 import com.topjohnwu.magisk.events.BiometricEvent
 import com.topjohnwu.magisk.events.DieEvent


### PR DESCRIPTION
Starting biometrics may cause the SuperuserFragment to lost focus. After onResume(), doLoadWork() will refresh the itemsPolicies, so notify property changed will work on wrong items. Fixed by snapshotting items to be refreshed before starting biometrics.