### PR TITLE
Switch DoH provider to Quad101

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/di/Networking.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/di/Networking.kt
@@ -25,17 +25,7 @@ private class DnsResolver(client: OkHttpClient) : Dns {
 
     private val doh by lazy {
         DnsOverHttps.Builder().client(client)
-            .url("https://cloudflare-dns.com/dns-query".toHttpUrl())
-            .bootstrapDnsHosts(listOf(
-                InetAddress.getByName("162.159.36.1"),
-                InetAddress.getByName("162.159.46.1"),
-                InetAddress.getByName("1.1.1.1"),
-                InetAddress.getByName("1.0.0.1"),
-                InetAddress.getByName("2606:4700:4700::1111"),
-                InetAddress.getByName("2606:4700:4700::1001"),
-                InetAddress.getByName("2606:4700:4700::0064"),
-                InetAddress.getByName("2606:4700:4700::6400")
-            ))
+            .url("https://101.101.101.101/dns-query".toHttpUrl())
             .resolvePrivateAddresses(true)  /* To make PublicSuffixDatabase never used */
             .build()
     }


### PR DESCRIPTION
Nope, DoH with domains has long been blocked by stupid governments in regions that need it.

```toml
nameserver = [
	    "https://185.222.222.222/dns-query",
	    "https://45.11.45.11/dns-query",

	    "https://9.9.9.9/dns-query",
	    "https://149.112.112.112/dns-query",

	    "https://208.67.220.220/dns-query",
	    "https://208.67.222.222/dns-query",

	    "https://101.101.101.101/dns-query",

	    "https://146.112.41.5/dns-query",

	    "https://130.59.31.248/dns-query",
	    "https://130.59.31.251/dns-query",

	    "https://77.88.8.1/dns-query",
	    "https://77.88.8.8/dns-query",

	    "https://94.140.14.140/dns-query",
	    "https://94.140.14.141/dns-query",

	    "https://1.1.1.1/dns-query",
	    "https://1.0.0.1/dns-query",

	    "https://dns.tuna.tsinghua.edu.cn:8443/dns-query",

	    "https://pdns.itxe.net/dns-query"
]
```
Pick one at random.