### PR TITLE
Fix fd sanitization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
- Fix broken logic introduced by commit 79a1c39 which modify `fds_to_ignore` when `android_log_close` is called, where `fds_to_ignore` was already read and converted into a C++ vector, so our hacks never take effect. This fixes #7448
- The previous logic rely on `android_log_close` to close `logd_fd` in zygote and causes `logd_fd` being closed and re-acquired too many times. Update `fds_to_ignore` in zygote process as well to avoid that case.