### PR TITLE
Change Safe Mode trigger (copy of #7543 but fixed)

### DIFF
--- a/native/src/core/bootstages.cpp
+++ b/native/src/core/bootstages.cpp
@@ -257,6 +257,7 @@ static bool check_key_combo() {
     uint8_t bitmask[(KEY_MAX + 1) / 8];
     vector<int> events;
     constexpr char name[] = "/dev/.ev";
+    int volumeDownCount = 0;
 
     // First collect candidate events that accepts volume down
     for (int minor = 64; minor < 96; ++minor) {
@@ -278,8 +279,8 @@ static bool check_key_combo() {
 
     run_finally fin([&]{ std::for_each(events.begin(), events.end(), close); });
 
-    // Check if volume down key is held continuously for more than 3 seconds
-    for (int i = 0; i < 300; ++i) {
+    // Check if volume down key is pressed more than 3 times
+    for (int i = 0; i < 3; ++i) {
         bool pressed = false;
         for (const int &fd : events) {
             memset(bitmask, 0, sizeof(bitmask));
@@ -289,15 +290,36 @@ static bool check_key_combo() {
                 break;
             }
         }
-        if (!pressed)
-            return false;
-        // Check every 10ms
-        usleep(10000);
+        if (pressed) {
+            volumeDownCount++;
+            // Wait for the next key press
+            usleep(10000);
+        }
     }
-    LOGD("KEY_VOLUMEDOWN detected: enter safe mode\n");
-    return true;
-}
 
+    // Wait for the volume down key to be released
+    bool stillPressed = true;
+    while (stillPressed) {
+        stillPressed = false;
+        for (const int &fd : events) {
+            memset(bitmask, 0, sizeof(bitmask));
+            ioctl(fd, EVIOCGKEY(sizeof(bitmask)), bitmask);
+            if (test_bit(KEY_VOLUMEDOWN, bitmask)) {
+                stillPressed = true;
+                break;
+            }
+        }
+        if (stillPressed)
+            usleep(10000);
+    }
+
+    if (volumeDownCount >= 3) {
+        LOGD("KEY_VOLUMEDOWN pressed more than 3 times: enter safe mode\n");
+        return true;
+    }
+
+    return false;
+}
 /***********************
  * Boot Stage Handlers *
  ***********************/


### PR DESCRIPTION
Press Volume Down Key more than 3 times to trigger Magisk's safemode ( Similar to KernelSU) instead of long pressing volume down key for 3 secs or more

Long pressing the volume down key also enable android's safe mode on some devices. Hence, change safe mode trigger for Magisk to avoid such conditions (copy of https://github.com/topjohnwu/Magisk/pull/7543 but fixed hopefully)