### PR TITLE
Fix native symbol strips

### DIFF
--- a/buildSrc/src/main/java/Setup.kt
+++ b/buildSrc/src/main/java/Setup.kt
@@ -72,6 +72,7 @@ fun Project.setupCommon() {
         compileSdkVersion(34)
         buildToolsVersion = "34.0.0"
         ndkPath = "$sdkDirectory/ndk/magisk"
+        ndkVersion = "26.1.10909125"
 
         defaultConfig {
             minSdk = 23

--- a/native/build.gradle.kts
+++ b/native/build.gradle.kts
@@ -6,7 +6,6 @@ setupCommon()
 
 android {
     namespace = "com.topjohnwu.magisk.native"
-    ndkVersion = "26.1.10909125"
 
     externalNativeBuild {
         ndkBuild {


### PR DESCRIPTION
`ndkVersion` is also needed by app for striping native symbols. Set it in `setupCommon` instead.