### PR TITLE
Make tmpfs mount of magic mount atomic

### DIFF
--- a/native/src/core/module.cpp
+++ b/native/src/core/module.cpp
@@ -124,8 +124,8 @@ void dir_node::collect_module_files(const char *module, int dfd) {
  * Mount Implementations
  ************************/
 
-void node_entry::create_and_mount(const char *reason, const string &src) {
-    const string &dest = node_path();
+void node_entry::create_and_mount(const char *reason, const string &src, bool ro) {
+    const string dest = isa<tmpfs_node>(parent()) ? worker_path() : node_path();
     if (is_lnk()) {
         VLOGD("cp_link", src.data(), dest.data());
         cp_afc(src.data(), dest.data());
@@ -137,6 +137,9 @@ void node_entry::create_and_mount(const char *reason, const string &src) {
         else
             return;
         bind_mount(reason, src.data(), dest.data());
+        if (ro) {
+            xmount(nullptr, dest.data(), nullptr, MS_REMOUNT | MS_BIND | MS_RDONLY, nullptr);
+        }
     }
 }
 
@@ -162,22 +165,23 @@ void module_node::mount() {
 
 void tmpfs_node::mount() {
     string src = mirror_path();
-    const string &dest = node_path();
-    const char *src_path;
-    if (access(src.data(), F_OK) == 0)
-        src_path = src.data();
-    else
-        src_path = parent()->node_path().data();
+    const char *src_path = access(src.data(), F_OK) == 0 ? src.data() : parent()->node_path().data();
     if (!isa<tmpfs_node>(parent())) {
-        auto worker_dir = get_magisk_tmp() + "/"s WORKERDIR + dest;
+        const string &dest = node_path();
+        auto worker_dir = worker_path();
         mkdirs(worker_dir.data(), 0);
-        create_and_mount(skip_mirror() ? "replace" : "tmpfs", worker_dir);
+        bind_mount("tmpfs", worker_dir.data(), worker_dir.data());
+        dir_node::mount();
+        VLOGD(skip_mirror() ? "replace" : "move", worker_dir.data(), dest.data());
+        xmount(worker_dir.data(), dest.data(), nullptr, MS_MOVE, nullptr);
+        clone_attr(src_path, dest.data());
     } else {
+        const string dest = worker_path();
         // We don't need another layer of tmpfs if parent is tmpfs
         mkdir(dest.data(), 0);
+        clone_attr(src_path, dest.data());
+        dir_node::mount();
     }
-    clone_attr(src_path, dest.data());
-    dir_node::mount();
 }
 
 /****************
@@ -193,7 +197,7 @@ public:
         if (access(src.data(), F_OK))
             return;
 
-        const string &dir_name = parent()->node_path();
+        const string dir_name = isa<tmpfs_node>(parent()) ? parent()->worker_path() : parent()->node_path();
         if (name() == "magisk") {
             for (int i = 0; applet_names[i]; ++i) {
                 string dest = dir_name + "/" + applet_names[i];
@@ -205,8 +209,7 @@ public:
             VLOGD("create", "./magiskpolicy", dest.data());
             xsymlink("./magiskpolicy", dest.data());
         }
-        create_and_mount("magisk", src);
-        xmount(nullptr, node_path().data(), nullptr, MS_REMOUNT | MS_BIND | MS_RDONLY, nullptr);
+        create_and_mount("magisk", src, true);
     }
 };
 
@@ -217,8 +220,7 @@ public:
 
     void mount() override {
         const string src = get_magisk_tmp() + "/magisk"s + (is64bit ? "64" : "32");
-        create_and_mount("zygisk", src);
-        xmount(nullptr, node_path().data(), nullptr, MS_REMOUNT | MS_BIND | MS_RDONLY, nullptr);
+        create_and_mount("zygisk", src, true);
     }
 
 private:

--- a/native/src/core/node.hpp
+++ b/native/src/core/node.hpp
@@ -45,6 +45,8 @@ public:
 
     // Don't call the following two functions before prepare
     const string &node_path();
+    const string worker_path();
+
     string mirror_path() { return mirror_dir + node_path(); }
 
     virtual void mount() = 0;
@@ -67,7 +69,7 @@ protected:
         delete other;
     }
 
-    void create_and_mount(const char *reason, const string &src);
+    void create_and_mount(const char *reason, const string &src, bool ro=false);
 
     // Use bit 7 of _file_type for exist status
     bool exist() const { return static_cast<bool>(_file_type & (1 << 7)); }
@@ -313,4 +315,8 @@ const string &node_entry::node_path() {
     if (_parent && _node_path.empty())
         _node_path = _parent->node_path() + '/' + _name;
     return _node_path;
+}
+
+const string node_entry::worker_path() {
+    return get_magisk_tmp() + "/"s WORKERDIR + node_path();
 }


### PR DESCRIPTION
This avoid system libraries disappear temporarily during magic mount, which causes some dynamic executables fails to run during post-fs-data.