### PR TITLE
Fixes for Android 14 QPR2 B2

### DIFF
--- a/native/src/core/zygisk/api.hpp
+++ b/native/src/core/zygisk/api.hpp
@@ -161,6 +161,7 @@ struct AppSpecializeArgs {
     jobjectArray *const whitelisted_data_info_list;
     jboolean *const mount_data_dirs;
     jboolean *const mount_storage_dirs;
+    jboolean *const mount_sysprop_overrides;
 
     AppSpecializeArgs() = delete;
 };

--- a/native/src/core/zygisk/gen_jni_hooks.py
+++ b/native/src/core/zygisk/gen_jni_hooks.py
@@ -146,6 +146,9 @@ whitelisted_data_info_list = Argument('whitelisted_data_info_list', JArray(jstri
 mount_data_dirs = Argument('mount_data_dirs', jboolean, True)
 mount_storage_dirs = Argument('mount_storage_dirs', jboolean, True)
 
+# u
+mount_sysprop_overrides = Argument('mount_sysprop_overrides', jboolean, True)
+
 # server
 permitted_capabilities = Argument('permitted_capabilities', jlong)
 effective_capabilities = Argument('effective_capabilities', jlong)
@@ -166,6 +169,10 @@ fas_q_alt = ForkAndSpec('q_alt', [uid, gid, gids, runtime_flags, rlimits, mount_
 fas_r = ForkAndSpec('r', [uid, gid, gids, runtime_flags, rlimits, mount_external, se_info,
     nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app,
     pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs])
+
+fas_u = ForkAndSpec('u', [uid, gid, gids, runtime_flags, rlimits, mount_external, se_info,
+    nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app,
+    pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides])
 
 fas_samsung_m = ForkAndSpec('samsung_m', [uid, gid, gids, runtime_flags, rlimits, mount_external,
     se_info, Anon(jint), Anon(jint), nice_name, fds_to_close, instruction_set, app_data_dir])
@@ -189,6 +196,10 @@ spec_q_alt = SpecApp('q_alt', [uid, gid, gids, runtime_flags, rlimits, mount_ext
 spec_r = SpecApp('r', [uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name,
     is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list,
     whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs])
+
+spec_u = SpecApp('u', [uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name,
+    is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list,
+    whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides])
 
 spec_samsung_q = SpecApp('samsung_q', [uid, gid, gids, runtime_flags, rlimits, mount_external,
     se_info, Anon(jint), Anon(jint), nice_name, is_child_zygote, instruction_set, app_data_dir])
@@ -234,10 +245,10 @@ with open('jni_hooks.hpp', 'w') as f:
 
     zygote = 'com/android/internal/os/Zygote'
 
-    methods = [fas_l, fas_o, fas_p, fas_q_alt, fas_r, fas_samsung_m, fas_samsung_n, fas_samsung_o, fas_samsung_p]
+    methods = [fas_l, fas_o, fas_p, fas_q_alt, fas_r, fas_u, fas_samsung_m, fas_samsung_n, fas_samsung_o, fas_samsung_p]
     f.write(gen_jni_def(zygote, methods))
 
-    methods = [spec_q, spec_q_alt, spec_r, spec_samsung_q]
+    methods = [spec_q, spec_q_alt, spec_r, spec_u, spec_samsung_q]
     f.write(gen_jni_def(zygote, methods))
 
     methods = [server_l, server_samsung_q]

--- a/native/src/core/zygisk/jni_hooks.hpp
+++ b/native/src/core/zygisk/jni_hooks.hpp
@@ -66,6 +66,24 @@ void *nativeForkAndSpecialize_orig = nullptr;
     ctx.nativeForkAndSpecialize_post();
     return ctx.pid;
 }
+[[clang::no_stack_protector]] jint nativeForkAndSpecialize_u(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides) {
+    AppSpecializeArgs_v3 args(uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, instruction_set, app_data_dir);
+    args.fds_to_ignore = &fds_to_ignore;
+    args.is_child_zygote = &is_child_zygote;
+    args.is_top_app = &is_top_app;
+    args.pkg_data_info_list = &pkg_data_info_list;
+    args.whitelisted_data_info_list = &whitelisted_data_info_list;
+    args.mount_data_dirs = &mount_data_dirs;
+    args.mount_storage_dirs = &mount_storage_dirs;
+    args.mount_sysprop_overrides = &mount_sysprop_overrides;
+    ZygiskContext ctx(env, &args);
+    ctx.nativeForkAndSpecialize_pre();
+    reinterpret_cast<decltype(&nativeForkAndSpecialize_u)>(nativeForkAndSpecialize_orig)(
+        env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides
+    );
+    ctx.nativeForkAndSpecialize_post();
+    return ctx.pid;
+}
 [[clang::no_stack_protector]] jint nativeForkAndSpecialize_samsung_m(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jint _0, jint _1, jstring nice_name, jintArray fds_to_close, jstring instruction_set, jstring app_data_dir) {
     AppSpecializeArgs_v3 args(uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, instruction_set, app_data_dir);
     ZygiskContext ctx(env, &args);
@@ -137,6 +155,11 @@ std::array nativeForkAndSpecialize_methods = {
     },
     JNINativeMethod {
         "nativeForkAndSpecialize",
+        "(II[II[[IILjava/lang/String;Ljava/lang/String;[I[IZLjava/lang/String;Ljava/lang/String;Z[Ljava/lang/String;[Ljava/lang/String;ZZZ)I",
+        (void *) &nativeForkAndSpecialize_u
+    },
+    JNINativeMethod {
+        "nativeForkAndSpecialize",
         "(II[II[[IILjava/lang/String;IILjava/lang/String;[ILjava/lang/String;Ljava/lang/String;)I",
         (void *) &nativeForkAndSpecialize_samsung_m
     },
@@ -194,6 +217,22 @@ void *nativeSpecializeAppProcess_orig = nullptr;
     );
     ctx.nativeSpecializeAppProcess_post();
 }
+[[clang::no_stack_protector]] void nativeSpecializeAppProcess_u(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides) {
+    AppSpecializeArgs_v3 args(uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, instruction_set, app_data_dir);
+    args.is_child_zygote = &is_child_zygote;
+    args.is_top_app = &is_top_app;
+    args.pkg_data_info_list = &pkg_data_info_list;
+    args.whitelisted_data_info_list = &whitelisted_data_info_list;
+    args.mount_data_dirs = &mount_data_dirs;
+    args.mount_storage_dirs = &mount_storage_dirs;
+    args.mount_sysprop_overrides = &mount_sysprop_overrides;
+    ZygiskContext ctx(env, &args);
+    ctx.nativeSpecializeAppProcess_pre();
+    reinterpret_cast<decltype(&nativeSpecializeAppProcess_u)>(nativeSpecializeAppProcess_orig)(
+        env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides
+    );
+    ctx.nativeSpecializeAppProcess_post();
+}
 [[clang::no_stack_protector]] void nativeSpecializeAppProcess_samsung_q(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jint _9, jint _10, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir) {
     AppSpecializeArgs_v3 args(uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, instruction_set, app_data_dir);
     args.is_child_zygote = &is_child_zygote;
@@ -219,6 +258,11 @@ std::array nativeSpecializeAppProcess_methods = {
         "nativeSpecializeAppProcess",
         "(II[II[[IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Z[Ljava/lang/String;[Ljava/lang/String;ZZ)V",
         (void *) &nativeSpecializeAppProcess_r
+    },
+    JNINativeMethod {
+        "nativeSpecializeAppProcess",
+        "(II[II[[IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Z[Ljava/lang/String;[Ljava/lang/String;ZZZ)V",
+        (void *) &nativeSpecializeAppProcess_u
     },
     JNINativeMethod {
         "nativeSpecializeAppProcess",

--- a/native/src/core/zygisk/module.hpp
+++ b/native/src/core/zygisk/module.hpp
@@ -45,6 +45,7 @@ struct AppSpecializeArgs_v3 {
     jobjectArray *whitelisted_data_info_list = nullptr;
     jboolean *mount_data_dirs = nullptr;
     jboolean *mount_storage_dirs = nullptr;
+    jboolean *mount_sysprop_overrides = nullptr;
 
     AppSpecializeArgs_v3(
             jint &uid, jint &gid, jintArray &gids, jint &runtime_flags,


### PR DESCRIPTION
Added new method signatures and arguments to handle new `bindMountSyspropOverrides` argument.

I **think** both ForkAndSpec and Spec are required, though quite honestly I'm not 100% sure. 

Tested locally and working on a Pixel 8 Pro.