### PR TITLE
Skip svc for ro properties

### DIFF
--- a/native/src/base/include/stream.hpp
+++ b/native/src/base/include/stream.hpp
@@ -78,6 +78,21 @@ private:
     void resize(size_t new_sz, bool zero = false);
 };
 
+class rust_vec_channel : public channel {
+public:
+    rust_vec_channel(rust::Vec<uint8_t> &data) : _data(data) {}
+
+    ssize_t read(void *buf, size_t len) override;
+    bool write(const void *buf, size_t len) override;
+    off_t seek(off_t off, int whence) override;
+
+private:
+    rust::Vec<uint8_t> &_data;
+    size_t _pos = 0;
+
+    void ensure_size(size_t sz);
+};
+
 class file_channel : public channel {
 public:
     bool write(const void *buf, size_t len) final;

--- a/native/src/base/include/stream.hpp
+++ b/native/src/base/include/stream.hpp
@@ -90,7 +90,7 @@ private:
     rust::Vec<uint8_t> &_data;
     size_t _pos = 0;
 
-    void ensure_size(size_t sz);
+    void ensure_size(size_t sz, bool zero = false);
 };
 
 class file_channel : public channel {

--- a/native/src/base/lib.rs
+++ b/native/src/base/lib.rs
@@ -66,5 +66,10 @@ fn set_log_level_state_cxx(level: ffi::LogLevelCxx, enabled: bool) {
 }
 
 fn resize_vec(vec: &mut Vec<u8>, size: usize) {
-    vec.resize(size, 0);
+    if size > vec.len() {
+        vec.reserve(size - vec.len());
+    }
+    unsafe {
+        vec.set_len(size);
+    }
 }

--- a/native/src/base/lib.rs
+++ b/native/src/base/lib.rs
@@ -44,6 +44,7 @@ pub mod ffi {
         fn set_log_level_state_cxx(level: LogLevelCxx, enabled: bool);
         fn exit_on_error(b: bool);
         fn cmdline_logging();
+        fn resize_vec(vec: &mut Vec<u8>, size: usize);
     }
 
     #[namespace = "rust"]
@@ -62,4 +63,8 @@ fn set_log_level_state_cxx(level: ffi::LogLevelCxx, enabled: bool) {
     if let Some(level) = LogLevel::from_i32(level.repr) {
         set_log_level_state(level, enabled)
     }
+}
+
+fn resize_vec(vec: &mut Vec<u8>, size: usize) {
+    vec.resize(size, 0);
 }

--- a/native/src/base/stream.cpp
+++ b/native/src/base/stream.cpp
@@ -180,6 +180,47 @@ void byte_channel::resize(size_t new_sz, bool zero) {
     }
 }
 
+ssize_t rust_vec_channel::read(void *buf, size_t len) {
+    len = std::min<size_t>(len, _data.size() - _pos);
+    memcpy(buf, _data.data() + _pos, len);
+    _pos += len;
+    return len;
+}
+
+bool rust_vec_channel::write(const void *buf, size_t len) {
+    ensure_size(_pos + len);
+    memcpy(_data.data() + _pos, buf, len);
+    _pos += len;
+    return true;
+}
+
+off_t rust_vec_channel::seek(off_t off, int whence) {
+    off_t np;
+    switch (whence) {
+        case SEEK_CUR:
+            np = _pos + off;
+            break;
+        case SEEK_END:
+            np = _data.size() + off;
+            break;
+        case SEEK_SET:
+            np = off;
+            break;
+        default:
+            return -1;
+    }
+    ensure_size(np);
+    _pos = np;
+    return np;
+}
+
+void rust_vec_channel::ensure_size(size_t sz) {
+    size_t old_sz = _data.size();
+    if (sz > old_sz) {
+        resize_vec(_data, sz);
+    }
+}
+
 ssize_t fd_channel::read(void *buf, size_t len) {
     return ::read(fd, buf, len);
 }

--- a/native/src/base/stream.cpp
+++ b/native/src/base/stream.cpp
@@ -209,15 +209,17 @@ off_t rust_vec_channel::seek(off_t off, int whence) {
         default:
             return -1;
     }
-    ensure_size(np);
+    ensure_size(np, true);
     _pos = np;
     return np;
 }
 
-void rust_vec_channel::ensure_size(size_t sz) {
+void rust_vec_channel::ensure_size(size_t sz, bool zero) {
     size_t old_sz = _data.size();
     if (sz > old_sz) {
         resize_vec(_data, sz);
+        if (zero)
+            memset(_data.data() + old_sz, 0, sz - old_sz);
     }
 }
 

--- a/native/src/boot/compress.cpp
+++ b/native/src/boot/compress.cpp
@@ -732,3 +732,24 @@ bool decompress(rust::Slice<const uint8_t> buf, int fd) {
     }
     return true;
 }
+
+bool xz(rust::Slice<const uint8_t> buf, rust::Vec<uint8_t> &out) {
+    auto strm = get_encoder(XZ, make_unique<rust_vec_channel>(out));
+    if (!strm->write(buf.data(), buf.length())) {
+        return false;
+    }
+    return true;
+}
+
+bool unxz(rust::Slice<const uint8_t> buf, rust::Vec<uint8_t> &out) {
+    format_t type = check_fmt(buf.data(), buf.length());
+    if (type != XZ) {
+        LOGE("Input file is not in xz format!\n");
+        return false;
+    }
+    auto strm = get_decoder(XZ, make_unique<rust_vec_channel>(out));
+    if (!strm->write(buf.data(), buf.length())) {
+        return false;
+    }
+    return true;
+}

--- a/native/src/boot/compress.hpp
+++ b/native/src/boot/compress.hpp
@@ -10,3 +10,5 @@ out_strm_ptr get_decoder(format_t type, out_strm_ptr &&base);
 void compress(const char *method, const char *infile, const char *outfile);
 void decompress(char *infile, const char *outfile);
 bool decompress(rust::Slice<const uint8_t> buf, int fd);
+bool xz(rust::Slice<const uint8_t> buf, rust::Vec<uint8_t> &out);
+bool unxz(rust::Slice<const uint8_t> buf, rust::Vec<uint8_t> &out);

--- a/native/src/boot/cpio.rs
+++ b/native/src/boot/cpio.rs
@@ -499,22 +499,30 @@ impl Cpio {
 }
 
 impl CpioEntry {
-    pub(crate) fn compress(&mut self) -> LoggedResult<()> {
+    pub(crate) fn compress(&mut self) -> bool {
+        if self.mode & S_IFMT != S_IFREG {
+            return false;
+        }
         let mut compressed = Vec::new();
         if !xz(&self.data, &mut compressed) {
-            return Err(log_err!("xz compression failed"));
+            eprintln!("xz compression failed");
+            return false;
         }
         self.data = compressed;
-        Ok(())
+        true
     }
 
-    pub(crate) fn decompress(&mut self) -> LoggedResult<()> {
+    pub(crate) fn decompress(&mut self) -> bool {
+        if self.mode & S_IFMT != S_IFREG {
+            return false;
+        }
         let mut decompressed = Vec::new();
         if !unxz(&self.data, &mut decompressed) {
-            return Err(log_err!("xz decompression failed"));
+            eprintln!("xz decompression failed");
+            return false;
         }
         self.data = decompressed;
-        Ok(())
+        true
     }
 }
 

--- a/native/src/boot/lib.rs
+++ b/native/src/boot/lib.rs
@@ -25,6 +25,8 @@ pub mod ffi {
     unsafe extern "C++" {
         include!("compress.hpp");
         fn decompress(buf: &[u8], fd: i32) -> bool;
+        fn xz(buf: &[u8], out: &mut Vec<u8>) -> bool;
+        fn unxz(buf: &[u8], out: &mut Vec<u8>) -> bool;
 
         include!("bootimg.hpp");
         #[cxx_name = "boot_img"]

--- a/native/src/boot/ramdisk.rs
+++ b/native/src/boot/ramdisk.rs
@@ -95,7 +95,7 @@ impl MagiskCpio for Cpio {
                         rm_list.push_str(data);
                     }
                 } else if name != ".backup/.magisk" {
-                    let new_name = if name.ends_with(".xz") && entry.decompress().is_ok() {
+                    let new_name = if name.ends_with(".xz") && entry.decompress() {
                         &name[8..name.len() - 3]
                     } else {
                         &name[8..]
@@ -175,7 +175,7 @@ impl MagiskCpio for Cpio {
             };
             match action {
                 Action::Backup(name, mut entry) => {
-                    let backup = if !skip_compress && entry.compress().is_ok() {
+                    let backup = if !skip_compress && entry.compress() {
                         format!(".backup/{}.xz", name)
                     } else {
                         format!(".backup/{}", name)

--- a/native/src/core/module.cpp
+++ b/native/src/core/module.cpp
@@ -313,12 +313,12 @@ void load_modules() {
             native_bridge_orig = "0";
         }
         native_bridge = native_bridge_orig != "0" ? ZYGISKLDR + native_bridge_orig : ZYGISKLDR;
-        set_prop(NBPROP, native_bridge.data(), true);
+        set_prop(NBPROP, native_bridge.data());
         // Weather Huawei's Maple compiler is enabled.
         // If so, system server will be created by a special Zygote which ignores the native bridge
         // and make system server out of our control. Avoid it by disabling.
         if (get_prop("ro.maple.enable") == "1") {
-            set_prop("ro.maple.enable", "0", true);
+            set_prop("ro.maple.enable", "0");
         }
         inject_zygisk_libs(system);
     }

--- a/native/src/core/zygisk/entry.cpp
+++ b/native/src/core/zygisk/entry.cpp
@@ -229,9 +229,11 @@ void zygisk_handler(int client, const sock_cred *cred) {
 void reset_zygisk(bool restore) {
     if (!zygisk_enabled) return;
     static atomic_uint zygote_start_count{1};
-    close(zygiskd_sockets[0]);
-    close(zygiskd_sockets[1]);
-    zygiskd_sockets[0] = zygiskd_sockets[1] = -1;
+    if (!restore) {
+        close(zygiskd_sockets[0]);
+        close(zygiskd_sockets[1]);
+        zygiskd_sockets[0] = zygiskd_sockets[1] = -1;
+    }
     if (restore) {
         zygote_start_count = 1;
     } else if (zygote_start_count.fetch_add(1) > 3) {

--- a/native/src/core/zygisk/entry.cpp
+++ b/native/src/core/zygisk/entry.cpp
@@ -245,8 +245,8 @@ void reset_zygisk(bool restore) {
         if (native_bridge.length() > strlen(ZYGISKLDR)) {
             native_bridge_orig = native_bridge.substr(strlen(ZYGISKLDR));
         }
-        set_prop(NBPROP, native_bridge_orig.data(), true);
+        set_prop(NBPROP, native_bridge_orig.data());
     } else {
-        set_prop(NBPROP, native_bridge.data(), true);
+        set_prop(NBPROP, native_bridge.data());
     }
 }


### PR DESCRIPTION
ro properties' triggers should only be triggered once, otherwise it
may undefined behaviour.
This patch avoids triggering ro properties' actions again when using
resetprop to modify them.
