### PR TITLE
Add `resetprop -w` for waiting property change

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -109,7 +109,7 @@ Update JSON format:
 
 #### Shell scripts (`*.sh`)
 
-Please read the [Boot Scripts](#boot-scripts) section to understand the difference between `post-fs-data.sh` and `service.sh`. For most module developers, `service.sh` should be good enough if you just need to run a boot script.
+Please read the [Boot Scripts](#boot-scripts) section to understand the difference between `post-fs-data.sh` and `service.sh`. For most module developers, `service.sh` should be good enough if you just need to run a boot script. If you need to wait for boot completed, you can use `resetprop -w sys.boot_completed 0`.
 
 In all scripts of your module, please use `MODDIR=${0%/*}` to get your module's base directory path; do **NOT** hardcode your module path in scripts.
 If Zygisk is enabled, the environment variable `ZYGISK_ENABLED` will be set to `1`.

--- a/native/src/core/include/resetprop.hpp
+++ b/native/src/core/include/resetprop.hpp
@@ -5,14 +5,14 @@
 #include <cxx.h>
 
 struct prop_cb {
-    virtual void exec(const char *name, const char *value) = 0;
+    virtual void exec(const char *name, const char *value, uint32_t serial) = 0;
 };
 
 using prop_list = std::map<std::string, std::string>;
 
 struct prop_collector : prop_cb {
     explicit prop_collector(prop_list &list) : list(list) {}
-    void exec(const char *name, const char *value) override {
+    void exec(const char *name, const char *value, uint32_t) override {
         list.insert({name, value});
     }
 private:
@@ -26,6 +26,6 @@ int delete_prop(const char *name, bool persist = false);
 int set_prop(const char *name, const char *value, bool skip_svc = false);
 void load_prop_file(const char *filename, bool skip_svc = false);
 
-static inline void prop_cb_exec(prop_cb &cb, const char *name, const char *value) {
-    cb.exec(name, value);
+static inline void prop_cb_exec(prop_cb &cb, const char *name, const char *value, uint32_t serial) {
+    cb.exec(name, value, serial);
 }

--- a/native/src/core/lib.rs
+++ b/native/src/core/lib.rs
@@ -49,7 +49,12 @@ pub mod ffi {
         #[cxx_name = "prop_cb"]
         type PropCb;
         unsafe fn get_prop_rs(name: *const c_char, persist: bool) -> String;
-        unsafe fn prop_cb_exec(cb: Pin<&mut PropCb>, name: *const c_char, value: *const c_char);
+        unsafe fn prop_cb_exec(
+            cb: Pin<&mut PropCb>,
+            name: *const c_char,
+            value: *const c_char,
+            serial: u32,
+        );
     }
 
     unsafe extern "C++" {

--- a/native/src/core/resetprop/persist.rs
+++ b/native/src/core/resetprop/persist.rs
@@ -39,7 +39,7 @@ trait PropCbExec {
 
 impl PropCbExec for Pin<&mut PropCb> {
     fn exec(&mut self, name: &Utf8CStr, value: &Utf8CStr) {
-        unsafe { prop_cb_exec(self.as_mut(), name.as_ptr(), value.as_ptr()) }
+        unsafe { prop_cb_exec(self.as_mut(), name.as_ptr(), value.as_ptr(), u32::MAX) }
     }
 }
 


### PR DESCRIPTION
It's very easy to wait for property change both in Java and C++, but it's not the case in shell script. With this patch, developers can now easil wait for property change, just like what we have in `.rc` files, and can wait for boot complete.