### PR TITLE
Refactor magic mount

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/App.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/App.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
+import android.system.Os
 import androidx.profileinstaller.ProfileInstaller
 import com.topjohnwu.magisk.BuildConfig
 import com.topjohnwu.magisk.StubApk
@@ -46,6 +47,8 @@ open class App() : Application() {
             Timber.e(e)
             exitProcess(1)
         }
+
+        Os.setenv("PATH", "${Os.getenv("PATH")}:/debug_ramdisk:/sbin", true)
     }
 
     override fun attachBaseContext(context: Context) {

--- a/app/src/main/res/raw/manager.sh
+++ b/app/src/main/res/raw/manager.sh
@@ -14,7 +14,7 @@ env_check() {
     [ -f "$MAGISKBIN/magiskpolicy" ] || return 1
   fi
   if [ "$2" -ge 25210 ]; then
-    [ -b "$MAGISKTMP/.magisk/block/preinit" ] || return 2
+    [ -b "$MAGISKTMP/.magisk/device/preinit" ] || [ -b "$MAGISKTMP/.magisk/block/preinit" ] || return 2
   fi
   grep -xqF "MAGISK_VER='$1'" "$MAGISKBIN/util_functions.sh" || return 3
   grep -xqF "MAGISK_VER_CODE=$2" "$MAGISKBIN/util_functions.sh" || return 3

--- a/native/src/core/bootstages.cpp
+++ b/native/src/core/bootstages.cpp
@@ -72,6 +72,7 @@ static void setup_mounts() {
 
     // Prepare worker
     ssprintf(path, sizeof(path), "%s/" WORKERDIR, get_magisk_tmp());
+    xmkdir(path, 0);
     xmount("worker", path, "tmpfs", 0, "mode=755");
     xmount(nullptr, path, nullptr, MS_PRIVATE, nullptr);
 }

--- a/native/src/core/bootstages.cpp
+++ b/native/src/core/bootstages.cpp
@@ -73,7 +73,7 @@ static void setup_mounts() {
     // Prepare worker
     ssprintf(path, sizeof(path), "%s/" WORKERDIR, get_magisk_tmp());
     xmkdir(path, 0);
-    xmount("worker", path, "tmpfs", 0, "mode=755");
+    xmount(path, path, nullptr, MS_BIND, nullptr);
     xmount(nullptr, path, nullptr, MS_PRIVATE, nullptr);
 }
 

--- a/native/src/core/bootstages.cpp
+++ b/native/src/core/bootstages.cpp
@@ -19,18 +19,10 @@ bool zygisk_enabled = false;
 /*********
  * Setup *
  *********/
-
-static bool rec_mount(const std::string_view from, const std::string_view to) {
-    return !xmkdirs(to.data(), 0755) &&
-           // recursively bind mount to mirror dir, rootfs will fail before 3.12 kernel
-           // because of MS_NOUSER
-           !mount(from.data(), to.data(), nullptr, MS_BIND | MS_REC, nullptr);
-}
-
-static void mount_mirrors() {
-    LOGI("* Mounting mirrors\n");
+static void setup_mounts() {
+    LOGI("* Magic mount setup\n");
     auto self_mount_info = parse_mount_info("self");
-    char path[64];
+    char path[PATH_MAX];
 
     // Bind remount module root to clear nosuid
     if (access(SECURE_DIR, F_OK) == 0 || SDK_INT < 24) {
@@ -65,8 +57,9 @@ static void mount_mirrors() {
                 if (!rw) continue;
                 string preinit_dir = resolve_preinit_dir(info.target.data());
                 xmkdir(preinit_dir.data(), 0700);
-                if ((mounted = rec_mount(preinit_dir, path))) {
-                    xmount(nullptr, path, nullptr, MS_UNBINDABLE, nullptr);
+                xmkdirs(path, 0755);
+                mounted = xmount(preinit_dir.data(), path, nullptr, MS_BIND, nullptr) == 0;
+                if (mounted) {
                     break;
                 }
             }
@@ -81,27 +74,6 @@ static void mount_mirrors() {
     ssprintf(path, sizeof(path), "%s/" WORKERDIR, get_magisk_tmp());
     xmount("worker", path, "tmpfs", 0, "mode=755");
     xmount(nullptr, path, nullptr, MS_PRIVATE, nullptr);
-    // Recursively bind mount / to mirror dir
-    // Keep mirror shared so that mounting during post-fs-data will be propagated
-    if (auto mirror_dir = get_magisk_tmp() + "/"s MIRRDIR; !rec_mount("/", mirror_dir)) {
-        LOGI("fallback to mount subtree\n");
-        // create new a bind mount for easy make private
-        xmount(mirror_dir.data(), mirror_dir.data(), nullptr, MS_BIND, nullptr);
-        // rootfs may fail, fallback to bind mount each mount point
-        set<string, greater<>> mounted_dirs {{ get_magisk_tmp() }};
-        for (const auto &info: self_mount_info) {
-            if (info.type == "rootfs"sv) continue;
-            // the greatest mount point that less than info.target, which is possibly a parent
-            if (auto last_mount = mounted_dirs.upper_bound(info.target);
-                last_mount != mounted_dirs.end() && info.target.starts_with(*last_mount + '/')) {
-                continue;
-            }
-            if (rec_mount(info.target, mirror_dir + info.target)) {
-                LOGD("%-8s: %s <- %s\n", "rbind", (mirror_dir + info.target).data(), info.target.data());
-                mounted_dirs.insert(info.target);
-            }
-        }
-    }
 }
 
 string find_preinit_device() {
@@ -310,7 +282,7 @@ bool MagiskD::post_fs_data() const {
     LOGI("** post-fs-data mode running\n");
 
     unlock_blocks();
-    mount_mirrors();
+    setup_mounts();
     prune_su_access();
 
     bool safe_mode = false;
@@ -341,15 +313,7 @@ bool MagiskD::post_fs_data() const {
     }
 
 early_abort:
-    auto mirror_dir = get_magisk_tmp() + "/"s MIRRDIR;
-    // make mirror dir as a private mount so that it won't be affected by magic mount
-    LOGD("make %s private\n", mirror_dir.data());
-    xmount(nullptr, mirror_dir.data(), nullptr, MS_PRIVATE | MS_REC, nullptr);
-    // We still do magic mount because root itself might need it
     load_modules();
-    // make mirror dir as a shared mount to make magisk --stop work for other ns
-    xmount(nullptr, mirror_dir.data(), nullptr, MS_SHARED | MS_REC, nullptr);
-    LOGD("make %s shared\n", mirror_dir.data());
     return safe_mode;
 }
 

--- a/native/src/core/daemon.cpp
+++ b/native/src/core/daemon.cpp
@@ -391,13 +391,6 @@ static void daemon_entry() {
     ssprintf(path, sizeof(path), "%s/" ROOTOVL, tmp);
     rm_rf(path);
 
-    // Unshare magiskd
-    xunshare(CLONE_NEWNS);
-    // Hide magisk internal mount point
-    xmount(nullptr, tmp, nullptr, MS_PRIVATE | MS_REC, nullptr);
-    // Fix sdcardfs bug on old kernel
-    xmount(nullptr, "/mnt", nullptr, MS_SLAVE | MS_REC, nullptr);
-
     // Use isolated devpts if kernel support
     if (access("/dev/pts/ptmx", F_OK) == 0) {
         ssprintf(path, sizeof(path), "%s/" SHELLPTS, tmp);

--- a/native/src/core/deny/revert.cpp
+++ b/native/src/core/deny/revert.cpp
@@ -20,7 +20,7 @@ void revert_unmount() {
     // Unmount dummy skeletons and MAGISKTMP
     // since mirror nodes are always mounted under skeleton, we don't have to specifically unmount
     for (auto &info: parse_mount_info("self")) {
-        if (info.source == "magisk" || info.source == "worker" || // magisktmp tmpfs
+        if (info.source == "magisk" || // magisktmp tmpfs
             info.root.starts_with("/adb/modules")) { // bind mount from data partition
             targets.insert(info.target);
         }

--- a/native/src/core/module.cpp
+++ b/native/src/core/module.cpp
@@ -162,6 +162,7 @@ void tmpfs_node::mount() {
         dir_node::mount();
         VLOGD(replace() ? "replace" : "move", worker_dir.data(), node_path().data());
         xmount(worker_dir.data(), node_path().data(), nullptr, MS_MOVE, nullptr);
+        xmount(nullptr, node_path().data(), nullptr, MS_REMOUNT | MS_BIND | MS_RDONLY, nullptr);
     } else {
         const string dest = worker_path();
         // We don't need another layer of tmpfs if parent is tmpfs
@@ -326,8 +327,11 @@ void load_modules() {
         root->mount();
     }
 
+    // cleanup mounts
     ssprintf(buf, sizeof(buf), "%s/" WORKERDIR, get_magisk_tmp());
-    xmount(nullptr, buf, nullptr, MS_REMOUNT | MS_RDONLY, nullptr);
+    xumount2(buf, MNT_DETACH);
+    ssprintf(buf, sizeof(buf), "%s/" MODULEMNT, get_magisk_tmp());
+    xumount2(buf, MNT_DETACH);
 }
 
 /************************

--- a/native/src/include/consts.hpp
+++ b/native/src/include/consts.hpp
@@ -13,8 +13,8 @@
 #define INTLROOT      ".magisk"
 #define MIRRDIR       INTLROOT "/mirror"
 #define PREINITMIRR   INTLROOT "/preinit"
-#define BLOCKDIR      INTLROOT "/block"
-#define PREINITDEV    BLOCKDIR "/preinit"
+#define DEVICEDIR     INTLROOT "/device"
+#define PREINITDEV    DEVICEDIR "/preinit"
 #define WORKERDIR     INTLROOT "/worker"
 #define MODULEMNT     INTLROOT "/modules"
 #define BBPATH        INTLROOT "/busybox"
@@ -23,8 +23,8 @@
 #define ROOTMNT       ROOTOVL  "/.mount_list"
 #define SELINUXMOCK   INTLROOT "/selinux"
 #define MAIN_CONFIG   INTLROOT "/config"
-#define MAIN_SOCKET   INTLROOT "/socket"
-#define LOG_PIPE      INTLROOT "/log"
+#define MAIN_SOCKET   DEVICEDIR "/socket"
+#define LOG_PIPE      DEVICEDIR "/log"
 
 constexpr const char *applet_names[] = { "su", "resetprop", nullptr };
 

--- a/native/src/include/consts.rs
+++ b/native/src/include/consts.rs
@@ -17,7 +17,7 @@ macro_rules! INTLROOT {
 #[macro_export]
 macro_rules! LOG_PIPE {
     () => {
-        concat!($crate::INTLROOT!(), "/log")
+        concat!($crate::INTLROOT!(), "/device/log")
     };
 }
 

--- a/native/src/init/rootdir.cpp
+++ b/native/src/init/rootdir.cpp
@@ -13,7 +13,6 @@ using namespace std;
 
 static vector<string> rc_list;
 
-#define ROOTMIR         MIRRDIR "/system_root"
 #define NEW_INITRC_DIR  "/system/etc/init/hw"
 #define INIT_RC         "init.rc"
 
@@ -250,10 +249,10 @@ void MagiskInit::patch_ro_root() {
 
     if (tmp_dir == "/sbin") {
         // Recreate original sbin structure
-        xmkdir(ROOTMIR, 0755);
-        xmount("/", ROOTMIR, nullptr, MS_BIND, nullptr);
-        recreate_sbin(ROOTMIR "/sbin", true);
-        xumount2(ROOTMIR, MNT_DETACH);
+        xmkdir(MIRRDIR, 0755);
+        xmount("/", MIRRDIR, nullptr, MS_BIND, nullptr);
+        recreate_sbin(MIRRDIR "/sbin", true);
+        xumount2(MIRRDIR, MNT_DETACH);
     } else {
         // Restore debug_ramdisk
         xmount("/data/debug_ramdisk", "/debug_ramdisk", nullptr, MS_MOVE, nullptr);

--- a/scripts/avd_magisk.sh
+++ b/scripts/avd_magisk.sh
@@ -138,9 +138,7 @@ ln -s ./magisk $MAGISKTMP/su
 ln -s ./magisk $MAGISKTMP/resetprop
 ln -s ./magiskpolicy $MAGISKTMP/supolicy
 
-mkdir -p $MAGISKTMP/.magisk/mirror
-mkdir $MAGISKTMP/.magisk/block
-mkdir $MAGISKTMP/.magisk/worker
+mkdir -p $MAGISKTMP/.magisk/device
 touch $MAGISKTMP/.magisk/config
 
 export MAGISKTMP

--- a/scripts/avd_test.sh
+++ b/scripts/avd_test.sh
@@ -138,7 +138,7 @@ test_emu() {
   emu_pid=$!
   wait_emu wait_for_boot
 
-  adb shell magisk -v
+  adb shell 'PATH=$PATH:/debug_ramdisk magisk -v'
 
   # Install the Magisk app
   adb install -r -g out/app-${variant}.apk
@@ -149,7 +149,7 @@ test_emu() {
   # Install LSPosed
   if [ $api -ge $lsposed_min_api -a $api -le $atd_max_api ]; then
     adb push out/lsposed.zip /data/local/tmp/lsposed.zip
-    adb shell echo 'magisk --install-module /data/local/tmp/lsposed.zip' \| /system/xbin/su
+    adb shell echo 'PATH=$PATH:/debug_ramdisk magisk --install-module /data/local/tmp/lsposed.zip' \| /system/xbin/su
   fi
 
   adb reboot


### PR DESCRIPTION
Mirror was previously used for accessing the original file during magic mount when we are using a tmpfs to cover the target. However, since we introduce atomic mount, we switch all tmpfs mount in worker and then move to the target at once. It means that we can still access the original file when we are constructing the tmpfs mount point. Thus we no longer need mirror.