### PR TITLE
update[buildSrc/build.gradle.kts]: AGP 8.2.0 -> 8.2.1.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,7 +17,7 @@ gradlePlugin {
 
 dependencies {
     implementation(embeddedKotlin("gradle-plugin"))
-    implementation("com.android.tools.build:gradle:8.2.0")
+    implementation("com.android.tools.build:gradle:8.2.1")
     implementation("androidx.navigation:navigation-safe-args-gradle-plugin:2.7.5")
     implementation("org.lsposed.lsparanoid:gradle-plugin:0.5.2")
     implementation("org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r")


### PR DESCRIPTION
Build failed with java 21.0.1, update AGP to 8.2.1 can fixes.  
More details: https://issuetracker.google.com/issues/294137077