### PR TITLE
Fix zygisk unload

### DIFF
--- a/native/src/core/zygisk/entry.cpp
+++ b/native/src/core/zygisk/entry.cpp
@@ -16,7 +16,6 @@ using namespace std;
 string native_bridge = "0";
 
 static bool is_compatible_with(uint32_t) {
-    auto name = get_prop(NBPROP);
     zygisk_logging();
     hook_functions();
     ZLOGD("load success\n");

--- a/native/src/core/zygisk/hook.cpp
+++ b/native/src/core/zygisk/hook.cpp
@@ -204,7 +204,7 @@ DCL_HOOK_FUNC(static int, pthread_attr_destroy, void *target) {
             // Because both `pthread_attr_destroy` and `dlclose` have the same function signature,
             // we can use `musttail` to let the compiler reuse our stack frame and thus
             // `dlclose` will directly return to the caller of `pthread_attr_destroy`.
-            [[clang::musttail]] return old_dlclose(self_handle);
+            [[clang::musttail]] return dlclose(self_handle);
         }
     }
 


### PR DESCRIPTION
Magisk is not hooking itself, so it's safe to directly call `dlclose`. Otherwise, using `old_dlclose` will cause the unload to fail.