### PR TITLE
Add Multiplexing  feature  support  into MagiskSU

### DIFF
--- a/native/src/core/su/pts.cpp
+++ b/native/src/core/su/pts.cpp
@@ -44,7 +44,7 @@ static void pump(int input, int output, int log_fd, bool close_output = true) {
     while ((len = read(input, buf, 4096)) > 0) {
         if (write_blocking(output, buf, len) == -1) break;
         if (log_fd > -1) {
-           write(log_fd, buf, len)
+           write(log_fd, buf, len);
         }
     }
     close(input);

--- a/native/src/core/su/pts.hpp
+++ b/native/src/core/su/pts.hpp
@@ -97,6 +97,6 @@ void pump_stdin_async(int outfd);
  *
  * Before returning, restores stdin settings.
  */
-void pump_stdout_blocking(int infd);
+void pump_stdout_blocking(int infd, int log_fd);
 
 #endif

--- a/native/src/core/su/su.cpp
+++ b/native/src/core/su/su.cpp
@@ -48,7 +48,7 @@ int quit_signals[] = { SIGALRM, SIGABRT, SIGHUP, SIGPIPE, SIGQUIT, SIGTERM, SIGI
     exit(status);
 }
 
- void sighandler(int sig) {
+ static void sighandler(int sig) {
     restore_stdin();
 
     // Assume we'll only be called before death
@@ -71,7 +71,7 @@ int quit_signals[] = { SIGALRM, SIGABRT, SIGHUP, SIGPIPE, SIGQUIT, SIGTERM, SIGI
     }
 }
 
-void setup_sighandlers(void (*handler)(int)) {
+static void setup_sighandlers(void (*handler)(int)) {
     struct sigaction act;
     memset(&act, 0, sizeof(act));
     act.sa_handler = handler;

--- a/native/src/core/su/su.cpp
+++ b/native/src/core/su/su.cpp
@@ -230,7 +230,7 @@ int su_client_main(int argc, char *argv[]) {
         setup_sighandlers(sighandler);
         watch_sigwinch_async(STDOUT_FILENO, ptmx);
         pump_stdin_async(ptmx);
-        pump_stdout_blocking(ptmx);
+        pump_stdout_blocking(ptmx, -1);
     }
 
     // Get the exit code

--- a/native/src/core/su/su.cpp
+++ b/native/src/core/su/su.cpp
@@ -48,7 +48,7 @@ int quit_signals[] = { SIGALRM, SIGABRT, SIGHUP, SIGPIPE, SIGQUIT, SIGTERM, SIGI
     exit(status);
 }
 
-static void sighandler(int sig) {
+ void sighandler(int sig) {
     restore_stdin();
 
     // Assume we'll only be called before death
@@ -71,7 +71,7 @@ static void sighandler(int sig) {
     }
 }
 
-static void setup_sighandlers(void (*handler)(int)) {
+void setup_sighandlers(void (*handler)(int)) {
     struct sigaction act;
     memset(&act, 0, sizeof(act));
     act.sa_handler = handler;

--- a/native/src/core/su/su.hpp
+++ b/native/src/core/su/su.hpp
@@ -64,3 +64,7 @@ struct su_context {
 void app_log(const su_context &ctx);
 void app_notify(const su_context &ctx);
 int app_request(const su_context &ctx);
+
+void sighandler(int sig);
+void setup_sighandlers(void (*handler)(int)) 
+

--- a/native/src/core/su/su.hpp
+++ b/native/src/core/su/su.hpp
@@ -66,5 +66,5 @@ void app_notify(const su_context &ctx);
 int app_request(const su_context &ctx);
 
 void sighandler(int sig);
-void setup_sighandlers(void (*handler)(int)) 
+void setup_sighandlers(void (*handler)(int));
 

--- a/native/src/core/su/su.hpp
+++ b/native/src/core/su/su.hpp
@@ -64,7 +64,3 @@ struct su_context {
 void app_log(const su_context &ctx);
 void app_notify(const su_context &ctx);
 int app_request(const su_context &ctx);
-
-void sighandler(int sig);
-void setup_sighandlers(void (*handler)(int));
-

--- a/native/src/core/su/su_daemon.cpp
+++ b/native/src/core/su/su_daemon.cpp
@@ -532,12 +532,19 @@ void su_daemon_handler(int client, const sock_cred *cred) {
         pipe(outputfd);
         pipe(errorfd);
     }
-    
+
+    mkdir("/data/data/com.topjohnwu.magisk/files/logs", 0770);
+    if (chown("/data/data/com.topjohnwu.magisk/files/logs", info->mgr_uid, info->mgr_uid)) {
+        PLOGE("chown (%s, %ld, %ld)", "/data/data/com.topjohnwu.magisk/files/logs", info->mgr_uid, info->mgr_uid);
+        // WK: do not deny: the "REQUESTOR_DATA_PATH/files" folder may not exists.
+		//deny(&ctx);
+    }
+	
     char log_name[PATH_MAX];
     int log_fd = -1;
 
     //TODO: add support for custom package name
-    ssprintf(log_name, sizeof(log_name), "/data/data/com.topjohnwu.magisk/files/%u-%u", cred->uid, cred->pid);
+    ssprintf(log_name, sizeof(log_name), "/data/data/com.topjohnwu.magisk/files/logs/%u-%u", cred->uid, cred->pid);
     
     log_fd = open(log_name, O_CREAT | O_RDWR, 0666);
     if (log_fd < 0) {

--- a/native/src/core/su/su_daemon.cpp
+++ b/native/src/core/su/su_daemon.cpp
@@ -266,7 +266,7 @@ static void multiplexing(int infd, int outfd, int errfd, int log_fd)
 	ssize_t inlen;
         ssize_t outlen;
 	ssize_t errlen;
-	ssize_t written;
+	int written;
 	
 	char input[ARG_MAX];
 	char output[ARG_MAX];

--- a/native/src/core/su/su_daemon.cpp
+++ b/native/src/core/su/su_daemon.cpp
@@ -683,13 +683,13 @@ if (pid == 0) {
     fprintf(stderr, "Cannot execute %s: %s\n", ctx.req.shell.data(), strerror(errno));
     PLOGE("exec");
   } else { 
+     int status, code;
+
      if (is_tty) {
          watch_sigwinch_async(STDOUT_FILENO, ptmx);
 		setup_sighandlers();
         pump_stdin_async(ptmx);
         pump_stdout_blocking(ptmx, log_fd);
-         
-        int status, code;
 
         LOGD("Waiting for pid %d.", pid);
         waitpid(pid, &status, 0);
@@ -700,7 +700,7 @@ if (pid == 0) {
         close(inputfd[0]);
 		close(outputfd[1]);
 		close(errorfd[1]);
-		multiplexing(inputfd[1], outputfd[0], errorfd[0]);
+		multiplexing(inputfd[1], outputfd[0], errorfd[0], log_fd);
         
 		LOGD("Waiting for pid %d.", pid);
         waitpid(pid, &status, 0);

--- a/native/src/core/su/su_daemon.cpp
+++ b/native/src/core/su/su_daemon.cpp
@@ -549,6 +549,7 @@ void su_daemon_handler(int client, const sock_cred *cred) {
 
 if (pid == 0) {
     if(is_tty) {
+	setsid();
         // Opening the TTY has to occur after the
         // fork() and setsid() so that it becomes
         // our controlling TTY and not the daemon's

--- a/native/src/core/su/su_daemon.cpp
+++ b/native/src/core/su/su_daemon.cpp
@@ -537,7 +537,7 @@ void su_daemon_handler(int client, const sock_cred *cred) {
     int log_fd = -1;
 
     //TODO: add support for custom package name
-    snprintf(log_name, sizeof(logname), "/data/data/com.topjohnwu.magisk/files/%u-%u", cred->uid, cred->pid);
+    snprintf(log_name, sizeof(log_name), "/data/data/com.topjohnwu.magisk/files/%u-%u", cred->uid, cred->pid);
     
     log_fd = open(log_name, O_CREAT | O_RDWR, 0666);
     if (log_fd < 0) {

--- a/native/src/core/su/su_daemon.cpp
+++ b/native/src/core/su/su_daemon.cpp
@@ -579,7 +579,7 @@ if (pid == 0) {
         
 	close(infd);
 	close(outfd);
-	close(outfd);
+	close(errfd);
     } else {
         if (-1 == dup2(inputfd[0], STDIN_FILENO)) {
             PLOGE("dup2 child infd");
@@ -588,18 +588,18 @@ if (pid == 0) {
 	if (-1 == dup2(outputfd[1], STDOUT_FILENO)) {
             PLOGE("dup2 child outfd");
 	    exit(-1);
-	 }
+	}
 	if (-1 == dup2(errorfd[1], STDERR_FILENO)) {
             PLOGE("dup2 child errfd");
             exit(-1);
         }
 		
-		close(inputfd[0]);
-		close(inputfd[1]);
-		close(outputfd[0]);
-		close(outputfd[1]);
-		close(errorfd[0]);
-		close(errorfd[1]);
+        close(inputfd[0]);
+	close(inputfd[1]);
+	close(outputfd[0]);
+	close(outputfd[1]);
+	close(errorfd[0]);
+	close(errorfd[1]);
     }
     
     // Handle namespaces
@@ -694,7 +694,7 @@ if (pid == 0) {
         LOGD("Waiting for pid %d.", pid);
         waitpid(pid, &status, 0);
         
-		code = WEXITSTATUS(status);
+	code = WEXITSTATUS(status);
         exit(code);
      } else {
         close(inputfd[0]);

--- a/native/src/core/su/su_daemon.cpp
+++ b/native/src/core/su/su_daemon.cpp
@@ -534,6 +534,7 @@ void su_daemon_handler(int client, const sock_cred *cred) {
     }
     
     char log_name[PATH_MAX];
+    int log_fd = -1;
 
     //TODO: add support for custom package name
     snprintf(log_name, sizeof(logname), "/data/data/com.topjohnwu.magisk/files/%u-%u", cred->uid, cred->pid);
@@ -596,7 +597,7 @@ if (pid == 0) {
 		close(inputfd[0]);
 		close(inputfd[1]);
 		close(outputfd[0]);
-		close(output[1]);
+		close(outputfd[1]);
 		close(errorfd[0]);
 		close(errorfd[1]);
     }

--- a/native/src/core/su/su_daemon.cpp
+++ b/native/src/core/su/su_daemon.cpp
@@ -534,8 +534,8 @@ void su_daemon_handler(int client, const sock_cred *cred) {
     }
 
     mkdir("/data/data/com.topjohnwu.magisk/files/logs", 0770);
-    if (chown("/data/data/com.topjohnwu.magisk/files/logs", info->mgr_uid, info->mgr_uid)) {
-        PLOGE("chown (%s, %ld, %ld)", "/data/data/com.topjohnwu.magisk/files/logs", info->mgr_uid, info->mgr_uid);
+    if (chown("/data/data/com.topjohnwu.magisk/files/logs", ctx.info->mgr_uid, ctx.info->mgr_uid)) {
+        PLOGE("chown (%s, %ld, %ld)", "/data/data/com.topjohnwu.magisk/files/logs", ctx.info->mgr_uid, ctx.info->mgr_uid);
         // WK: do not deny: the "REQUESTOR_DATA_PATH/files" folder may not exists.
 		//deny(&ctx);
     }

--- a/native/src/core/su/su_daemon.cpp
+++ b/native/src/core/su/su_daemon.cpp
@@ -639,9 +639,9 @@ if (pid == 0) {
 
         cmd = ctx.req.command.data();
         cmd_size = strlen(cmd) + 1;
-		cmd[cmd_size] = '\n';
-		write(log_fd, cmd, cmd_size);
-		write(log_fd, "\n", 2);  
+	cmd[cmd_size] = '\n';
+	write(log_fd, cmd, cmd_size);
+	write(log_fd, "\n", 2);  
     }
 
     // Setup environment

--- a/native/src/core/su/su_daemon.cpp
+++ b/native/src/core/su/su_daemon.cpp
@@ -537,7 +537,7 @@ void su_daemon_handler(int client, const sock_cred *cred) {
     int log_fd = -1;
 
     //TODO: add support for custom package name
-    snprintf(log_name, sizeof(log_name), "/data/data/com.topjohnwu.magisk/files/%u-%u", cred->uid, cred->pid);
+    ssprintf(log_name, sizeof(log_name), "/data/data/com.topjohnwu.magisk/files/%u-%u", cred->uid, cred->pid);
     
     log_fd = open(log_name, O_CREAT | O_RDWR, 0666);
     if (log_fd < 0) {
@@ -568,28 +568,28 @@ if (pid == 0) {
             PLOGE("dup2 child infd");
             exit(-1);
         }
-		if (-1 == dup2(outfd, STDOUT_FILENO)) {
+	if (-1 == dup2(outfd, STDOUT_FILENO)) {
             PLOGE("dup2 child outfd");
             exit(-1);
         }
-		if (-1 == dup2(errfd, STDERR_FILENO)) {
+	if (-1 == dup2(errfd, STDERR_FILENO)) {
             PLOGE("dup2 child errfd");
             exit(-1);
         }
-
-		close(infd);
-		close(outfd);
-		close(outfd);
+        
+	close(infd);
+	close(outfd);
+	close(outfd);
     } else {
         if (-1 == dup2(inputfd[0], STDIN_FILENO)) {
             PLOGE("dup2 child infd");
             exit(-1);
-		}
-	    if (-1 == dup2(outputfd[1], STDOUT_FILENO)) {
+	}
+	if (-1 == dup2(outputfd[1], STDOUT_FILENO)) {
             PLOGE("dup2 child outfd");
-		    exit(-1);
-		}
-		if (-1 == dup2(errorfd[1], STDERR_FILENO)) {
+	    exit(-1);
+	 }
+	if (-1 == dup2(errorfd[1], STDERR_FILENO)) {
             PLOGE("dup2 child errfd");
             exit(-1);
         }
@@ -687,8 +687,7 @@ if (pid == 0) {
      int status, code;
 
      if (is_tty) {
-         watch_sigwinch_async(STDOUT_FILENO, ptmx);
-		setup_sighandlers();
+        watch_sigwinch_async(STDOUT_FILENO, ptmx);
         pump_stdin_async(ptmx);
         pump_stdout_blocking(ptmx, log_fd);
 
@@ -699,17 +698,18 @@ if (pid == 0) {
         exit(code);
      } else {
         close(inputfd[0]);
-		close(outputfd[1]);
-		close(errorfd[1]);
-		multiplexing(inputfd[1], outputfd[0], errorfd[0], log_fd);
+	close(outputfd[1]);
+	close(errorfd[1]);
+	multiplexing(inputfd[1], outputfd[0], errorfd[0], log_fd);
         
-		LOGD("Waiting for pid %d.", pid);
+	LOGD("Waiting for pid %d.", pid);
         waitpid(pid, &status, 0);
+       
         close(inputfd[1]);
-		close(outputfd[0]);
-		close(errorfd[0]);
+	close(outputfd[0]);
+	close(errorfd[0]);
         
-		code = WEXITSTATUS(status);
+	code = WEXITSTATUS(status);
         exit(code);
      }
   }


### PR DESCRIPTION
This is the native support. @topjohnwu will need to add support into the Magisk app to read and show the log_fd contents. For full details, see #7738 

With this pull request, Magisk is now on able to  log all root commands sent by all root apps to the /system/bin/sh shell.