### PR TITLE
CI also builds release on win and mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup
 
+      - name: Build release
+        run: python build.py -vr all
+
       - name: Build debug
         run: python build.py -v all
 


### PR DESCRIPTION
Because release version has some codes that are not activated on debug version. We should also check them.