### PR TITLE
Clean up recovery install various errors in log

### DIFF
--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -173,7 +173,7 @@ if [ -n "$PREINITDEVICE" ]; then
   echo "PREINITDEVICE=$PREINITDEVICE" >> config
 fi
 [ -n "$SHA1" ] && echo "SHA1=$SHA1" >> config
-RANDOMSEED=$(tr -dc 'a-f0-9' < /dev/urandom | head -c 16)
+RANDOMSEED=$(tr -dc 'a-f0-9' < /dev/urandom 2>/dev/null | head -c 16)
 echo "RANDOMSEED=0x$RANDOMSEED" >> config
 
 ./magiskboot cpio ramdisk.cpio \


### PR DESCRIPTION
- hide RANDOMSEED tr stderr when run in recovery

[  179.306595] tr: write error: Broken pipe

- add shell context workaround for loop mounts errors on LOS Recovery

[  152.382751] mount: mounting /dev/block/loop0 on /apex/com.android.adbd failed: Invalid argument

- don't attempt to use BOOTSIGNER if /system/bin/dalvikvm is not present

[  177.836745] /dev/tmp/install/META-INF/com/google/android/updater-script: eval: line 1: /system/bin/dalvikvm: not found