### PR TITLE
Do not delete the READE.md file during module installation

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -718,7 +718,7 @@ install_module() {
   # Remove stuff that doesn't belong to modules and clean up any empty directories
   rm -rf \
   $MODPATH/system/placeholder $MODPATH/customize.sh \
-  $MODPATH/README.md $MODPATH/.git*
+  $MODPATH/.git*
   rmdir -p $MODPATH 2>/dev/null
 
   cd /


### PR DESCRIPTION
I think the behavior of automatically deleting README.md files is unreasonable.
Because README.md usually contains basic information about the module, usage methods, copyright statements, etc.
If the module developer needs to delete it, they can delete it themselves in the module installation file, instead of deleting it directly by default.
Additionally, due to the existence of multiple languages, there may be files such as README-en.md, but according to the original code logic, these files will not be deleted by default. Therefore, overall, I believe that deleting README.md by default is redundant.
Thanks.