### PR TITLE
Catch possible exceptions when the receiver is already unregistered

### DIFF
--- a/app/shared/src/main/java/com/topjohnwu/magisk/utils/APKInstall.java
+++ b/app/shared/src/main/java/com/topjohnwu/magisk/utils/APKInstall.java
@@ -116,7 +116,10 @@ public final class APKInstall {
                         if (onFailure != null) {
                             onFailure.run();
                         }
-                        context.getApplicationContext().unregisterReceiver(this);
+                        try {
+                            context.getApplicationContext().unregisterReceiver(this);
+                        } catch (IllegalArgumentException ignored) {
+                        }
                     }
                 }
                 latch.countDown();
@@ -126,7 +129,10 @@ public final class APKInstall {
         private void onSuccess(Context context) {
             if (onSuccess != null)
                 onSuccess.run();
-            context.getApplicationContext().unregisterReceiver(this);
+            try {
+                context.getApplicationContext().unregisterReceiver(this);
+            } catch (IllegalArgumentException ignored) {
+            }
         }
 
         @Override


### PR DESCRIPTION
https://appcenter.ms/users/vvb2060/apps/Magisk/crashes/errors/411818780u/overview
```
java.lang.IllegalArgumentException: Receiver not registered: a.q@e4bb01c
android.app.LoadedApk.forgetReceiverDispatcher LoadedApk.java:1687
android.app.ContextImpl.unregisterReceiver ContextImpl.java:1840
android.content.ContextWrapper.unregisterReceiver ContextWrapper.java:812
com.topjohnwu.magisk.utils.APKInstall$InstallReceiver.onSuccess APKInstall.java
com.topjohnwu.magisk.utils.APKInstall$InstallReceiver.onReceive APKInstall.java
android.app.LoadedApk$ReceiverDispatcher$Args.broadcastReceiveReg LoadedApk.java:1878
android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$0$android-app-LoadedApk$ReceiverDispatcher$Args LoadedApk.java:1816
android.app.LoadedApk$ReceiverDispatcher$Args$$ExternalSyntheticLambda1.run LoadedApk.java:10
android.os.Handler.handleCallback Handler.java:942
android.os.Handler.dispatchMessage Handler.java:99
android.os.Looper.loopOnce Looper.java:242
android.os.Looper.loop Looper.java:374
android.app.ActivityThread.main ActivityThread.java:8911
java.lang.reflect.Method.invoke Method.java:-2
com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run RuntimeInit.java:671
com.android.internal.os.ZygoteInit.main ZygoteInit.java:951
```

This seems to be caused by a race condition that two broadcasts can be delivered in a short time, and the second broadcast will be handled while the receiver is already unregistered when handling the first broadcast.
TODO: Shall we also prevent the callbacks being ran twice?