### PR TITLE
Change build.py env ANDROID_SDK_ROOT to ANDROID_HOME

### DIFF
--- a/build.py
+++ b/build.py
@@ -55,8 +55,8 @@ if is_windows:
 if not sys.version_info >= (3, 8):
     error("Requires Python 3.8+")
 
-if "ANDROID_SDK_ROOT" not in os.environ:
-    error("Please set Android SDK path to environment variable ANDROID_SDK_ROOT!")
+if "ANDROID_HOME" not in os.environ:
+    error("Please set Android SDK path to environment variable ANDROID_HOME!")
 
 if shutil.which("sccache") is not None:
     os.environ["RUSTC_WRAPPER"] = "sccache"
@@ -79,7 +79,7 @@ default_targets = ["magisk", "magiskinit", "magiskboot", "magiskpolicy", "busybo
 support_targets = default_targets + ["resetprop"]
 rust_targets = ["magisk", "magiskinit", "magiskboot", "magiskpolicy"]
 
-sdk_path = Path(os.environ["ANDROID_SDK_ROOT"])
+sdk_path = Path(os.environ["ANDROID_HOME"])
 ndk_root = sdk_path / "ndk"
 ndk_path = ndk_root / "magisk"
 ndk_build = ndk_path / "ndk-build"

--- a/docs/build.md
+++ b/docs/build.md
@@ -18,7 +18,7 @@
   - On Windows, download the install the latest Git version on the [official website](https://git-scm.com/download/win).<br>
     Make sure to **"Enable symbolic links"** during installation.
 - Install Android Studio and follow the instructions and go through the initial setup.
-- Set environment variable `ANDROID_SDK_ROOT` to the Android SDK folder. This path can be found in Android Studio settings.
+- Set environment variable `ANDROID_HOME` to the Android SDK folder. This path can be found in Android Studio settings.
 - Setup JDK:
   - The recommended option is to set environment variable `ANDROID_STUDIO` to the path where your Android Studio is installed. The build script will automatically find and use the bundled JDK.
   - You can also setup JDK 17 yourself, but this guide will not cover the instructions.
@@ -49,7 +49,7 @@ Let's first setup `rustup` to use our custom ONDK Rust toolchain by default:
 
 ```bash
 # Link the ONDK toolchain with the name "magisk"
-rustup toolchain link magisk "$ANDROID_SDK_ROOT/ndk/magisk/toolchains/rust"
+rustup toolchain link magisk "$ANDROID_HOME/ndk/magisk/toolchains/rust"
 # Set magisk as default
 rustup default magisk
 ```


### PR DESCRIPTION
ANDROID_SDK_ROOT, which also points to the SDK installation directory, is deprecated. ref: https://developer.android.com/tools/variables#envar