### PR TITLE
Use icf to further minimize binary size

### DIFF
--- a/native/src/Application.mk
+++ b/native/src/Application.mk
@@ -1,8 +1,8 @@
 APP_BUILD_SCRIPT := src/Android.mk
 APP_ABI          := armeabi-v7a arm64-v8a x86 x86_64
 APP_CFLAGS       := -Wall -Oz -fomit-frame-pointer -flto
-APP_LDFLAGS      := -flto
-APP_CPPFLAGS     := -std=c++20
+APP_LDFLAGS      := -flto -Wl,--icf=all
+APP_CPPFLAGS     := -std=c++23
 APP_STL          := none
 APP_PLATFORM     := android-23
 APP_THIN_ARCHIVE := true


### PR DESCRIPTION
Before v.s. After:

<img width="593" alt="image" src="https://github.com/topjohnwu/Magisk/assets/5022927/4998b654-0365-4ac0-9540-e8624e4daade">
