### PR TITLE
Optimize unzip for module installation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,4 +118,5 @@ dependencies {
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("androidx.profileinstaller:profileinstaller:1.3.1")
     implementation("com.google.android.material:material:1.12.0")
+    implementation("org.apache.commons:commons-compress:1.26.2")
 }

--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/ZipUtils.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/ZipUtils.kt
@@ -1,41 +1,30 @@
 package com.topjohnwu.magisk.core.utils
 
 import com.topjohnwu.magisk.core.ktx.copyAll
+import org.apache.commons.compress.archivers.zip.ZipFile
 import java.io.File
 import java.io.IOException
-import java.io.InputStream
-import java.util.zip.ZipEntry
-import java.util.zip.ZipInputStream
 
 @Throws(IOException::class)
 suspend fun File.unzip(folder: File, path: String = "", junkPath: Boolean = false) {
-    inputStream().buffered().use {
-        it.unzip(folder, path, junkPath)
-    }
-}
-
-@Throws(IOException::class)
-suspend fun InputStream.unzip(folder: File, path: String, junkPath: Boolean) {
     try {
-        val zin = ZipInputStream(this)
-        var entry: ZipEntry
-        while (true) {
-            entry = zin.nextEntry ?: break
-            if (!entry.name.startsWith(path) || entry.isDirectory) {
-                // Ignore directories, only create files
-                continue
+        ZipFile.Builder().setFile(this).get().use { zip ->
+            for (entry in zip.entries) {
+                if (!entry.name.startsWith(path) || entry.isDirectory) {
+                    // Ignore directories, only create files
+                    continue
+                }
+                val name = if (junkPath)
+                    entry.name.substring(entry.name.lastIndexOf('/') + 1)
+                else
+                    entry.name
+                val dest = File(folder, name)
+                dest.parentFile!!.let {
+                    if (!it.exists())
+                        it.mkdirs()
+                }
+                dest.outputStream().use { out -> zip.getInputStream(entry).copyAll(out) }
             }
-            val name = if (junkPath)
-                entry.name.substring(entry.name.lastIndexOf('/') + 1)
-            else
-                entry.name
-
-            val dest = File(folder, name)
-            dest.parentFile!!.let {
-                if (!it.exists())
-                    it.mkdirs()
-            }
-            dest.outputStream().use { out -> zin.copyAll(out) }
         }
     } catch (e: IllegalArgumentException) {
         throw IOException(e)


### PR DESCRIPTION
Previous ZipInputStream will decompress all entries even we don't use, and java.utils.ZipFile is too complex.
Use org.apache.commons.compress for better compatability.