### PR TITLE
Unset FLAG_ACTIVITY_NO_HISTORY for SuRequestActivity

### DIFF
--- a/native/src/core/su/connect.cpp
+++ b/native/src/core/su/connect.cpp
@@ -16,11 +16,10 @@ using namespace std;
 #define START_ACTIVITY \
 "/system/bin/app_process", "/system/bin", "com.android.commands.am.Am", \
 "start", "-p", target, "--user", user, "-a", "android.intent.action.VIEW", \
-"-f", "0x58800020", "--es", "action", action
+"-f", "0x18800020", "--es", "action", action
 
-// 0x58800020 = FLAG_ACTIVITY_NEW_TASK|FLAG_ACTIVITY_MULTIPLE_TASK|
-//              FLAG_ACTIVITY_NO_HISTORY|FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS|
-//              FLAG_INCLUDE_STOPPED_PACKAGES
+// 0x18800020 = FLAG_ACTIVITY_NEW_TASK|FLAG_ACTIVITY_MULTIPLE_TASK|
+//              FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS|FLAG_INCLUDE_STOPPED_PACKAGES
 
 #define get_cmd(to) \
 ((to).command.empty() ? \


### PR DESCRIPTION
This fixes device credential confirm activity on OnePlus devices because SuRequestActivity is accidentally finished before a valid response is delivered to it.
close #7577