### PR TITLE
Disable stack protector for busybox

### DIFF
--- a/native/src/Application.mk
+++ b/native/src/Application.mk
@@ -21,6 +21,7 @@ endif
 # Busybox should use a newer libc.a
 ifdef B_BB
 APP_PLATFORM     := android-26
+APP_CFLAGS       += -fno-stack-protector
 ifeq ($(OS),Windows_NT)
 APP_SHORT_COMMANDS := true
 endif


### PR DESCRIPTION
![image](https://github.com/topjohnwu/Magisk/assets/5022927/545db975-480d-45cb-9882-475fcb989264)
![image](https://github.com/topjohnwu/Magisk/assets/5022927/0756cb01-5073-4f3a-8cd7-52b76a46eb02)

`busybox'__stack_chk_guard, address = 0x00177a60`