### PR TITLE
Set default visibility of restart button to GONE

### DIFF
--- a/app/src/main/res/layout/fragment_flash_md2.xml
+++ b/app/src/main/res/layout/fragment_flash_md2.xml
@@ -39,7 +39,7 @@
 
         <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
             android:id="@+id/restart_btn"
-            gone="@{viewModel.flashing || !viewModel.showReboot}"
+            android:visibility="gone"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"


### PR DESCRIPTION
This fixes the issue that button still shows when installation fails.