### PR TITLE
Fix StackOverflowError

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/utils/AXML.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/utils/AXML.kt
@@ -85,7 +85,7 @@ class AXML(b: ByteArray) {
         baos.align()
 
         val sizeDiff = baos.size() - start - size
-        val newBuffer = ByteBuffer.wrap(baos.buf).order(LITTLE_ENDIAN)
+        val newBuffer = ByteBuffer.wrap(baos.buffer).order(LITTLE_ENDIAN)
 
         // Patch XML size
         newBuffer.putInt(CHUNK_SIZE_OFF, buffer.getInt(CHUNK_SIZE_OFF) + sizeDiff)
@@ -111,7 +111,7 @@ class AXML(b: ByteArray) {
     }
 
     private class RawByteStream : ByteArrayOutputStream() {
-        val buf: ByteArray get() = buf
+        val buffer: ByteArray get() = buf
 
         fun align(alignment: Int = 4) {
             val newCount = (count + alignment - 1) / alignment * alignment


### PR DESCRIPTION
Now field from base class java.io.ByteArrayOutputStream shadows the property with custom getter from derived class com.topjohnwu.magisk.core.utils.AXML.RawByteStream. This behavior will be changed soon in favor of the property. Please use explicit cast to java.io.ByteArrayOutputStream if you wish to preserve current behavior. See https://youtrack.jetbrains.com/issue/KT-55017 for details