### PR TITLE
Tighten rules for tmpfs file

### DIFF
--- a/native/src/sepolicy/rules.rs
+++ b/native/src/sepolicy/rules.rs
@@ -100,8 +100,9 @@ impl SepolicyMagisk for sepolicy {
                 "system_app", "priv_app", "untrusted_app", "untrusted_app_all"],
                 [proc], ["unix_stream_socket"], ["connectto", "getopt"]);
 
-            // Let everyone access tmpfs files (for SAR sbin overlay)
-            allow(["domain"], ["tmpfs"], ["file"], all);
+            // Let selected domains access tmpfs files
+            // For tmpfs overlay on 2SI, Zygisk on lower Android versions and AVD scripts
+            allow(["init", "zygote", "shell"], ["tmpfs"], ["file"], all);
 
             // Allow magiskinit daemon to handle mock selinuxfs
             allow(["kernel"], ["tmpfs"], ["fifo_file"], ["write"]);


### PR DESCRIPTION
Before magiskd is executed, all files in magisk tmpfs still shares tmpfs label. This commit tightens the rule to only allow init, zygote and shell to access magisk tmpfs files. Zygotes rules is needed because lower Android versions don't have rule for zygote itself using memfd even memfd is supported in kernel.