### PR TITLE
Upgrade to JDK 21

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
       uses: actions/setup-java@v4
       with:
         distribution: "temurin"
-        java-version: "17"
+        java-version: "21"
 
     - name: Set up Python 3
       uses: actions/setup-python@v5

--- a/buildSrc/src/main/java/Setup.kt
+++ b/buildSrc/src/main/java/Setup.kt
@@ -80,8 +80,8 @@ fun Project.setupCommon() {
         }
 
         compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_17
-            targetCompatibility = JavaVersion.VERSION_17
+            sourceCompatibility = JavaVersion.VERSION_21
+            targetCompatibility = JavaVersion.VERSION_21
         }
 
         packagingOptions {
@@ -101,7 +101,7 @@ fun Project.setupCommon() {
 
         kotlin {
             compilerOptions {
-                jvmTarget = JvmTarget.JVM_17
+                jvmTarget = JvmTarget.JVM_21
             }
         }
     }


### PR DESCRIPTION
Otherwise

```
> Task :app:core:kspDebugKotlin FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:core:kspDebugKotlin'.
> Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (17) and 'kspDebugKotlin' (21).
```