### PR TITLE
Fix incomplete native debug symbols

### DIFF
--- a/native/src/Android.mk
+++ b/native/src/Android.mk
@@ -52,7 +52,7 @@ ifdef B_PRELOAD
 include $(CLEAR_VARS)
 LOCAL_MODULE := init-ld
 LOCAL_SRC_FILES := init/preload.c
-LOCAL_STRIP_MODE := --strip-all
+LOCAL_LDFLAGS := -Wl,--strip-all
 include $(BUILD_SHARED_LIBRARY)
 
 endif


### PR DESCRIPTION
See https://github.com/android/ndk/issues/2039

Before v.s. After

![](https://github.com/topjohnwu/Magisk/assets/5022927/c6d65cdc-497d-4657-a225-937d0ee4b428)
