### PR TITLE
Remove NVBASE

### DIFF
--- a/scripts/app_functions.sh
+++ b/scripts/app_functions.sh
@@ -43,7 +43,7 @@ fix_env() {
   # Cleanup and make dirs
   rm -rf $MAGISKBIN/*
   mkdir -p $MAGISKBIN 2>/dev/null
-  chmod 700 $NVBASE
+  chmod 700 /data/adb
   cp_readlink $1 $MAGISKBIN
   rm -rf $1
   chown -R 0:0 $MAGISKBIN
@@ -97,7 +97,7 @@ restore_imgs() {
 }
 
 post_ota() {
-  cd $NVBASE
+  cd /data/adb
   cp -f $1 bootctl
   rm -f $1
   chmod 755 bootctl
@@ -116,8 +116,8 @@ EOF
 
 add_hosts_module() {
   # Do not touch existing hosts module
-  [ -d $NVBASE/modules/hosts ] && return
-  cd $NVBASE/modules
+  [ -d /data/adb/modules/hosts ] && return
+  cd /data/adb/modules
   mkdir -p hosts/system/etc
   cat << EOF > hosts/module.prop
 id=hosts

--- a/scripts/avd_magisk.sh
+++ b/scripts/avd_magisk.sh
@@ -123,9 +123,9 @@ fi
 # Magisk stuff
 mkdir -p $MAGISKBIN 2>/dev/null
 unzip -oj magisk.apk 'assets/*.sh' -d $MAGISKBIN
-mkdir $NVBASE/modules 2>/dev/null
-mkdir $NVBASE/post-fs-data.d 2>/dev/null
-mkdir $NVBASE/service.d 2>/dev/null
+mkdir /data/adb/modules 2>/dev/null
+mkdir /data/adb/post-fs-data.d 2>/dev/null
+mkdir /data/adb/service.d 2>/dev/null
 
 for file in magisk magisk32 magiskpolicy stub.apk; do
   chmod 755 ./$file


### PR DESCRIPTION
We only move /cache/data_adb/magisk and /data/magisk to /data/adb/magisk (#7638), so NVBASE is redundant and we can just use MAGISKBIN.