### PR TITLE
Make Zygote injection optional for Zygisk modules

### DIFF
--- a/app/apk/src/main/java/com/topjohnwu/magisk/ui/module/ModuleRvItem.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/ui/module/ModuleRvItem.kt
@@ -31,10 +31,11 @@ class LocalModuleRvItem(
         val isZygisk = item.isZygisk
         val isRiru = item.isRiru
         val zygiskUnloaded = isZygisk && item.zygiskUnloaded
+        val isZygiskOptional = item.isZygiskOptional
 
         showNotice = zygiskUnloaded ||
             (Info.isZygiskEnabled && isRiru) ||
-            (!Info.isZygiskEnabled && isZygisk)
+            (!Info.isZygiskEnabled && isZygisk && !isZygiskOptional)
         noticeText =
             when {
                 zygiskUnloaded -> CoreR.string.zygisk_module_unloaded.asText()

--- a/app/core/src/main/java/com/topjohnwu/magisk/core/model/module/LocalModule.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/model/module/LocalModule.kt
@@ -32,11 +32,13 @@ data class LocalModule(
     private val riruFolder = RootUtils.fs.getFile(path, "riru")
     private val zygiskFolder = RootUtils.fs.getFile(path, "zygisk")
     private val unloaded = RootUtils.fs.getFile(zygiskFolder, "unloaded")
+    private val zygiskOptional = RootUtils.fs.getFile(zygiskFolder, "optional")
 
     val updated: Boolean get() = updateFile.exists()
     val isRiru: Boolean get() = (id == "riru-core") || riruFolder.exists()
     val isZygisk: Boolean get() = zygiskFolder.exists()
     val zygiskUnloaded: Boolean get() = unloaded.exists()
+    val isZygiskOptional: Boolean get() = zygiskOptional.exists()
 
     var enable: Boolean
         get() = !disableFile.exists()

--- a/native/src/core/module.cpp
+++ b/native/src/core/module.cpp
@@ -428,7 +428,8 @@ static void collect_modules(bool open_zygisk) {
             }
         } else {
             // Ignore zygisk modules when zygisk is not enabled
-            if (faccessat(modfd, "zygisk", F_OK, 0) == 0) {
+            if (faccessat(modfd, "zygisk", F_OK, 0) == 0 &&
+                    faccessat(modfd, "zygisk/optional", F_OK, 0) != 0) {
                 LOGI("%s: ignore\n", entry->d_name);
                 return;
             }


### PR DESCRIPTION
This is useful when a module has Zygisk features, but also has other features which can work without Zygisk, such as TrickyStore.