### PR TITLE
Check vendor boot ramdisk table size

### DIFF
--- a/native/src/boot/bootimg.cpp
+++ b/native/src/boot/bootimg.cpp
@@ -462,7 +462,7 @@ bool boot_img::parse_image(const uint8_t *p, format_t type) {
         fprintf(stderr, "%-*s [%s]\n", PADDING, "KERNEL_FMT", fmt2name[k_fmt]);
     }
     if (auto size = hdr->ramdisk_size()) {
-        if (vendor_ramdisk_table != nullptr) {
+        if (hdr->vendor_ramdisk_table_size()) {
             // v4 vendor boot contains multiple ramdisks
             using table_entry = const vendor_ramdisk_table_entry_v4;
             if (hdr->vendor_ramdisk_table_entry_size() != sizeof(table_entry)) {
@@ -581,7 +581,7 @@ int unpack(const char *image, bool skip_decomp, bool hdr) {
     dump(boot.kernel_dtb.buf(), boot.kernel_dtb.sz(), KER_DTB_FILE);
 
     // Dump ramdisk
-    if (boot.vendor_ramdisk_table != nullptr) {
+    if (boot.hdr->vendor_ramdisk_table_size()) {
         using table_entry = const vendor_ramdisk_table_entry_v4;
         span<table_entry> table(
                 reinterpret_cast<table_entry *>(boot.vendor_ramdisk_table),
@@ -754,7 +754,7 @@ void repack(const char *src_img, const char *out_img, bool skip_comp) {
     using table_entry = vendor_ramdisk_table_entry_v4;
     vector<table_entry> ramdisk_table;
 
-    if (boot.vendor_ramdisk_table) {
+    if (boot.hdr->vendor_ramdisk_table_size()) {
         // Create a copy so we can modify it
         auto entry_start = reinterpret_cast<const table_entry *>(boot.vendor_ramdisk_table);
         ramdisk_table.insert(


### PR DESCRIPTION
Commit 5ac7dc0b37fd715309560c7c03529fb59ee58785 breaks patching any non-vendor boot images:
```
+ ./build.py avd_patch -s /home/runner/aosp_cf_phone/init_boot.img magisk_patched.img
Parsing boot image: [/data/local/tmp/init_boot.img]
HEADER_VER      [4]
KERNEL_SZ       [0]
RAMDISK_SZ      [2845054]
OS_VERSION      [14.0.0]
OS_PATCH_LEVEL  [2024-04]
PAGESIZE        [4096]
CMDLINE         []
! Invalid vendor image: vendor_ramdisk_table_entry_size != 108
cp: can't stat 'ramdisk.cpio': No such file or directory
resetprop: get prop [ro.crypto.state]: [encrypted]
resetprop: get prop [ro.crypto.type]: [file]
resetprop: get prop [ro.crypto.metadata.enabled]: [true]
Add file [init] (100750)
Create directory [overlay.d] (0750)
Create directory [overlay.d/sbin] (0750)
Add file [overlay.d/sbin/magisk.xz] (100644)
Add file [overlay.d/sbin/stub.xz] (100644)
Add file [overlay.d/sbin/init-ld.xz] (100644)
Patch with flag KEEPVERITY=[true] KEEPFORCEENCRYPT=[true]
Loading cpio: [ramdisk.cpio.orig]
[boot/cpio.rs:273] No such file or directory (os error 2)
[boot/cpio.rs:828] Failed to process cpio
Parsing boot image: [/data/local/tmp/init_boot.img]
HEADER_VER      [4]
KERNEL_SZ       [0]
RAMDISK_SZ      [2845054]
OS_VERSION      [14.0.0]
OS_PATCH_LEVEL  [2024-04]
PAGESIZE        [4096]
CMDLINE         []
! Invalid vendor image: vendor_ramdisk_table_entry_size != 108
```