### PR TITLE
Require Magisk v25.2 for modules

### DIFF
--- a/scripts/module_installer.sh
+++ b/scripts/module_installer.sh
@@ -11,7 +11,7 @@ ui_print() { echo "$1"; }
 
 require_new_magisk() {
   ui_print "*******************************"
-  ui_print " Please install Magisk v20.4+! "
+  ui_print " Please install Magisk v25.2+! "
   ui_print "*******************************"
   exit 1
 }
@@ -27,7 +27,7 @@ mount /data 2>/dev/null
 
 [ -f /data/adb/magisk/util_functions.sh ] || require_new_magisk
 . /data/adb/magisk/util_functions.sh
-[ $MAGISK_VER_CODE -lt 20400 ] && require_new_magisk
+[ $MAGISK_VER_CODE -lt 25200 ] && require_new_magisk
 
 install_module
 exit 0


### PR DESCRIPTION
It has been long enough, no one uses Android versions below 5.0 nowadays, and is a security concern that people might still use Magisk 20.4 nowadays.