### PR TITLE
Use `androidboot.partition_map` as a fallback for matching partition names in the preinit finding.

### DIFF
--- a/native/src/init/getinfo.cpp
+++ b/native/src/init/getinfo.cpp
@@ -229,14 +229,6 @@ kv_pairs load_partition_map() {
     return {};
 }
 
-std::string get_partition_name_for_device(const kv_pairs &partition_map, const std::string &query_device){
-    for (const auto &[device, partition] : partition_map) {
-        if (query_device == device)
-            return partition;
-    }
-    return {};
-}
-
 bool check_two_stage() {
     if (access("/apex", F_OK) == 0)
         return true;

--- a/native/src/init/init.hpp
+++ b/native/src/init/init.hpp
@@ -30,7 +30,6 @@ int magisk_proxy_main(int argc, char *argv[]);
 bool unxz(out_stream &strm, rust::Slice<const uint8_t> bytes);
 void load_kernel_info(BootConfig *config);
 kv_pairs load_partition_map();
-std::string get_partition_name_for_device(const kv_pairs &partition_map, const std::string &query_device);
 bool check_two_stage();
 const char *backup_init();
 void restore_ramdisk_init();

--- a/native/src/init/init.hpp
+++ b/native/src/init/init.hpp
@@ -29,6 +29,8 @@ extern std::vector<std::string> mount_list;
 int magisk_proxy_main(int argc, char *argv[]);
 bool unxz(out_stream &strm, rust::Slice<const uint8_t> bytes);
 void load_kernel_info(BootConfig *config);
+kv_pairs load_partition_map();
+std::string get_partition_name_for_device(const kv_pairs &partition_map, const std::string &query_device);
 bool check_two_stage();
 const char *backup_init();
 void restore_ramdisk_init();

--- a/native/src/init/mount.cpp
+++ b/native/src/init/mount.cpp
@@ -78,7 +78,7 @@ static struct {
 } blk_info;
 
 static dev_t setup_block() {
-    const auto partition_map = load_partition_map();
+    static const auto partition_map = load_partition_map();
     if (dev_list.empty())
         collect_devices(partition_map);
 


### PR DESCRIPTION
Fixes **Play Games Developer Emulator** `magiskinit: Cannot find preinit metadata, abort!`.

only tested on the **Play Games Developer Emulator**, need to do some test on the production one, which runs on older version of Android iirc.