### PR TITLE
Don't append "start logd" in post-fs-data

### DIFF
--- a/native/src/init/rootdir.rs
+++ b/native/src/init/rootdir.rs
@@ -14,7 +14,6 @@ pub fn inject_magisk_rc(fd: RawFd, tmp_dir: &Utf8CStr) {
         file,
         r#"
 on post-fs-data
-    start logd
     exec {0} 0 0 -- {1}/magisk --post-fs-data
 
 on property:vold.decrypt=trigger_restart_framework


### PR DESCRIPTION
This was first done in b13eb3f because magiskd was started in post-fs stage that time. Among all android versions, logd was all started before post-fs-data.