### PR TITLE
Upgrade Gradle

### DIFF
--- a/app/apk/build.gradle.kts
+++ b/app/apk/build.gradle.kts
@@ -13,7 +13,7 @@ kapt {
     useBuildCache = true
     mapDiagnosticLocations = true
     javacOptions {
-        option("-Xmaxerrs", 1000)
+        option("-Xmaxerrs", "1000")
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
```
Magisk/app/apk/build.gradle.kts:16:9: 'option(Any, Any): Unit' is deprecated. This function with Any parameters is scheduled for removal in Kotlin 2.2. Consider migrating to the function with String parameters.
```