### PR TITLE
scripts: flash_script.sh: Check the MAGISKBIN variable before constructing the environment

### DIFF
--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -66,6 +66,8 @@ $BOOTMODE || remove_system_su
 
 ui_print "- Constructing environment"
 
+[ -z $MAGISKBIN ] && abort "! The MAGISKBIN variable is not configured correctly"
+
 # Copy required files
 rm -rf $MAGISKBIN/* 2>/dev/null
 mkdir -p $MAGISKBIN 2>/dev/null


### PR DESCRIPTION
If the MAGISKBIN variable is not configured, or is configured with an empty string, the installation script will become a script that formats the device. No one wants to accept such an outcome.

Even though our previous code was very rigorous, such an important check would not be redundant.