### PR TITLE
scripts: flash_script.sh: Avoid overly dangerous code

### DIFF
--- a/scripts/flash_script.sh
+++ b/scripts/flash_script.sh
@@ -67,7 +67,7 @@ $BOOTMODE || remove_system_su
 ui_print "- Constructing environment"
 
 # Copy required files
-rm -rf $MAGISKBIN/* 2>/dev/null
+rm -rf $MAGISKBIN 2>/dev/null
 mkdir -p $MAGISKBIN 2>/dev/null
 cp -af $BINDIR/. $COMMONDIR/. $BBBIN $MAGISKBIN
 


### PR DESCRIPTION
If the `MAGISKBIN` variable is not configured, or is configured with an empty string, the installation script will become a script that formats the device. No one wants to accept such an outcome.