### PR TITLE
daemon: some samsung devices using incorrect mediatek-res path

### DIFF
--- a/native/src/core/daemon.cpp
+++ b/native/src/core/daemon.cpp
@@ -372,6 +372,11 @@ static void daemon_entry() {
         }
     }
     LOGI("* Device API level: %d\n", SDK_INT);
+    
+    // Samsung workaround  #7887
+    if (access("/system_ext/app/mediatek-res/mediatek-res.apk", F_OK) == 0) {
+        set_prop("ro.vendor.mtk_model", "0");
+    }
 
     restore_tmpcon();
 


### PR DESCRIPTION
```java
    private static final String MEDIATEK_APK_PATH = "/system/app/mediatek-res/mediatek-res.apk";
    private static final String PROPERTY_MTK_MODEL = "ro.vendor.mtk_model";

    public static void createSystemAssetsInZygoteLocked(boolean reinitialize, String frameworkPath) {
        if (sSystem != null && !reinitialize) {
            return;
        }
        try {
            ArrayList<ApkAssets> apkAssets = new ArrayList<>();
            apkAssets.add(ApkAssets.loadFromPath(frameworkPath, 1));
            String[] systemIdmapPaths = OverlayConfig.getZygoteInstance().createImmutableFrameworkIdmapsInZygote();
            for (String idmapPath : systemIdmapPaths) {
                apkAssets.add(ApkAssets.loadOverlayFromPath(idmapPath, 1));
            }
            if ("1".equals(SystemProperties.get(PROPERTY_MTK_MODEL))) {
                apkAssets.add(ApkAssets.loadFromPath(MEDIATEK_APK_PATH, 1));
            }
            sSystemApkAssetsSet = new ArraySet<>(apkAssets);
            sSystemApkAssets = (ApkAssets[]) apkAssets.toArray(new ApkAssets[apkAssets.size()]);
            if (sSystem == null) {
                sSystem = new AssetManager(true);
            }
            sSystem.setApkAssets(sSystemApkAssets, false);
        } catch (IOException e) {
            throw new IllegalStateException("Failed to create system AssetManager", e);
        }
    }

```