### PR TITLE
App: Add the ability to hide the manager app with a non-random package name

### DIFF
--- a/app/apk/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsViewModel.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/ui/settings/SettingsViewModel.kt
@@ -105,7 +105,7 @@ class SettingsViewModel : BaseViewModel(), BaseSettingsItem.Handler {
             SystemlessHosts -> createHosts()
             DenyListConfig -> SettingsFragmentDirections.actionSettingsFragmentToDenyFragment().navigate()
             UpdateChannel -> openUrlIfNecessary(view)
-            is Hide -> viewModelScope.launch { AppMigration.hide(view.activity, item.value) }
+            is Hide -> viewModelScope.launch { AppMigration.hide(view.activity, label = item.value.label, pkg = item.value.pkg) }
             Restore -> viewModelScope.launch { AppMigration.restore(view.activity) }
             Zygisk -> if (Zygisk.mismatch) SnackbarEvent(R.string.reboot_apply_change).publish()
             else -> Unit

--- a/app/apk/src/main/res/layout/dialog_settings_app_name.xml
+++ b/app/apk/src/main/res/layout/dialog_settings_app_name.xml
@@ -22,25 +22,57 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_generic"
-            android:hint="@string/settings_app_name_hint"
+            android:hint="@string/settings_app_name_label_hint"
             app:boxStrokeColor="?colorOnSurfaceVariant"
             app:counterEnabled="true"
-            app:counterMaxLength="@{data.maxLength}"
+            app:counterMaxLength="@{data.maxLabelLength}"
             app:counterOverflowTextColor="?colorError"
-            app:error="@{data.error ? @string/settings_app_name_error : @string/empty}"
+            app:error="@{data.labelError ? @string/settings_app_name_error : @string/empty}"
             app:errorEnabled="true"
             app:errorTextColor="?colorError"
-            app:helperText="@string/settings_app_name_helper"
+            app:helperText="@string/settings_app_name_label_helper"
             app:hintEnabled="true"
             app:hintTextAppearance="@style/AppearanceFoundation.Tiny"
             app:hintTextColor="?colorOnSurfaceVariant">
 
             <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/dialog_custom_download_text"
+                android:id="@+id/dialog_app_name_label_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="textCapWords"
-                android:text="@={data.result}"
+                android:text="@={data.label}"
+                android:textAppearance="@style/AppearanceFoundation.Body"
+                android:textColor="?colorOnSurface"
+                tools:text="@tools:sample/lorem" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- TODO Fix the label/hint to say what the field is, not just (random) -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/dialog_app_name_pkg_textinputlayout"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_generic"
+            android:hint="@{data.pkgFocused ? @string/settings_app_name_pkg_hint_focused : @string/settings_app_name_pkg_hint}"
+            app:boxStrokeColor="?colorOnSurfaceVariant"
+            app:counterEnabled="true"
+            app:counterMaxLength="@{data.maxPkgLength}"
+            app:counterOverflowTextColor="?colorError"
+            app:error="@{data.pkgError ? @string/settings_app_name_error : @string/empty}"
+            app:errorEnabled="true"
+            app:errorTextColor="?colorError"
+            app:helperText="@string/settings_app_name_pkg_helper"
+            app:hintEnabled="true"
+            app:hintTextAppearance="@style/AppearanceFoundation.Tiny"
+            app:hintTextColor="?colorOnSurfaceVariant">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/dialog_app_name_pkg_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textUri"
+                android:text="@={data.pkg}"
                 android:textAppearance="@style/AppearanceFoundation.Body"
                 android:textColor="?colorOnSurface"
                 tools:text="@tools:sample/lorem" />

--- a/app/apk/src/main/res/layout/dialog_settings_app_name.xml
+++ b/app/apk/src/main/res/layout/dialog_settings_app_name.xml
@@ -47,7 +47,6 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
-        <!-- TODO Fix the label/hint to say what the field is, not just (random) -->
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/dialog_app_name_pkg_textinputlayout"
             style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"

--- a/app/core/src/main/java/com/topjohnwu/magisk/core/tasks/AppMigration.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/tasks/AppMigration.kt
@@ -221,8 +221,8 @@ object AppMigration {
             val isPkgIdInUse = pkgCheckResult.out.contains("package:$pkg")
             if(isPkgIdInUse) {
                 android.app.AlertDialog.Builder(activity)
-                    .setTitle("Package ID Collision")
-                    .setMessage("Package with ID $pkg already exists on system. Please choose another.")
+                    .setTitle(R.string.hide_app_package_collision_dialog_title)
+                    .setMessage(activity.getString(R.string.hide_app_package_collision_dialog_message, pkg))
                     .setPositiveButton(R.string.close) { dialog, _ ->
                         dialog.dismiss()
                     }
@@ -232,8 +232,8 @@ object AppMigration {
         } else {
             Timber.e("Error running $listPkgsCmd. err=${pkgCheckResult.err}")
             android.app.AlertDialog.Builder(activity)
-                .setTitle("Package ID Check Failed")
-                .setMessage("An error occurred when looking for packages with id $pkg. Please try again.")
+                .setTitle(R.string.hide_app_package_error_dialog_title)
+                .setMessage(activity.getString(R.string.hide_app_package_error_dialog_message, pkg))
                 .setPositiveButton(R.string.close) { dialog, _ ->
                     dialog.dismiss()
                 }

--- a/app/core/src/main/res/values-ar/strings.xml
+++ b/app/core/src/main/res/values-ar/strings.xml
@@ -123,7 +123,7 @@
     <string name="settings_hosts_title">موانع الاعلانات</string>
     <string name="settings_hosts_summary">حجب الاعلانات دون تعديل النظام</string>
     <string name="settings_hosts_toast">تم تمكين خاصية حجب الاعلانات</string>
-    <string name="settings_app_name_hint">الإسم الجديد</string>
+    <string name="settings_app_name_label_hint">الإسم الجديد</string>
     <string name="settings_app_name_helper">التطبيق الجديد سوف يملك هذا الإسم</string>
     <string name="settings_app_name_error">الصيغة غير مقبولة</string>
     <string name="settings_su_app_adb">التطبيقات و ADB</string>

--- a/app/core/src/main/res/values-ar/strings.xml
+++ b/app/core/src/main/res/values-ar/strings.xml
@@ -124,7 +124,7 @@
     <string name="settings_hosts_summary">حجب الاعلانات دون تعديل النظام</string>
     <string name="settings_hosts_toast">تم تمكين خاصية حجب الاعلانات</string>
     <string name="settings_app_name_label_hint">الإسم الجديد</string>
-    <string name="settings_app_name_helper">التطبيق الجديد سوف يملك هذا الإسم</string>
+    <string name="settings_app_name_label_helper">التطبيق الجديد سوف يملك هذا الإسم</string>
     <string name="settings_app_name_error">الصيغة غير مقبولة</string>
     <string name="settings_su_app_adb">التطبيقات و ADB</string>
     <string name="settings_su_app">التطبيقات فقط</string>

--- a/app/core/src/main/res/values-ast/strings.xml
+++ b/app/core/src/main/res/values-ast/strings.xml
@@ -132,7 +132,7 @@
     <string name="settings_hosts_summary">Un módulu pa les aplicaciones que bloquien anuncios</string>
     <string name="settings_hosts_toast">Amestóse\'l módulu «Systemless Hosts»</string>
     <string name="settings_app_name_label_hint">Nome nuevu</string>
-    <string name="settings_app_name_helper">L\'aplicación va volver empaquetase con esti nome</string>
+    <string name="settings_app_name_label_helper">L\'aplicación va volver empaquetase con esti nome</string>
     <string name="settings_app_name_error">El formatu nun ye válidu</string>
     <string name="settings_su_app_adb">Aplicaciones y ADB</string>
     <string name="settings_su_app">Namás aplicaciones</string>

--- a/app/core/src/main/res/values-ast/strings.xml
+++ b/app/core/src/main/res/values-ast/strings.xml
@@ -131,7 +131,7 @@
     <string name="settings_hosts_title">Módulu «Systemless Hosts»</string>
     <string name="settings_hosts_summary">Un módulu pa les aplicaciones que bloquien anuncios</string>
     <string name="settings_hosts_toast">Amestóse\'l módulu «Systemless Hosts»</string>
-    <string name="settings_app_name_hint">Nome nuevu</string>
+    <string name="settings_app_name_label_hint">Nome nuevu</string>
     <string name="settings_app_name_helper">L\'aplicación va volver empaquetase con esti nome</string>
     <string name="settings_app_name_error">El formatu nun ye válidu</string>
     <string name="settings_su_app_adb">Aplicaciones y ADB</string>

--- a/app/core/src/main/res/values-ast/strings.xml
+++ b/app/core/src/main/res/values-ast/strings.xml
@@ -112,7 +112,6 @@
     <string name="settings_download_path_title">Camín de les descargues</string>
     <string name="settings_download_path_message">Los ficheros van guardase en «%1$s»</string>
     <string name="settings_hide_app_title">Anubrir Magisk</string>
-    <string name="settings_hide_app_summary">Instala una aplicación intermedia con una ID y una etiqueta al debalu</string>
     <string name="settings_restore_app_title">Restaurar el mou visible</string>
     <string name="settings_restore_app_summary">Fai que l\'aplicación orixinal vuelva ser visible</string>
     <string name="language">Llingua</string>

--- a/app/core/src/main/res/values-az/strings.xml
+++ b/app/core/src/main/res/values-az/strings.xml
@@ -126,7 +126,6 @@
     <string name="settings_download_path_title">Endirmə yolu</string>
     <string name="settings_download_path_message">Fayllar %1$s\'a yerləşdiriləcək</string>
     <string name="settings_hide_app_title">Magisk tətbiqini gizlət</string>
-    <string name="settings_hide_app_summary">Təsadüfi paket ID\'si ilə proxy yüklə və özəl tətbiq adı yaz</string>
     <string name="settings_restore_app_title">Magisk tətbiqini bərpa et</string>
     <string name="settings_restore_app_summary">Tətbiqi üzə çıxar və orijinal APKnı bərpa et</string>
     <string name="language">Dil</string>

--- a/app/core/src/main/res/values-az/strings.xml
+++ b/app/core/src/main/res/values-az/strings.xml
@@ -145,7 +145,7 @@
     <string name="settings_hosts_title">Sistemsiz hostlar</string>
     <string name="settings_hosts_summary">Reklam əngəlləyici tətbiqlər üçün host faylları</string>
     <string name="settings_hosts_toast">Sistemsiz hostların əlavəsi quruldu</string>
-    <string name="settings_app_name_hint">Yeni Ad</string>
+    <string name="settings_app_name_label_hint">Yeni Ad</string>
     <string name="settings_app_name_helper">Tətbiq bu adla yenidən paketlənəcək</string>
     <string name="settings_app_name_error">Keçərsiz Format</string>
     <string name="settings_su_app_adb">Tətbiqlər və ADB</string>

--- a/app/core/src/main/res/values-az/strings.xml
+++ b/app/core/src/main/res/values-az/strings.xml
@@ -146,7 +146,7 @@
     <string name="settings_hosts_summary">Reklam əngəlləyici tətbiqlər üçün host faylları</string>
     <string name="settings_hosts_toast">Sistemsiz hostların əlavəsi quruldu</string>
     <string name="settings_app_name_label_hint">Yeni Ad</string>
-    <string name="settings_app_name_helper">Tətbiq bu adla yenidən paketlənəcək</string>
+    <string name="settings_app_name_label_helper">Tətbiq bu adla yenidən paketlənəcək</string>
     <string name="settings_app_name_error">Keçərsiz Format</string>
     <string name="settings_su_app_adb">Tətbiqlər və ADB</string>
     <string name="settings_su_app">Yalmız Tətbiqlər</string>

--- a/app/core/src/main/res/values-be/strings.xml
+++ b/app/core/src/main/res/values-be/strings.xml
@@ -120,7 +120,7 @@
     <string name="settings_hosts_title">Пазасістэмны файл hosts</string>
     <string name="settings_hosts_summary">Падтрымка пазасістэмнага файла hosts для праграм, якія блакуюць рэкламу</string>
     <string name="settings_hosts_toast">Дададзены модуль пазасістэмнага файла hosts</string>
-    <string name="settings_app_name_hint">Новая назва</string>
+    <string name="settings_app_name_label_hint">Новая назва</string>
     <string name="settings_app_name_helper">Праграма будзе перапакаваная з гэтай назвай</string>
     <string name="settings_app_name_error">Хібны фармат</string>
     <string name="settings_su_app_adb">Праграмы і ADB</string>

--- a/app/core/src/main/res/values-be/strings.xml
+++ b/app/core/src/main/res/values-be/strings.xml
@@ -121,7 +121,7 @@
     <string name="settings_hosts_summary">Падтрымка пазасістэмнага файла hosts для праграм, якія блакуюць рэкламу</string>
     <string name="settings_hosts_toast">Дададзены модуль пазасістэмнага файла hosts</string>
     <string name="settings_app_name_label_hint">Новая назва</string>
-    <string name="settings_app_name_helper">Праграма будзе перапакаваная з гэтай назвай</string>
+    <string name="settings_app_name_label_helper">Праграма будзе перапакаваная з гэтай назвай</string>
     <string name="settings_app_name_error">Хібны фармат</string>
     <string name="settings_su_app_adb">Праграмы і ADB</string>
     <string name="settings_su_app">Толькі праграмы</string>

--- a/app/core/src/main/res/values-be/strings.xml
+++ b/app/core/src/main/res/values-be/strings.xml
@@ -106,7 +106,6 @@
     <string name="settings_download_path_title">Каталог спамповак</string>
     <string name="settings_download_path_message">Файлы будуць спампоўвацца ў %1$s</string>
     <string name="settings_hide_app_title">Схаваць праграму Magisk</string>
-    <string name="settings_hide_app_summary">Усталяваць проксі-праграму з выпадковым ідэнтыфікатарам пакунка і адвольным значком</string>
     <string name="settings_restore_app_title">Аднавіць праграму Magisk</string>
     <string name="settings_restore_app_summary">Вярнуць праграму да зыходнага стану</string>
     <string name="language">Мова</string>

--- a/app/core/src/main/res/values-bg/strings.xml
+++ b/app/core/src/main/res/values-bg/strings.xml
@@ -144,7 +144,7 @@
     <string name="settings_hosts_summary">Поддръжка на безсистемни хостове, ползвани от приложения за спиране на реклами</string>
     <string name="settings_hosts_toast">Модулът за безсистемни хостове е добавен</string>
     <string name="settings_app_name_label_hint">Ново име</string>
-    <string name="settings_app_name_helper">Приложението ще бъде пакетирано с това име</string>
+    <string name="settings_app_name_label_helper">Приложението ще бъде пакетирано с това име</string>
     <string name="settings_app_name_error">Форматът е недействителен</string>
     <string name="settings_su_app_adb">Приложения и ADB</string>
     <string name="settings_su_app">Само приложения</string>

--- a/app/core/src/main/res/values-bg/strings.xml
+++ b/app/core/src/main/res/values-bg/strings.xml
@@ -143,7 +143,7 @@
     <string name="settings_hosts_title">Безсистемни хостове</string>
     <string name="settings_hosts_summary">Поддръжка на безсистемни хостове, ползвани от приложения за спиране на реклами</string>
     <string name="settings_hosts_toast">Модулът за безсистемни хостове е добавен</string>
-    <string name="settings_app_name_hint">Ново име</string>
+    <string name="settings_app_name_label_hint">Ново име</string>
     <string name="settings_app_name_helper">Приложението ще бъде пакетирано с това име</string>
     <string name="settings_app_name_error">Форматът е недействителен</string>
     <string name="settings_su_app_adb">Приложения и ADB</string>

--- a/app/core/src/main/res/values-bg/strings.xml
+++ b/app/core/src/main/res/values-bg/strings.xml
@@ -124,7 +124,6 @@
     <string name="settings_download_path_title">Папка за изтегляния</string>
     <string name="settings_download_path_message">Файловете ще бъдат запазвани в %1$s</string>
     <string name="settings_hide_app_title">Скриване на приложението на Magisk</string>
-    <string name="settings_hide_app_summary">Инсталира междинно приложение с произволен идестификатор и име</string>
     <string name="settings_restore_app_title">Възстановяване на приложението на Magisk</string>
     <string name="settings_restore_app_summary">Показва и възстановява оригиналното приложение</string>
     <string name="language">Език</string>

--- a/app/core/src/main/res/values-bn/strings.xml
+++ b/app/core/src/main/res/values-bn/strings.xml
@@ -121,7 +121,6 @@
     <string name="settings_download_path_title">পাথ ডাউনলোড করুন</string>
     <string name="settings_download_path_message">ফাইলগুলি %1$s এ সংরক্ষণ করা হবে৷</string>
     <string name="settings_hide_app_title">ম্যাজিস্ক অ্যাপটি লুকান</string>
-    <string name="settings_hide_app_summary">একটি র্যান্ডম প্যাকেজ আইডি এবং কাস্টম অ্যাপ লেব সহ একটি প্রক্সি অ্যাপ ইনস্টল করুনl</string>
     <string name="settings_restore_app_title">ম্যাজিস্ক অ্যাপটি পুনরুদ্ধার করুন</string>
     <string name="settings_restore_app_summary">অ্যাপটি আড়াল করুন এবং আসলটি পুনরুদ্ধার করুন</string>
     <string name="language">ভাষা</string>

--- a/app/core/src/main/res/values-bn/strings.xml
+++ b/app/core/src/main/res/values-bn/strings.xml
@@ -141,7 +141,7 @@
     <string name="settings_hosts_summary">বিজ্ঞাপন ব্লকিং অ্যাপের জন্য সিস্টেমলেস হোস্ট</string>
     <string name="settings_hosts_toast">সিস্টেমহীন হোস্ট মডিউল যোগ করা হয়েছে</string>
     <string name="settings_app_name_label_hint">নতুন নাম</string>
-    <string name="settings_app_name_helper">অ্যাপটি এই নামের সাথে পুনরায় প্যাকেজ করা হবে</string>
+    <string name="settings_app_name_label_helper">অ্যাপটি এই নামের সাথে পুনরায় প্যাকেজ করা হবে</string>
     <string name="settings_app_name_error">ভুল ফরম্যাট</string>
     <string name="settings_su_app_adb">অ্যাপস এবং এডিবি</string>
     <string name="settings_su_app">শুধুমাত্র অ্যাপস</string>

--- a/app/core/src/main/res/values-bn/strings.xml
+++ b/app/core/src/main/res/values-bn/strings.xml
@@ -140,7 +140,7 @@
     <string name="settings_hosts_title">সিস্টেমহীন হোস্ট</string>
     <string name="settings_hosts_summary">বিজ্ঞাপন ব্লকিং অ্যাপের জন্য সিস্টেমলেস হোস্ট</string>
     <string name="settings_hosts_toast">সিস্টেমহীন হোস্ট মডিউল যোগ করা হয়েছে</string>
-    <string name="settings_app_name_hint">নতুন নাম</string>
+    <string name="settings_app_name_label_hint">নতুন নাম</string>
     <string name="settings_app_name_helper">অ্যাপটি এই নামের সাথে পুনরায় প্যাকেজ করা হবে</string>
     <string name="settings_app_name_error">ভুল ফরম্যাট</string>
     <string name="settings_su_app_adb">অ্যাপস এবং এডিবি</string>

--- a/app/core/src/main/res/values-ca/strings.xml
+++ b/app/core/src/main/res/values-ca/strings.xml
@@ -116,7 +116,6 @@
     <string name="settings_download_path_title">Directori de baixades</string>
     <string name="settings_download_path_message">Els arxius es desaran a %1$s</string>
     <string name="settings_hide_app_title">Amagar Magisk Manager</string>
-    <string name="settings_hide_app_summary">Torna a empaquetar Magisk Manager amb un nom de paquet a l\'atzar</string>
     <string name="settings_restore_app_title">Restaurar Magisk Manager</string>
     <string name="settings_restore_app_summary">Restaura Magisk Manager amb el nom de paquet original</string>
     <string name="language">Idioma</string>

--- a/app/core/src/main/res/values-ca/strings.xml
+++ b/app/core/src/main/res/values-ca/strings.xml
@@ -131,7 +131,7 @@
     <string name="settings_hosts_summary">Suport per aplicacions tipus Adblock fora de la partició del sistema</string>
     <string name="settings_hosts_toast">Agregat el mòdul Systemless Hosts</string>
     <string name="settings_app_name_label_hint">Nou nom</string>
-    <string name="settings_app_name_helper">Es refarà l\'aplicació amb aquest nom</string>
+    <string name="settings_app_name_label_helper">Es refarà l\'aplicació amb aquest nom</string>
     <string name="settings_app_name_error">Format invàlid</string>
     <string name="settings_su_app_adb">Aplicacions i ADB</string>
     <string name="settings_su_app">Només aplicacions</string>

--- a/app/core/src/main/res/values-ca/strings.xml
+++ b/app/core/src/main/res/values-ca/strings.xml
@@ -130,7 +130,7 @@
     <string name="settings_hosts_title">Systemless Hosts</string>
     <string name="settings_hosts_summary">Suport per aplicacions tipus Adblock fora de la partició del sistema</string>
     <string name="settings_hosts_toast">Agregat el mòdul Systemless Hosts</string>
-    <string name="settings_app_name_hint">Nou nom</string>
+    <string name="settings_app_name_label_hint">Nou nom</string>
     <string name="settings_app_name_helper">Es refarà l\'aplicació amb aquest nom</string>
     <string name="settings_app_name_error">Format invàlid</string>
     <string name="settings_su_app_adb">Aplicacions i ADB</string>

--- a/app/core/src/main/res/values-cs/strings.xml
+++ b/app/core/src/main/res/values-cs/strings.xml
@@ -127,7 +127,6 @@
     <string name="settings_download_path_title">Složka pro stahování</string>
     <string name="settings_download_path_message">Soubory budou uloženy do %1$s.</string>
     <string name="settings_hide_app_title">Skrýt aplikaci Magisk</string>
-    <string name="settings_hide_app_summary">Skryje aplikaci náhodným ID balíčku a vlastním názvem aplikace</string>
     <string name="settings_restore_app_title">Obnovit aplikaci Magisk</string>
     <string name="settings_restore_app_summary">Obnoví aplikaci zpět do původního APK</string>
     <string name="language">Jazyk</string>

--- a/app/core/src/main/res/values-cs/strings.xml
+++ b/app/core/src/main/res/values-cs/strings.xml
@@ -147,7 +147,7 @@
     <string name="settings_hosts_summary">Přidá modul pro podporu nesystémových hostitelů v aplikaci AdBlock</string>
     <string name="settings_hosts_toast">Modul nesystémových hostitelů přidán</string>
     <string name="settings_app_name_label_hint">Nový název</string>
-    <string name="settings_app_name_helper">Název aplikace bude nahrazen tímto názvem</string>
+    <string name="settings_app_name_label_helper">Název aplikace bude nahrazen tímto názvem</string>
     <string name="settings_app_name_error">Neplatný formát</string>
     <string name="settings_su_app_adb">Aplikace a ADB</string>
     <string name="settings_su_app">Pouze aplikace</string>

--- a/app/core/src/main/res/values-cs/strings.xml
+++ b/app/core/src/main/res/values-cs/strings.xml
@@ -146,7 +146,7 @@
     <string name="settings_hosts_title">Nesystémoví hostitelé</string>
     <string name="settings_hosts_summary">Přidá modul pro podporu nesystémových hostitelů v aplikaci AdBlock</string>
     <string name="settings_hosts_toast">Modul nesystémových hostitelů přidán</string>
-    <string name="settings_app_name_hint">Nový název</string>
+    <string name="settings_app_name_label_hint">Nový název</string>
     <string name="settings_app_name_helper">Název aplikace bude nahrazen tímto názvem</string>
     <string name="settings_app_name_error">Neplatný formát</string>
     <string name="settings_su_app_adb">Aplikace a ADB</string>

--- a/app/core/src/main/res/values-de/strings.xml
+++ b/app/core/src/main/res/values-de/strings.xml
@@ -146,7 +146,7 @@
     <string name="settings_hosts_title">Systemlose Hosts-Datei</string>
     <string name="settings_hosts_summary">Systemlose Unterstützung für Werbeblocker</string>
     <string name="settings_hosts_toast">Systemloses Hosts-Modul hinzugefügt</string>
-    <string name="settings_app_name_hint">Neuer Name</string>
+    <string name="settings_app_name_label_hint">Neuer Name</string>
     <string name="settings_app_name_helper">App wird unter diesem Namen neu gepackt</string>
     <string name="settings_app_name_error">Ungültiges Format</string>
     <string name="settings_su_app_adb">Apps und ADB</string>

--- a/app/core/src/main/res/values-de/strings.xml
+++ b/app/core/src/main/res/values-de/strings.xml
@@ -147,7 +147,7 @@
     <string name="settings_hosts_summary">Systemlose Unterstützung für Werbeblocker</string>
     <string name="settings_hosts_toast">Systemloses Hosts-Modul hinzugefügt</string>
     <string name="settings_app_name_label_hint">Neuer Name</string>
-    <string name="settings_app_name_helper">App wird unter diesem Namen neu gepackt</string>
+    <string name="settings_app_name_label_helper">App wird unter diesem Namen neu gepackt</string>
     <string name="settings_app_name_error">Ungültiges Format</string>
     <string name="settings_su_app_adb">Apps und ADB</string>
     <string name="settings_su_app">Nur Apps</string>

--- a/app/core/src/main/res/values-de/strings.xml
+++ b/app/core/src/main/res/values-de/strings.xml
@@ -127,7 +127,6 @@
     <string name="settings_download_path_title">Download-Verzeichnis</string>
     <string name="settings_download_path_message">Dateien werden in %1$s gespeichert</string>
     <string name="settings_hide_app_title">Magisk-App verstecken</string>
-    <string name="settings_hide_app_summary">Proxy-App mit zufälliger Paket-ID und benutzerdefiniertem App-Label installieren</string>
     <string name="settings_restore_app_title">Magisk-App wiederherstellen</string>
     <string name="settings_restore_app_summary">App wieder einblenden und original APK wiederherstellen</string>
     <string name="language">Sprache</string>

--- a/app/core/src/main/res/values-el/strings.xml
+++ b/app/core/src/main/res/values-el/strings.xml
@@ -142,7 +142,7 @@
     <string name="settings_hosts_title">Systemless hosts</string>
     <string name="settings_hosts_summary">Υποστήριξη Systemless hosts για εφαρμογές Adblock</string>
     <string name="settings_hosts_toast">Προσθήκη αρθρώματος systemless hosts</string>
-    <string name="settings_app_name_hint">Νέο όνομα</string>
+    <string name="settings_app_name_label_hint">Νέο όνομα</string>
     <string name="settings_app_name_helper">Η εφαρμογή θα επανασυσκευαστεί με αυτό το όνομα</string>
     <string name="settings_app_name_error">Μη έγκυρη μορφή</string>
     <string name="settings_su_app_adb">Εφαρμογές και ADB</string>

--- a/app/core/src/main/res/values-el/strings.xml
+++ b/app/core/src/main/res/values-el/strings.xml
@@ -122,7 +122,7 @@
     <string name="settings_download_path_title">Διαδρομή λήψης</string>
     <string name="settings_download_path_message">Τα αρχεία θα αποθηκευτούν στο %1$s</string>
     <string name="settings_hide_app_title">Απόκρυψη της εφαρμογής Magisk</string>
-    <string name="settings_hide_app_summary">Εγκαταστήστε μια εφαρμογή με τυχαίο αναγνωριστικό πακέτου και προσαρμοσμένη ετικέτα εφαρμογής</string>
+    <string name="settings_hide_app_summary">" "</string>
     <string name="settings_restore_app_title">Επαναφέρετε την εφαρμογή Magisk</string>
     <string name="settings_restore_app_summary">Καταργήστε την απόκρυψη της εφαρμογής και επαναφέρετέ την στο αρχικό APK</string>
     <string name="language">Γλώσσα</string>

--- a/app/core/src/main/res/values-el/strings.xml
+++ b/app/core/src/main/res/values-el/strings.xml
@@ -143,7 +143,7 @@
     <string name="settings_hosts_summary">Υποστήριξη Systemless hosts για εφαρμογές Adblock</string>
     <string name="settings_hosts_toast">Προσθήκη αρθρώματος systemless hosts</string>
     <string name="settings_app_name_label_hint">Νέο όνομα</string>
-    <string name="settings_app_name_helper">Η εφαρμογή θα επανασυσκευαστεί με αυτό το όνομα</string>
+    <string name="settings_app_name_label_helper">Η εφαρμογή θα επανασυσκευαστεί με αυτό το όνομα</string>
     <string name="settings_app_name_error">Μη έγκυρη μορφή</string>
     <string name="settings_su_app_adb">Εφαρμογές και ADB</string>
     <string name="settings_su_app">Εφαρμογές μόνο</string>

--- a/app/core/src/main/res/values-es/strings.xml
+++ b/app/core/src/main/res/values-es/strings.xml
@@ -125,7 +125,6 @@
     <string name="settings_download_path_title">Ruta de descarga</string>
     <string name="settings_download_path_message">Los archivos serán guardados en la siguiente ruta:\n%1$s</string>
     <string name="settings_hide_app_title">Ocultar la app de Magisk</string>
-    <string name="settings_hide_app_summary">Instalar una versión proxy de la app con un nombre de paquete aleatorio y una etiqueta personalizada</string>
     <string name="settings_restore_app_title">Restaurar la app</string>
     <string name="settings_restore_app_summary">Desoculta la app y la reemplaza por la original</string>
     <string name="language">Idioma</string>

--- a/app/core/src/main/res/values-es/strings.xml
+++ b/app/core/src/main/res/values-es/strings.xml
@@ -144,7 +144,7 @@
     <string name="settings_hosts_title">Systemless hosts</string>
     <string name="settings_hosts_summary">Prepara al archivo hosts para que los bloqueadores de anuncios puedan modificarlo sin alterar el sistema</string>
     <string name="settings_hosts_toast">El módulo se instaló correctamente, reinicia para aplicar los cambios.</string>
-    <string name="settings_app_name_hint">Nuevo nombre de la app</string>
+    <string name="settings_app_name_label_hint">Nuevo nombre de la app</string>
     <string name="settings_app_name_helper">La app de Magisk será reempaquetada con este nombre</string>
     <string name="settings_app_name_error">El nombre es inválido</string>
     <string name="settings_su_app_adb">Permitir tanto a las apps como a ADB</string>

--- a/app/core/src/main/res/values-es/strings.xml
+++ b/app/core/src/main/res/values-es/strings.xml
@@ -145,7 +145,7 @@
     <string name="settings_hosts_summary">Prepara al archivo hosts para que los bloqueadores de anuncios puedan modificarlo sin alterar el sistema</string>
     <string name="settings_hosts_toast">El módulo se instaló correctamente, reinicia para aplicar los cambios.</string>
     <string name="settings_app_name_label_hint">Nuevo nombre de la app</string>
-    <string name="settings_app_name_helper">La app de Magisk será reempaquetada con este nombre</string>
+    <string name="settings_app_name_label_helper">La app de Magisk será reempaquetada con este nombre</string>
     <string name="settings_app_name_error">El nombre es inválido</string>
     <string name="settings_su_app_adb">Permitir tanto a las apps como a ADB</string>
     <string name="settings_su_app">Permitir solo a las apps</string>

--- a/app/core/src/main/res/values-et/strings.xml
+++ b/app/core/src/main/res/values-et/strings.xml
@@ -120,7 +120,6 @@
     <string name="settings_download_path_title">Allalaadimise failitee</string>
     <string name="settings_download_path_message">Failid salvestatakse kausta %1$s</string>
     <string name="settings_hide_app_title">Peida Magiski rakendus</string>
-    <string name="settings_hide_app_summary">Paigalda juhusliku paketi-ID ja kohandatud nimega puhverrakendus</string>
     <string name="settings_restore_app_title">Taasta Magiski rakendus</string>
     <string name="settings_restore_app_summary">Too rakendus peidust välja, taastades originaalse APK</string>
     <string name="language">Keel</string>

--- a/app/core/src/main/res/values-et/strings.xml
+++ b/app/core/src/main/res/values-et/strings.xml
@@ -139,7 +139,7 @@
     <string name="settings_hosts_title">Süsteemivaba hosts</string>
     <string name="settings_hosts_summary">Süsteemivaba hosts-tugi reklaamiblokeerijatest rakendustele</string>
     <string name="settings_hosts_toast">Süsteemivaba hostsi moodul lisatud</string>
-    <string name="settings_app_name_hint">Uus nimi</string>
+    <string name="settings_app_name_label_hint">Uus nimi</string>
     <string name="settings_app_name_helper">Rakendus taaspakitakse selle nimega</string>
     <string name="settings_app_name_error">Sobimatu vorming</string>
     <string name="settings_su_app_adb">Rakendused ja ADB</string>

--- a/app/core/src/main/res/values-et/strings.xml
+++ b/app/core/src/main/res/values-et/strings.xml
@@ -140,7 +140,7 @@
     <string name="settings_hosts_summary">Süsteemivaba hosts-tugi reklaamiblokeerijatest rakendustele</string>
     <string name="settings_hosts_toast">Süsteemivaba hostsi moodul lisatud</string>
     <string name="settings_app_name_label_hint">Uus nimi</string>
-    <string name="settings_app_name_helper">Rakendus taaspakitakse selle nimega</string>
+    <string name="settings_app_name_label_helper">Rakendus taaspakitakse selle nimega</string>
     <string name="settings_app_name_error">Sobimatu vorming</string>
     <string name="settings_su_app_adb">Rakendused ja ADB</string>
     <string name="settings_su_app">Ainult rakendused</string>

--- a/app/core/src/main/res/values-fa/strings.xml
+++ b/app/core/src/main/res/values-fa/strings.xml
@@ -120,7 +120,7 @@
     <string name="settings_hosts_summary">نصب بدون حذف یا تغییر در فایل ها رای ساپورت از برنامه های Adblock</string>
     <string name="settings_hosts_toast">ماژول نصب بدون حذف یا تغییر در فایل ها اضافه شد</string>
     <string name="settings_app_name_label_hint">اسم جدید</string>
-    <string name="settings_app_name_helper">برنامه به این نام تغییر خواهد کرد</string>
+    <string name="settings_app_name_label_helper">برنامه به این نام تغییر خواهد کرد</string>
     <string name="settings_app_name_error">فرمت نامعتبر</string>
     <string name="settings_su_app_adb">برنامه ها و ADB</string>
     <string name="settings_su_app">فقط برنامه ها</string>

--- a/app/core/src/main/res/values-fa/strings.xml
+++ b/app/core/src/main/res/values-fa/strings.xml
@@ -119,7 +119,7 @@
     <string name="settings_hosts_title">نصب بدون حذف یا تغییر در فایل ها</string>
     <string name="settings_hosts_summary">نصب بدون حذف یا تغییر در فایل ها رای ساپورت از برنامه های Adblock</string>
     <string name="settings_hosts_toast">ماژول نصب بدون حذف یا تغییر در فایل ها اضافه شد</string>
-    <string name="settings_app_name_hint">اسم جدید</string>
+    <string name="settings_app_name_label_hint">اسم جدید</string>
     <string name="settings_app_name_helper">برنامه به این نام تغییر خواهد کرد</string>
     <string name="settings_app_name_error">فرمت نامعتبر</string>
     <string name="settings_su_app_adb">برنامه ها و ADB</string>

--- a/app/core/src/main/res/values-fr/strings.xml
+++ b/app/core/src/main/res/values-fr/strings.xml
@@ -128,7 +128,6 @@
     <string name="settings_download_path_title">Répertoire de téléchargement</string>
     <string name="settings_download_path_message">Les fichiers seront enregistrés sous %1$s</string>
     <string name="settings_hide_app_title">Masquer l’application Magisk</string>
-    <string name="settings_hide_app_summary">Installer une application intermédiaire avec un identifiant de paquet aléatoire et un nom personnalisé</string>
     <string name="settings_restore_app_title">Restaurer l’application Magisk</string>
     <string name="settings_restore_app_summary">Démasquer l’application et la restaurer comme son APK d’origine.</string>
     <string name="language">Langue</string>

--- a/app/core/src/main/res/values-fr/strings.xml
+++ b/app/core/src/main/res/values-fr/strings.xml
@@ -148,7 +148,7 @@
     <string name="settings_hosts_summary">Utilisation d’un fichier d’hôtes hors de la partition système pour les applications de blocage de publicité.</string>
     <string name="settings_hosts_toast">Ajout d’un module pour fichier hosts hors système</string>
     <string name="settings_app_name_label_hint">Nouveau nom</string>
-    <string name="settings_app_name_helper">L’application sera réempaquetée sous ce nom</string>
+    <string name="settings_app_name_label_helper">L’application sera réempaquetée sous ce nom</string>
     <string name="settings_app_name_error">Format incorrect</string>
     <string name="settings_su_app_adb">Applications et ADB</string>
     <string name="settings_su_app">Applications uniquement</string>

--- a/app/core/src/main/res/values-fr/strings.xml
+++ b/app/core/src/main/res/values-fr/strings.xml
@@ -147,7 +147,7 @@
     <string name="settings_hosts_title">Fichier d’hôtes hors partition système</string>
     <string name="settings_hosts_summary">Utilisation d’un fichier d’hôtes hors de la partition système pour les applications de blocage de publicité.</string>
     <string name="settings_hosts_toast">Ajout d’un module pour fichier hosts hors système</string>
-    <string name="settings_app_name_hint">Nouveau nom</string>
+    <string name="settings_app_name_label_hint">Nouveau nom</string>
     <string name="settings_app_name_helper">L’application sera réempaquetée sous ce nom</string>
     <string name="settings_app_name_error">Format incorrect</string>
     <string name="settings_su_app_adb">Applications et ADB</string>

--- a/app/core/src/main/res/values-hi/strings.xml
+++ b/app/core/src/main/res/values-hi/strings.xml
@@ -142,7 +142,7 @@
     <string name="settings_hosts_summary">विज्ञापन ब्लॉक ऐप्स के लिए सिस्टमलेस होस्ट समर्थन:</string>
     <string name="settings_hosts_toast">सिस्टमलेस होस्ट मॉड्यूल जोड़ा गया</string>
     <string name="settings_app_name_label_hint">नया नाम</string>
-    <string name="settings_app_name_helper">इस नाम से ऐप को फिर से इंस्टॉल किया जाएगा</string>
+    <string name="settings_app_name_label_helper">इस नाम से ऐप को फिर से इंस्टॉल किया जाएगा</string>
     <string name="settings_app_name_error">अवैध प्रारूप</string>
     <string name="settings_su_app_adb">ऐप्स और एडीबी</string>
     <string name="settings_su_app">केवल ऐप्स</string>

--- a/app/core/src/main/res/values-hi/strings.xml
+++ b/app/core/src/main/res/values-hi/strings.xml
@@ -141,7 +141,7 @@
     <string name="settings_hosts_title">सिस्टमलेस होस्ट</string>
     <string name="settings_hosts_summary">विज्ञापन ब्लॉक ऐप्स के लिए सिस्टमलेस होस्ट समर्थन:</string>
     <string name="settings_hosts_toast">सिस्टमलेस होस्ट मॉड्यूल जोड़ा गया</string>
-    <string name="settings_app_name_hint">नया नाम</string>
+    <string name="settings_app_name_label_hint">नया नाम</string>
     <string name="settings_app_name_helper">इस नाम से ऐप को फिर से इंस्टॉल किया जाएगा</string>
     <string name="settings_app_name_error">अवैध प्रारूप</string>
     <string name="settings_su_app_adb">ऐप्स और एडीबी</string>

--- a/app/core/src/main/res/values-hi/strings.xml
+++ b/app/core/src/main/res/values-hi/strings.xml
@@ -122,7 +122,6 @@
     <string name="settings_download_path_title">डाउनलोड पथ</string>
     <string name="settings_download_path_message">फ़ाइलों को %1$s में सहेजा जाएगा</string>
     <string name="settings_hide_app_title">मैजिस्क ऐप को छिपाएं</string>
-    <string name="settings_hide_app_summary">रैंडम पैकेज आईडी और कस्टम ऐप लेबल के साथ प्रॉक्सी ऐप इंस्टॉल करें</string>
     <string name="settings_restore_app_title">मैजिस्क ऐप को पुनर्स्थापित करें</string>
     <string name="settings_restore_app_summary">ऐप को उनहीदे करें और मूल एपीके को पुनर्स्थापित करें</string>
     <string name="language">भाषा</string>

--- a/app/core/src/main/res/values-hr/strings.xml
+++ b/app/core/src/main/res/values-hr/strings.xml
@@ -124,7 +124,7 @@
     <string name="settings_hosts_summary">Podrška za hostove bez sistema za Adblock aplikacije</string>
     <string name="settings_hosts_toast">Dodan je modul hosta bez sistema</string>
     <string name="settings_app_name_label_hint">Novi naziv</string>
-    <string name="settings_app_name_helper">Aplikacija će se prepakirati na ovaj naziv</string>
+    <string name="settings_app_name_label_helper">Aplikacija će se prepakirati na ovaj naziv</string>
     <string name="settings_app_name_error">Nevažeći format</string>
     <string name="settings_su_app_adb">Aplikacije i ADB</string>
     <string name="settings_su_app">Samo aplikacije</string>

--- a/app/core/src/main/res/values-hr/strings.xml
+++ b/app/core/src/main/res/values-hr/strings.xml
@@ -123,7 +123,7 @@
     <string name="settings_hosts_title">Hostovi bez sistema</string>
     <string name="settings_hosts_summary">Podrška za hostove bez sistema za Adblock aplikacije</string>
     <string name="settings_hosts_toast">Dodan je modul hosta bez sistema</string>
-    <string name="settings_app_name_hint">Novi naziv</string>
+    <string name="settings_app_name_label_hint">Novi naziv</string>
     <string name="settings_app_name_helper">Aplikacija će se prepakirati na ovaj naziv</string>
     <string name="settings_app_name_error">Nevažeći format</string>
     <string name="settings_su_app_adb">Aplikacije i ADB</string>

--- a/app/core/src/main/res/values-hu/strings.xml
+++ b/app/core/src/main/res/values-hu/strings.xml
@@ -122,7 +122,6 @@
     <string name="settings_download_path_title">Letöltési útvonal</string>
     <string name="settings_download_path_message">A fájlok a következő helyre kerülnek: %1$s</string>
     <string name="settings_hide_app_title">A Magisk app elrejtése</string>
-    <string name="settings_hide_app_summary">Telepíts egy proxyalkalmazást véletlenszerű csomagazonosítóval és egyéni alkalmazáscímkével</string>
     <string name="settings_restore_app_title">A Magisk app visszaállítása</string>
     <string name="settings_restore_app_summary">Oldja fel az app elrejtését, és állítsa vissza az eredeti APK-t</string>
     <string name="language">Nyelv</string>

--- a/app/core/src/main/res/values-hu/strings.xml
+++ b/app/core/src/main/res/values-hu/strings.xml
@@ -142,7 +142,7 @@
     <string name="settings_hosts_summary">Systemless hosts támogatás a hirdetésblokkoló alkalmazásokhoz</string>
     <string name="settings_hosts_toast">Systemless hosts modul hozzáadva</string>
     <string name="settings_app_name_label_hint">Új név</string>
-    <string name="settings_app_name_helper">Az alkalmazás ezzel a névvel lesz újracsomagolva</string>
+    <string name="settings_app_name_label_helper">Az alkalmazás ezzel a névvel lesz újracsomagolva</string>
     <string name="settings_app_name_error">Érvénytelen formátum</string>
     <string name="settings_su_app_adb">Appok és ADB</string>
     <string name="settings_su_app">Csak Appok</string>

--- a/app/core/src/main/res/values-hu/strings.xml
+++ b/app/core/src/main/res/values-hu/strings.xml
@@ -141,7 +141,7 @@
     <string name="settings_hosts_title">Systemless hosts</string>
     <string name="settings_hosts_summary">Systemless hosts támogatás a hirdetésblokkoló alkalmazásokhoz</string>
     <string name="settings_hosts_toast">Systemless hosts modul hozzáadva</string>
-    <string name="settings_app_name_hint">Új név</string>
+    <string name="settings_app_name_label_hint">Új név</string>
     <string name="settings_app_name_helper">Az alkalmazás ezzel a névvel lesz újracsomagolva</string>
     <string name="settings_app_name_error">Érvénytelen formátum</string>
     <string name="settings_su_app_adb">Appok és ADB</string>

--- a/app/core/src/main/res/values-in/strings.xml
+++ b/app/core/src/main/res/values-in/strings.xml
@@ -143,7 +143,7 @@
     <string name="settings_hosts_title">Host systemless</string>
     <string name="settings_hosts_summary">Dukungan host secara systemless untuk aplikasi pemblokir iklan</string>
     <string name="settings_hosts_toast">Menambahkan modul host systemless</string>
-    <string name="settings_app_name_hint">Nama baru</string>
+    <string name="settings_app_name_label_hint">Nama baru</string>
     <string name="settings_app_name_helper">Aplikasi akan dikemas dengan nama tersebut</string>
     <string name="settings_app_name_error">Format tidak valid</string>
     <string name="settings_su_app_adb">Apl dan ADB</string>

--- a/app/core/src/main/res/values-in/strings.xml
+++ b/app/core/src/main/res/values-in/strings.xml
@@ -144,7 +144,7 @@
     <string name="settings_hosts_summary">Dukungan host secara systemless untuk aplikasi pemblokir iklan</string>
     <string name="settings_hosts_toast">Menambahkan modul host systemless</string>
     <string name="settings_app_name_label_hint">Nama baru</string>
-    <string name="settings_app_name_helper">Aplikasi akan dikemas dengan nama tersebut</string>
+    <string name="settings_app_name_label_helper">Aplikasi akan dikemas dengan nama tersebut</string>
     <string name="settings_app_name_error">Format tidak valid</string>
     <string name="settings_su_app_adb">Apl dan ADB</string>
     <string name="settings_su_app">Apl saja</string>

--- a/app/core/src/main/res/values-in/strings.xml
+++ b/app/core/src/main/res/values-in/strings.xml
@@ -124,7 +124,6 @@
     <string name="settings_download_path_title">Lokasi unduhan</string>
     <string name="settings_download_path_message">File akan disimpan ke %1$s</string>
     <string name="settings_hide_app_title">Sembunyikan aplikasi Magisk</string>
-    <string name="settings_hide_app_summary">Pasang aplikasi proxy dengan ID paket acak dan label aplikasi khusus</string>
     <string name="settings_restore_app_title">Pulihkan aplikasi Magisk</string>
     <string name="settings_restore_app_summary">Tampilkan aplikasi and pulihkan APK asli</string>
     <string name="language">Bahasa</string>

--- a/app/core/src/main/res/values-it/strings.xml
+++ b/app/core/src/main/res/values-it/strings.xml
@@ -122,7 +122,6 @@
     <string name="settings_download_path_title">Percorso di download</string>
     <string name="settings_download_path_message">I file verranno salvati in %1$s</string>
     <string name="settings_hide_app_title">Nascondi l\'app di Magisk</string>
-    <string name="settings_hide_app_summary">Installa un\'app \"proxy\" con un ID pacchetto casuale e un nome personalizzato</string>
     <string name="settings_restore_app_title">Ripristina l\'app di Magisk</string>
     <string name="settings_restore_app_summary">Rendi l\'app nuovamente rilevabile e ripristina l\'APK originale</string>
     <string name="language">Lingua</string>

--- a/app/core/src/main/res/values-it/strings.xml
+++ b/app/core/src/main/res/values-it/strings.xml
@@ -141,7 +141,7 @@
     <string name="settings_hosts_title">File hosts systemless</string>
     <string name="settings_hosts_summary">Supporto al file hosts systemless per le app che bloccano le pubblicità</string>
     <string name="settings_hosts_toast">Aggiunto modulo per il supporto al file hosts systemless</string>
-    <string name="settings_app_name_hint">Nuovo nome</string>
+    <string name="settings_app_name_label_hint">Nuovo nome</string>
     <string name="settings_app_name_helper">L\'app sarà ricreata con questo nome</string>
     <string name="settings_app_name_error">Formato non valido</string>
     <string name="settings_su_app_adb">App e ADB</string>

--- a/app/core/src/main/res/values-it/strings.xml
+++ b/app/core/src/main/res/values-it/strings.xml
@@ -142,7 +142,7 @@
     <string name="settings_hosts_summary">Supporto al file hosts systemless per le app che bloccano le pubblicità</string>
     <string name="settings_hosts_toast">Aggiunto modulo per il supporto al file hosts systemless</string>
     <string name="settings_app_name_label_hint">Nuovo nome</string>
-    <string name="settings_app_name_helper">L\'app sarà ricreata con questo nome</string>
+    <string name="settings_app_name_label_helper">L\'app sarà ricreata con questo nome</string>
     <string name="settings_app_name_error">Formato non valido</string>
     <string name="settings_su_app_adb">App e ADB</string>
     <string name="settings_su_app">Solo app</string>

--- a/app/core/src/main/res/values-iw/strings.xml
+++ b/app/core/src/main/res/values-iw/strings.xml
@@ -146,7 +146,7 @@
     <string name="settings_hosts_summary">מארחים חסרי מערכת תומכים ביישומים חוסמי פרסומות</string>
     <string name="settings_hosts_toast">הוספת מודול מארחים חסרי מערכת</string>
     <string name="settings_app_name_label_hint">שם חדש</string>
-    <string name="settings_app_name_helper">היישום יארז מחדש בשם זה</string>
+    <string name="settings_app_name_label_helper">היישום יארז מחדש בשם זה</string>
     <string name="settings_app_name_error">פורמט לא חוקי</string>
     <string name="settings_su_app_adb">יישומים ו-ADB</string>
     <string name="settings_su_app">יישומים בלבד</string>

--- a/app/core/src/main/res/values-iw/strings.xml
+++ b/app/core/src/main/res/values-iw/strings.xml
@@ -126,7 +126,6 @@
     <string name="settings_download_path_title">נתיב הורדה</string>
     <string name="settings_download_path_message">הקבצים ישמרו אל %1$s</string>
     <string name="settings_hide_app_title">הסתרת היישום Magisk</string>
-    <string name="settings_hide_app_summary">התקנת יישום מתווך עם מזהה חבילה אקראי ותווית שם מותאמת אישית</string>
     <string name="settings_restore_app_title">שיחזור היישום Magisk</string>
     <string name="settings_restore_app_summary">יש לבטל את הסתרת היישום ולשחזור אותו ל-APK המקורי</string>
     <string name="language">שפה</string>

--- a/app/core/src/main/res/values-iw/strings.xml
+++ b/app/core/src/main/res/values-iw/strings.xml
@@ -145,7 +145,7 @@
     <string name="settings_hosts_title">מארחים חסרי מערכת</string>
     <string name="settings_hosts_summary">מארחים חסרי מערכת תומכים ביישומים חוסמי פרסומות</string>
     <string name="settings_hosts_toast">הוספת מודול מארחים חסרי מערכת</string>
-    <string name="settings_app_name_hint">שם חדש</string>
+    <string name="settings_app_name_label_hint">שם חדש</string>
     <string name="settings_app_name_helper">היישום יארז מחדש בשם זה</string>
     <string name="settings_app_name_error">פורמט לא חוקי</string>
     <string name="settings_su_app_adb">יישומים ו-ADB</string>

--- a/app/core/src/main/res/values-ja/strings.xml
+++ b/app/core/src/main/res/values-ja/strings.xml
@@ -122,7 +122,6 @@
     <string name="settings_download_path_title">ファイルの保存場所</string>
     <string name="settings_download_path_message">ファイルは %1$s に保存されます</string>
     <string name="settings_hide_app_title">Magisk アプリを隠す</string>
-    <string name="settings_hide_app_summary">ランダムなパッケージ ID と任意のアプリ名のプロキシアプリをインストールします</string>
     <string name="settings_restore_app_title">Magisk アプリを復元する</string>
     <string name="settings_restore_app_summary">隠すのを止めて、元の APK をインストールします</string>
     <string name="language">言語 (Language)</string>

--- a/app/core/src/main/res/values-ja/strings.xml
+++ b/app/core/src/main/res/values-ja/strings.xml
@@ -142,7 +142,7 @@
     <string name="settings_hosts_summary">広告ブロックアプリのための Systemless hosts サポートを有効化します</string>
     <string name="settings_hosts_toast">Systemless hosts モジュールを追加しました</string>
     <string name="settings_app_name_label_hint">アプリ名</string>
-    <string name="settings_app_name_helper">プロキシアプリはこのアプリ名でインストールされます</string>
+    <string name="settings_app_name_label_helper">プロキシアプリはこのアプリ名でインストールされます</string>
     <string name="settings_app_name_error">不正な形式</string>
     <string name="settings_su_app_adb">アプリと ADB</string>
     <string name="settings_su_app">アプリのみ</string>

--- a/app/core/src/main/res/values-ja/strings.xml
+++ b/app/core/src/main/res/values-ja/strings.xml
@@ -141,7 +141,7 @@
     <string name="settings_hosts_title">Systemless hosts</string>
     <string name="settings_hosts_summary">広告ブロックアプリのための Systemless hosts サポートを有効化します</string>
     <string name="settings_hosts_toast">Systemless hosts モジュールを追加しました</string>
-    <string name="settings_app_name_hint">アプリ名</string>
+    <string name="settings_app_name_label_hint">アプリ名</string>
     <string name="settings_app_name_helper">プロキシアプリはこのアプリ名でインストールされます</string>
     <string name="settings_app_name_error">不正な形式</string>
     <string name="settings_su_app_adb">アプリと ADB</string>

--- a/app/core/src/main/res/values-ka/strings.xml
+++ b/app/core/src/main/res/values-ka/strings.xml
@@ -130,7 +130,7 @@
     <string name="settings_hosts_title">გარესისტემური ჰოსტები</string>
     <string name="settings_hosts_summary">გარესისტემური ჰოსტები Adblock-ებისთვის</string>
     <string name="settings_hosts_toast">გარესისტემური ჰოსტების მოდული დამატებულია</string>
-    <string name="settings_app_name_hint">ახალი სახელი</string>
+    <string name="settings_app_name_label_hint">ახალი სახელი</string>
     <string name="settings_app_name_helper">პროგრამას ეს პაკეტის სახელი ექნება</string>
     <string name="settings_app_name_error">არასწორი ფორმატი</string>
     <string name="settings_su_app_adb">აპები და ADB</string>

--- a/app/core/src/main/res/values-ka/strings.xml
+++ b/app/core/src/main/res/values-ka/strings.xml
@@ -116,7 +116,6 @@
     <string name="settings_download_path_title">გადმოწერის ლოკაცია</string>
     <string name="settings_download_path_message">ფაილები შეინახება %1$s-ში</string>
     <string name="settings_hide_app_title">Magisk-ის აპის დამალვა</string>
-    <string name="settings_hide_app_summary">დაყენდეს ამოუცნობელი აპი შემთხვევითი პაკეტის ID-ით და განსხვავებული სახელით</string>
     <string name="settings_restore_app_title">Magisk-ის აპის დაბრუნება</string>
     <string name="settings_restore_app_summary">აპის თავდაპირველ მდგომარეობაზე დაბრუნება</string>
     <string name="language">ენა</string>

--- a/app/core/src/main/res/values-ka/strings.xml
+++ b/app/core/src/main/res/values-ka/strings.xml
@@ -131,7 +131,7 @@
     <string name="settings_hosts_summary">გარესისტემური ჰოსტები Adblock-ებისთვის</string>
     <string name="settings_hosts_toast">გარესისტემური ჰოსტების მოდული დამატებულია</string>
     <string name="settings_app_name_label_hint">ახალი სახელი</string>
-    <string name="settings_app_name_helper">პროგრამას ეს პაკეტის სახელი ექნება</string>
+    <string name="settings_app_name_label_helper">პროგრამას ეს პაკეტის სახელი ექნება</string>
     <string name="settings_app_name_error">არასწორი ფორმატი</string>
     <string name="settings_su_app_adb">აპები და ADB</string>
     <string name="settings_su_app">მხოლოდ აპები</string>

--- a/app/core/src/main/res/values-kk/strings.xml
+++ b/app/core/src/main/res/values-kk/strings.xml
@@ -147,7 +147,7 @@
     <string name="settings_hosts_title">Жүйеден тыс hosts</string>
     <string name="settings_hosts_summary">Жарнама өшіретін қолданбалар үшін /system бөлімінен тыс hosts файлын қолдану</string>
     <string name="settings_hosts_toast">Жүйеден тыс hosts модулі қосылды</string>
-    <string name="settings_app_name_hint">Жаңа атау</string>
+    <string name="settings_app_name_label_hint">Жаңа атау</string>
     <string name="settings_app_name_helper">Қолданбаның қайта құрылған нұсқасы осы атауға ие болады</string>
     <string name="settings_app_name_error">Жарамсыз пішім</string>
     <string name="settings_su_app_adb">Қолданбалар мен ADB</string>

--- a/app/core/src/main/res/values-kk/strings.xml
+++ b/app/core/src/main/res/values-kk/strings.xml
@@ -128,7 +128,6 @@
     <string name="settings_download_path_title">Жүктеу бумасы</string>
     <string name="settings_download_path_message">Файлдар %1$s бумасына сақталады</string>
     <string name="settings_hide_app_title">Magisk қолданбасын жасыру</string>
-    <string name="settings_hide_app_summary">Қолданба атауын өзгертіп, кездейсоқ десте атауы бар APK файлын құрастыру</string>
     <string name="settings_restore_app_title">Magisk қолданбасын қалпына келтіру</string>
     <string name="settings_restore_app_summary">Қолданбаны жасырын күйден шығарып, түпнұсқа APK орнату</string>
     <string name="language">Тіл</string>

--- a/app/core/src/main/res/values-kk/strings.xml
+++ b/app/core/src/main/res/values-kk/strings.xml
@@ -148,7 +148,7 @@
     <string name="settings_hosts_summary">Жарнама өшіретін қолданбалар үшін /system бөлімінен тыс hosts файлын қолдану</string>
     <string name="settings_hosts_toast">Жүйеден тыс hosts модулі қосылды</string>
     <string name="settings_app_name_label_hint">Жаңа атау</string>
-    <string name="settings_app_name_helper">Қолданбаның қайта құрылған нұсқасы осы атауға ие болады</string>
+    <string name="settings_app_name_label_helper">Қолданбаның қайта құрылған нұсқасы осы атауға ие болады</string>
     <string name="settings_app_name_error">Жарамсыз пішім</string>
     <string name="settings_su_app_adb">Қолданбалар мен ADB</string>
     <string name="settings_su_app">Қолданбалар ғана</string>

--- a/app/core/src/main/res/values-ko/strings.xml
+++ b/app/core/src/main/res/values-ko/strings.xml
@@ -139,7 +139,7 @@
     <string name="settings_hosts_title">Systemless hosts</string>
     <string name="settings_hosts_summary">광고 차단 앱에서 사용하는 systemless hosts를 지원합니다.</string>
     <string name="settings_hosts_toast">Systemless hosts 모듈 추가됨</string>
-    <string name="settings_app_name_hint">새 이름</string>
+    <string name="settings_app_name_label_hint">새 이름</string>
     <string name="settings_app_name_helper">이 이름으로 앱을 다시 패키징합니다.</string>
     <string name="settings_app_name_error">올바르지 않은 형식</string>
     <string name="settings_su_app_adb">앱 및 ADB</string>

--- a/app/core/src/main/res/values-ko/strings.xml
+++ b/app/core/src/main/res/values-ko/strings.xml
@@ -140,7 +140,7 @@
     <string name="settings_hosts_summary">광고 차단 앱에서 사용하는 systemless hosts를 지원합니다.</string>
     <string name="settings_hosts_toast">Systemless hosts 모듈 추가됨</string>
     <string name="settings_app_name_label_hint">새 이름</string>
-    <string name="settings_app_name_helper">이 이름으로 앱을 다시 패키징합니다.</string>
+    <string name="settings_app_name_label_helper">이 이름으로 앱을 다시 패키징합니다.</string>
     <string name="settings_app_name_error">올바르지 않은 형식</string>
     <string name="settings_su_app_adb">앱 및 ADB</string>
     <string name="settings_su_app">앱만</string>

--- a/app/core/src/main/res/values-ko/strings.xml
+++ b/app/core/src/main/res/values-ko/strings.xml
@@ -120,7 +120,6 @@
     <string name="settings_download_path_title">다운로드 경로</string>
     <string name="settings_download_path_message">파일이 %1$s에 저장됩니다</string>
     <string name="settings_hide_app_title">Magisk 앱 숨기기</string>
-    <string name="settings_hide_app_summary">랜덤 패키지 ID와 커스텀 앱 이름으로 Magisk 프록시 앱을 설치합니다.</string>
     <string name="settings_restore_app_title">Magisk 앱 복원</string>
     <string name="settings_restore_app_summary">앱 숨기기를 해제하고 원래 APK로 복원합니다.</string>
     <string name="language">언어</string>

--- a/app/core/src/main/res/values-lt/strings.xml
+++ b/app/core/src/main/res/values-lt/strings.xml
@@ -124,7 +124,6 @@
     <string name="settings_download_path_title">Atsisiuntimo kelias</string>
     <string name="settings_download_path_message">Failai bus išsaugoti %1$s</string>
     <string name="settings_hide_app_title">Slėpti Magisk programėlę</string>
-    <string name="settings_hide_app_summary">Įdiegti įgaliotąją programėlę su atsitiktiniu paketo ID ir kitu pavadinimu</string>
     <string name="settings_restore_app_title">Atkurti Magisk programėlę</string>
     <string name="settings_restore_app_summary">Atkurti programėlę ir originalų APK</string>
     <string name="language">Kalba</string>

--- a/app/core/src/main/res/values-lt/strings.xml
+++ b/app/core/src/main/res/values-lt/strings.xml
@@ -143,7 +143,7 @@
     <string name="settings_hosts_title">Basisteminis hosts</string>
     <string name="settings_hosts_summary">Basisteminis hosts palaiko reklamų blokatorių programėlėms</string>
     <string name="settings_hosts_toast">Pridėtas besisteminio hosts modulis</string>
-    <string name="settings_app_name_hint">Naujas pavadinimas</string>
+    <string name="settings_app_name_label_hint">Naujas pavadinimas</string>
     <string name="settings_app_name_helper">Programėlė bus perpakuota su šiuo pavadinimu</string>
     <string name="settings_app_name_error">Netinkamas formatas</string>
     <string name="settings_su_app_adb">Programėlės ir ADB</string>

--- a/app/core/src/main/res/values-lt/strings.xml
+++ b/app/core/src/main/res/values-lt/strings.xml
@@ -144,7 +144,7 @@
     <string name="settings_hosts_summary">Basisteminis hosts palaiko reklamų blokatorių programėlėms</string>
     <string name="settings_hosts_toast">Pridėtas besisteminio hosts modulis</string>
     <string name="settings_app_name_label_hint">Naujas pavadinimas</string>
-    <string name="settings_app_name_helper">Programėlė bus perpakuota su šiuo pavadinimu</string>
+    <string name="settings_app_name_label_helper">Programėlė bus perpakuota su šiuo pavadinimu</string>
     <string name="settings_app_name_error">Netinkamas formatas</string>
     <string name="settings_su_app_adb">Programėlės ir ADB</string>
     <string name="settings_su_app">Tik programėlės</string>

--- a/app/core/src/main/res/values-ml/strings.xml
+++ b/app/core/src/main/res/values-ml/strings.xml
@@ -142,7 +142,7 @@
     <string name="settings_hosts_summary">പരസ്യം തടയുന്ന ആപ്പുകൾക്കായി സിസ്റ്റംലെസ്സ് ഹോസ്റ്റ്</string>
     <string name="settings_hosts_toast">സിസ്റ്റംലെസ്സ് ഹോസ്റ്റ് മൊഡ്യൂൾ ചേർത്തു</string>
     <string name="settings_app_name_label_hint">പുതിയ പേര്</string>
-    <string name="settings_app_name_helper">ആപ്പ് ഈ പേരിൽ വീണ്ടും പാക്ക് ചെയ്യും</string>
+    <string name="settings_app_name_label_helper">ആപ്പ് ഈ പേരിൽ വീണ്ടും പാക്ക് ചെയ്യും</string>
     <string name="settings_app_name_error">അസാധുവായ ഫോർമാറ്റ്</string>
     <string name="settings_su_app_adb">ആപ്പുകളും ADB</string>
     <string name="settings_su_app">ആപ്പുകൾ മാത്രം</string>

--- a/app/core/src/main/res/values-ml/strings.xml
+++ b/app/core/src/main/res/values-ml/strings.xml
@@ -141,7 +141,7 @@
     <string name="settings_hosts_title">സിസ്റ്റംലെസ്സ് ഹോസ്റ്റ്</string>
     <string name="settings_hosts_summary">പരസ്യം തടയുന്ന ആപ്പുകൾക്കായി സിസ്റ്റംലെസ്സ് ഹോസ്റ്റ്</string>
     <string name="settings_hosts_toast">സിസ്റ്റംലെസ്സ് ഹോസ്റ്റ് മൊഡ്യൂൾ ചേർത്തു</string>
-    <string name="settings_app_name_hint">പുതിയ പേര്</string>
+    <string name="settings_app_name_label_hint">പുതിയ പേര്</string>
     <string name="settings_app_name_helper">ആപ്പ് ഈ പേരിൽ വീണ്ടും പാക്ക് ചെയ്യും</string>
     <string name="settings_app_name_error">അസാധുവായ ഫോർമാറ്റ്</string>
     <string name="settings_su_app_adb">ആപ്പുകളും ADB</string>

--- a/app/core/src/main/res/values-ml/strings.xml
+++ b/app/core/src/main/res/values-ml/strings.xml
@@ -122,7 +122,6 @@
     <string name="settings_download_path_title">ഡൗൺലോഡ് സ്ഥലം</string>
     <string name="settings_download_path_message">ഫയലുകൾ %1$s-ലേക്ക് സേവ് ചെയ്യപ്പെടും</string>
     <string name="settings_hide_app_title">മജിസ്‌ക് ആപ്പ് മറയ്ക്കുക</string>
-    <string name="settings_hide_app_summary">ക്രമരഹിതമായ പാക്കേജ് ഐഡിയും ഇഷ്‌ടാനുസൃത ആപ്പ് ലേബലും ഉള്ള ഒരു പ്രോക്‌സി ആപ്പ് ഇൻസ്‌റ്റാൾ ചെയ്യുക</string>
     <string name="settings_restore_app_title">മജിസ്‌ക് ആപ്പ് പുനഃസ്ഥാപിക്കുക</string>
     <string name="settings_restore_app_summary">ആപ്പ് മറച്ചത് മാറ്റി യഥാർത്ഥ APK പുനഃസ്ഥാപിക്കുക</string>
     <string name="language">ഭാഷ</string>

--- a/app/core/src/main/res/values-nb/strings.xml
+++ b/app/core/src/main/res/values-nb/strings.xml
@@ -131,7 +131,7 @@
     <string name="settings_hosts_summary">Systemløs vertsfilstøtte for reklameblokkeringsprogrammer</string>
     <string name="settings_hosts_toast">La til modul for systemløs vertsfil</string>
     <string name="settings_app_name_label_hint">Nytt navn</string>
-    <string name="settings_app_name_helper">Programmet vil bli ompakket til dette navnet</string>
+    <string name="settings_app_name_label_helper">Programmet vil bli ompakket til dette navnet</string>
     <string name="settings_app_name_error">Ugyldig format</string>
     <string name="settings_su_app_adb">Programmer og ADB</string>
     <string name="settings_su_app">Kun programmer</string>

--- a/app/core/src/main/res/values-nb/strings.xml
+++ b/app/core/src/main/res/values-nb/strings.xml
@@ -130,7 +130,7 @@
     <string name="settings_hosts_title">Systemløs vertsfil</string>
     <string name="settings_hosts_summary">Systemløs vertsfilstøtte for reklameblokkeringsprogrammer</string>
     <string name="settings_hosts_toast">La til modul for systemløs vertsfil</string>
-    <string name="settings_app_name_hint">Nytt navn</string>
+    <string name="settings_app_name_label_hint">Nytt navn</string>
     <string name="settings_app_name_helper">Programmet vil bli ompakket til dette navnet</string>
     <string name="settings_app_name_error">Ugyldig format</string>
     <string name="settings_su_app_adb">Programmer og ADB</string>

--- a/app/core/src/main/res/values-nb/strings.xml
+++ b/app/core/src/main/res/values-nb/strings.xml
@@ -116,7 +116,6 @@
     <string name="settings_download_path_title">Nedlastingssti</string>
     <string name="settings_download_path_message">Filer vil lagres i %1$s</string>
     <string name="settings_hide_app_title">Skjul Magisk-programmet</string>
-    <string name="settings_hide_app_summary">Installer et mellomtjenerprogram med tilfeldig pakke-ID og egendefinert program-etikett</string>
     <string name="settings_restore_app_title">Gjenopprett Magisk-programmet</string>
     <string name="settings_restore_app_summary">Opphev skjuling av programmet og gjenopprett det tilbake til opprinnelig APK</string>
     <string name="language">Språk</string>

--- a/app/core/src/main/res/values-nl/strings.xml
+++ b/app/core/src/main/res/values-nl/strings.xml
@@ -123,7 +123,7 @@
     <string name="settings_hosts_summary">Systeemloze hosts-ondersteuning voor advertentieblokkeringsapps.</string>
     <string name="settings_hosts_toast">De systeemloze hosts-module is toegevoegd</string>
     <string name="settings_app_name_label_hint">Nieuwe naam</string>
-    <string name="settings_app_name_helper">De app wordt opnieuw ingepakt onder deze naam</string>
+    <string name="settings_app_name_label_helper">De app wordt opnieuw ingepakt onder deze naam</string>
     <string name="settings_app_name_error">Onjuiste opmaak</string>
     <string name="settings_su_app_adb">Apps en ADB</string>
     <string name="settings_su_app">Alleen apps</string>

--- a/app/core/src/main/res/values-nl/strings.xml
+++ b/app/core/src/main/res/values-nl/strings.xml
@@ -122,7 +122,7 @@
     <string name="settings_hosts_title">Systeemloze hosts</string>
     <string name="settings_hosts_summary">Systeemloze hosts-ondersteuning voor advertentieblokkeringsapps.</string>
     <string name="settings_hosts_toast">De systeemloze hosts-module is toegevoegd</string>
-    <string name="settings_app_name_hint">Nieuwe naam</string>
+    <string name="settings_app_name_label_hint">Nieuwe naam</string>
     <string name="settings_app_name_helper">De app wordt opnieuw ingepakt onder deze naam</string>
     <string name="settings_app_name_error">Onjuiste opmaak</string>
     <string name="settings_su_app_adb">Apps en ADB</string>

--- a/app/core/src/main/res/values-pa/strings.xml
+++ b/app/core/src/main/res/values-pa/strings.xml
@@ -124,7 +124,7 @@
     <string name="settings_hosts_title">Systemless ਹੋਸਟ</string>
     <string name="settings_hosts_summary">Adblock ਐਪਸ ਲਈ Systemless ਹੋਸਟ ਦੀ ਸਹਿਯੋਗ</string>
     <string name="settings_hosts_toast">Systemless ਹੋਸਟ ਮੋਡੀਊਲ ਸ਼ਾਮਲ ਕੀਤਾ ਗਿਆ</string>
-    <string name="settings_app_name_hint">ਨਵਾਂ ਨਾਮ</string>
+    <string name="settings_app_name_label_hint">ਨਵਾਂ ਨਾਮ</string>
     <string name="settings_app_name_helper">ਇਸ ਨਾਮ ਨਾਲ ਐਪ ਦੁਬਾਰਾ ਇੰਸਟਾਲ ਕੀਤਾ ਜਾਵੇਗਾ</string>
     <string name="settings_app_name_error">ਗਲਤ ਫਾਰਮੈਟ</string>
     <string name="settings_su_app_adb">ਐਪਸ ਅਤੇ ਐਡਬੀ</string>

--- a/app/core/src/main/res/values-pa/strings.xml
+++ b/app/core/src/main/res/values-pa/strings.xml
@@ -125,7 +125,7 @@
     <string name="settings_hosts_summary">Adblock ਐਪਸ ਲਈ Systemless ਹੋਸਟ ਦੀ ਸਹਿਯੋਗ</string>
     <string name="settings_hosts_toast">Systemless ਹੋਸਟ ਮੋਡੀਊਲ ਸ਼ਾਮਲ ਕੀਤਾ ਗਿਆ</string>
     <string name="settings_app_name_label_hint">ਨਵਾਂ ਨਾਮ</string>
-    <string name="settings_app_name_helper">ਇਸ ਨਾਮ ਨਾਲ ਐਪ ਦੁਬਾਰਾ ਇੰਸਟਾਲ ਕੀਤਾ ਜਾਵੇਗਾ</string>
+    <string name="settings_app_name_label_helper">ਇਸ ਨਾਮ ਨਾਲ ਐਪ ਦੁਬਾਰਾ ਇੰਸਟਾਲ ਕੀਤਾ ਜਾਵੇਗਾ</string>
     <string name="settings_app_name_error">ਗਲਤ ਫਾਰਮੈਟ</string>
     <string name="settings_su_app_adb">ਐਪਸ ਅਤੇ ਐਡਬੀ</string>
     <string name="settings_su_app">ਸਿਰਫ ਐਪਸ</string>

--- a/app/core/src/main/res/values-pl/strings.xml
+++ b/app/core/src/main/res/values-pl/strings.xml
@@ -147,7 +147,7 @@
     <string name="settings_hosts_summary">Wsparcie hostów Systemless dla aplikacji blokujących reklamy</string>
     <string name="settings_hosts_toast">Dodano moduł hostów Systemless</string>
     <string name="settings_app_name_label_hint">Nowa nazwa</string>
-    <string name="settings_app_name_helper">Aplikacja zostanie przepakowana z tą nazwą</string>
+    <string name="settings_app_name_label_helper">Aplikacja zostanie przepakowana z tą nazwą</string>
     <string name="settings_app_name_error">Nieprawidłowy format</string>
     <string name="settings_su_app_adb">Aplikacje i ADB</string>
     <string name="settings_su_app">Tylko aplikacje</string>

--- a/app/core/src/main/res/values-pl/strings.xml
+++ b/app/core/src/main/res/values-pl/strings.xml
@@ -127,7 +127,6 @@
     <string name="settings_download_path_title">Ścieżka pobierania plików</string>
     <string name="settings_download_path_message">Pliki zostaną zapisane do %1$s</string>
     <string name="settings_hide_app_title">Ukryj aplikację Magisk</string>
-    <string name="settings_hide_app_summary">Zainstaluj aplikację proxy z losowym ID pakietu i własną etykietą</string>
     <string name="settings_restore_app_title">Przywróć aplikację Magisk</string>
     <string name="settings_restore_app_summary">Przestań ukrywać aplikację i przywróć oryginalny plik APK</string>
     <string name="language">Język</string>

--- a/app/core/src/main/res/values-pl/strings.xml
+++ b/app/core/src/main/res/values-pl/strings.xml
@@ -146,7 +146,7 @@
     <string name="settings_hosts_title">Hosty Systemless</string>
     <string name="settings_hosts_summary">Wsparcie hostów Systemless dla aplikacji blokujących reklamy</string>
     <string name="settings_hosts_toast">Dodano moduł hostów Systemless</string>
-    <string name="settings_app_name_hint">Nowa nazwa</string>
+    <string name="settings_app_name_label_hint">Nowa nazwa</string>
     <string name="settings_app_name_helper">Aplikacja zostanie przepakowana z tą nazwą</string>
     <string name="settings_app_name_error">Nieprawidłowy format</string>
     <string name="settings_su_app_adb">Aplikacje i ADB</string>

--- a/app/core/src/main/res/values-pt-rBR/strings.xml
+++ b/app/core/src/main/res/values-pt-rBR/strings.xml
@@ -145,7 +145,7 @@
     <string name="settings_hosts_summary">Suporte de hosts sem sistema para apps AdBlock</string>
     <string name="settings_hosts_toast">Adicionado módulo de hosts sem sistema</string>
     <string name="settings_app_name_label_hint">Novo nome</string>
-    <string name="settings_app_name_helper">O app do Magisk será reinstalado com este nome</string>
+    <string name="settings_app_name_label_helper">O app do Magisk será reinstalado com este nome</string>
     <string name="settings_app_name_error">Formato inválido</string>
     <string name="settings_su_app_adb">Apps e ADB</string>
     <string name="settings_su_app">Apenas apps</string>

--- a/app/core/src/main/res/values-pt-rBR/strings.xml
+++ b/app/core/src/main/res/values-pt-rBR/strings.xml
@@ -144,7 +144,7 @@
     <string name="settings_hosts_title">Hosts sem sistema</string>
     <string name="settings_hosts_summary">Suporte de hosts sem sistema para apps AdBlock</string>
     <string name="settings_hosts_toast">Adicionado módulo de hosts sem sistema</string>
-    <string name="settings_app_name_hint">Novo nome</string>
+    <string name="settings_app_name_label_hint">Novo nome</string>
     <string name="settings_app_name_helper">O app do Magisk será reinstalado com este nome</string>
     <string name="settings_app_name_error">Formato inválido</string>
     <string name="settings_su_app_adb">Apps e ADB</string>

--- a/app/core/src/main/res/values-pt-rBR/strings.xml
+++ b/app/core/src/main/res/values-pt-rBR/strings.xml
@@ -125,7 +125,6 @@
     <string name="settings_download_path_title">Caminho para baixar</string>
     <string name="settings_download_path_message">Os arquivos serão salvos em %1$s</string>
     <string name="settings_hide_app_title">Ocultar app do Magisk</string>
-    <string name="settings_hide_app_summary">Instala o app oculto com ID aleatório e nome personalizado</string>
     <string name="settings_restore_app_title">Restaurar app do Magisk</string>
     <string name="settings_restore_app_summary">Desoculta o app do Magisk e restaura o APK original</string>
     <string name="language">Idioma</string>

--- a/app/core/src/main/res/values-pt-rPT/strings.xml
+++ b/app/core/src/main/res/values-pt-rPT/strings.xml
@@ -145,7 +145,7 @@
     <string name="settings_hosts_summary">Suporte de hosts sem sistema para apps AdBlock</string>
     <string name="settings_hosts_toast">Adicionado módulo de hosts sem sistema</string>
     <string name="settings_app_name_label_hint">Novo nome</string>
-    <string name="settings_app_name_helper">O app do Magisk será reinstalado com este nome</string>
+    <string name="settings_app_name_label_helper">O app do Magisk será reinstalado com este nome</string>
     <string name="settings_app_name_error">Formato inválido</string>
     <string name="settings_su_app_adb">Apps e ADB</string>
     <string name="settings_su_app">Apenas apps</string>

--- a/app/core/src/main/res/values-pt-rPT/strings.xml
+++ b/app/core/src/main/res/values-pt-rPT/strings.xml
@@ -144,7 +144,7 @@
     <string name="settings_hosts_title">Hosts sem sistema</string>
     <string name="settings_hosts_summary">Suporte de hosts sem sistema para apps AdBlock</string>
     <string name="settings_hosts_toast">Adicionado módulo de hosts sem sistema</string>
-    <string name="settings_app_name_hint">Novo nome</string>
+    <string name="settings_app_name_label_hint">Novo nome</string>
     <string name="settings_app_name_helper">O app do Magisk será reinstalado com este nome</string>
     <string name="settings_app_name_error">Formato inválido</string>
     <string name="settings_su_app_adb">Apps e ADB</string>

--- a/app/core/src/main/res/values-pt-rPT/strings.xml
+++ b/app/core/src/main/res/values-pt-rPT/strings.xml
@@ -125,7 +125,6 @@
     <string name="settings_download_path_title">Caminho para baixar</string>
     <string name="settings_download_path_message">Os arquivos serão salvos em %1$s</string>
     <string name="settings_hide_app_title">Ocultar app do Magisk</string>
-    <string name="settings_hide_app_summary">Instala o app oculto com ID aleatório e nome personalizado</string>
     <string name="settings_restore_app_title">Restaurar app do Magisk</string>
     <string name="settings_restore_app_summary">Desoculta o app do Magisk e restaura o APK original</string>
     <string name="language">Idioma</string>

--- a/app/core/src/main/res/values-ro/strings.xml
+++ b/app/core/src/main/res/values-ro/strings.xml
@@ -147,7 +147,7 @@
     <string name="settings_hosts_title">Fișier hosts în afara partiției system</string>
     <string name="settings_hosts_summary">Suport pentru fișierul hosts în afara partiției system, în cazul aplicațiilor care blochează reclame</string>
     <string name="settings_hosts_toast">Modulul pentru fișierul hosts în afara partiției system, adăugat</string>
-    <string name="settings_app_name_hint">Nume nou</string>
+    <string name="settings_app_name_label_hint">Nume nou</string>
     <string name="settings_app_name_helper">Aplicația va fi reîmpachetată cu acest nume</string>
     <string name="settings_app_name_error">Format nevalid</string>
     <string name="settings_su_app_adb">Aplicații și ADB</string>

--- a/app/core/src/main/res/values-ro/strings.xml
+++ b/app/core/src/main/res/values-ro/strings.xml
@@ -128,7 +128,6 @@
     <string name="settings_download_path_title">Cale de descărcare</string>
     <string name="settings_download_path_message">Fișierele vor fi salvate în %1$s</string>
     <string name="settings_hide_app_title">Ascunde aplicația Magisk</string>
-    <string name="settings_hide_app_summary">Instalează o aplicație proxy cu ID aleatoriu pentru pachet și etichetă personalizată pentru aplicație</string>
     <string name="settings_restore_app_title">Restaurează aplicația Magisk</string>
     <string name="settings_restore_app_summary">Dezvăluie aplicația și restaurează APK-ul original</string>
     <string name="language">Limbă</string>

--- a/app/core/src/main/res/values-ro/strings.xml
+++ b/app/core/src/main/res/values-ro/strings.xml
@@ -148,7 +148,7 @@
     <string name="settings_hosts_summary">Suport pentru fișierul hosts în afara partiției system, în cazul aplicațiilor care blochează reclame</string>
     <string name="settings_hosts_toast">Modulul pentru fișierul hosts în afara partiției system, adăugat</string>
     <string name="settings_app_name_label_hint">Nume nou</string>
-    <string name="settings_app_name_helper">Aplicația va fi reîmpachetată cu acest nume</string>
+    <string name="settings_app_name_label_helper">Aplicația va fi reîmpachetată cu acest nume</string>
     <string name="settings_app_name_error">Format nevalid</string>
     <string name="settings_su_app_adb">Aplicații și ADB</string>
     <string name="settings_su_app">Doar aplicații</string>

--- a/app/core/src/main/res/values-ru/strings.xml
+++ b/app/core/src/main/res/values-ru/strings.xml
@@ -143,7 +143,7 @@
     <string name="settings_hosts_title">Внесистемный hosts файл</string>
     <string name="settings_hosts_summary">Поддержка внесистемного hosts файла для приложений, блокирующих рекламу</string>
     <string name="settings_hosts_toast">Модуль для внесистемного hosts файла установлен</string>
-    <string name="settings_app_name_hint">Введите имя</string>
+    <string name="settings_app_name_label_hint">Введите имя</string>
     <string name="settings_app_name_helper">Приложение будет пересобрано с этим именем</string>
     <string name="settings_app_name_error">Некорректный формат</string>
     <string name="settings_su_app_adb">Приложения и ADB</string>

--- a/app/core/src/main/res/values-ru/strings.xml
+++ b/app/core/src/main/res/values-ru/strings.xml
@@ -124,7 +124,6 @@
     <string name="settings_download_path_title">Папка для загрузок</string>
     <string name="settings_download_path_message">Файлы будут загружаться в %1$s</string>
     <string name="settings_hide_app_title">Скрытие приложения Magisk</string>
-    <string name="settings_hide_app_summary">Пересобрать приложение Magisk с другим названием и случайным именем пакета</string>
     <string name="settings_restore_app_title">Восстановление приложения Magisk</string>
     <string name="settings_restore_app_summary">Восстановить приложение Magisk к исходному состоянию</string>
     <string name="language">Язык</string>

--- a/app/core/src/main/res/values-ru/strings.xml
+++ b/app/core/src/main/res/values-ru/strings.xml
@@ -144,7 +144,7 @@
     <string name="settings_hosts_summary">Поддержка внесистемного hosts файла для приложений, блокирующих рекламу</string>
     <string name="settings_hosts_toast">Модуль для внесистемного hosts файла установлен</string>
     <string name="settings_app_name_label_hint">Введите имя</string>
-    <string name="settings_app_name_helper">Приложение будет пересобрано с этим именем</string>
+    <string name="settings_app_name_label_helper">Приложение будет пересобрано с этим именем</string>
     <string name="settings_app_name_error">Некорректный формат</string>
     <string name="settings_su_app_adb">Приложения и ADB</string>
     <string name="settings_su_app">Только приложения</string>

--- a/app/core/src/main/res/values-sk/strings.xml
+++ b/app/core/src/main/res/values-sk/strings.xml
@@ -148,7 +148,7 @@
     <string name="settings_hosts_summary">Podpora pre aplikácie na blokovanie reklamy so systemless hosts</string>
     <string name="settings_hosts_toast">Pridaný modul systemless hosts</string>
     <string name="settings_app_name_label_hint">Nový názov</string>
-    <string name="settings_app_name_helper">Aplikácia bude prebalená s týmto názvom</string>
+    <string name="settings_app_name_label_helper">Aplikácia bude prebalená s týmto názvom</string>
     <string name="settings_app_name_error">Neplatný formát</string>
     <string name="settings_su_app_adb">Aplikácie a ADB</string>
     <string name="settings_su_app">Iba aplikácie</string>

--- a/app/core/src/main/res/values-sk/strings.xml
+++ b/app/core/src/main/res/values-sk/strings.xml
@@ -147,7 +147,7 @@
     <string name="settings_hosts_title">Systemless hosts</string>
     <string name="settings_hosts_summary">Podpora pre aplikácie na blokovanie reklamy so systemless hosts</string>
     <string name="settings_hosts_toast">Pridaný modul systemless hosts</string>
-    <string name="settings_app_name_hint">Nový názov</string>
+    <string name="settings_app_name_label_hint">Nový názov</string>
     <string name="settings_app_name_helper">Aplikácia bude prebalená s týmto názvom</string>
     <string name="settings_app_name_error">Neplatný formát</string>
     <string name="settings_su_app_adb">Aplikácie a ADB</string>

--- a/app/core/src/main/res/values-sk/strings.xml
+++ b/app/core/src/main/res/values-sk/strings.xml
@@ -128,7 +128,6 @@
     <string name="settings_download_path_title">Cesta na sťahovanie</string>
     <string name="settings_download_path_message">Súbory budú uložené do %1$s</string>
     <string name="settings_hide_app_title">Skryť aplikáciu Magisk</string>
-    <string name="settings_hide_app_summary">Inštalovať proxy aplikáciu s náhodným ID balíčka a vlastným názvom aplikácie</string>
     <string name="settings_restore_app_title">Obnoviť aplikáciu Magisk</string>
     <string name="settings_restore_app_summary">Odkryť aplikáciu a obnoviť pôvodný súbor APK</string>
     <string name="language">Jazyk</string>

--- a/app/core/src/main/res/values-sq/strings.xml
+++ b/app/core/src/main/res/values-sq/strings.xml
@@ -144,7 +144,7 @@
     <string name="settings_hosts_title">Pritësit pa sistem</string>
     <string name="settings_hosts_summary">Pritësit pa sistem mbështesin aplikacionet Adblock</string>
     <string name="settings_hosts_toast">Moduli i hosteve pa sistem u shtua</string>
-    <string name="settings_app_name_hint">Emri i ri</string>
+    <string name="settings_app_name_label_hint">Emri i ri</string>
     <string name="settings_app_name_helper">Aplikacioni do të ripaketohet me këtë emër</string>
     <string name="settings_app_name_error">Format i pavlefshëm</string>
     <string name="settings_su_app_adb">Aplikacionet dhe ADB</string>

--- a/app/core/src/main/res/values-sq/strings.xml
+++ b/app/core/src/main/res/values-sq/strings.xml
@@ -1,7 +1,6 @@
 <resources>
 
     <!--Sections-->
-    <string name="modules">Modulet</string>
     <string name="superuser">Super-përdoruesi</string>
     <string name="logs">Regjistrat</string>
     <string name="settings">Cilësimet</string>
@@ -126,7 +125,6 @@
     <string name="settings_download_path_title">Vendodhje e shkarkimit</string>
     <string name="settings_download_path_message">Shkarkimet do të ruhen në %1$s</string>
     <string name="settings_hide_app_title">Fsheh aplikacionin Magisk</string>
-    <string name="settings_hide_app_summary">Instaloni një aplikacion përfaqësues me ID të paketës të rastësishme dhe etiketë të personalizuar të aplikacionitl</string>
     <string name="settings_restore_app_title">Rivendosni aplikacionin Magisk</string>
     <string name="settings_restore_app_summary">un-fsheh aplikacionin dhe riktheni atë në APK origjinale</string>
     <string name="language">Gjuha</string>

--- a/app/core/src/main/res/values-sq/strings.xml
+++ b/app/core/src/main/res/values-sq/strings.xml
@@ -145,7 +145,7 @@
     <string name="settings_hosts_summary">Pritësit pa sistem mbështesin aplikacionet Adblock</string>
     <string name="settings_hosts_toast">Moduli i hosteve pa sistem u shtua</string>
     <string name="settings_app_name_label_hint">Emri i ri</string>
-    <string name="settings_app_name_helper">Aplikacioni do të ripaketohet me këtë emër</string>
+    <string name="settings_app_name_label_helper">Aplikacioni do të ripaketohet me këtë emër</string>
     <string name="settings_app_name_error">Format i pavlefshëm</string>
     <string name="settings_su_app_adb">Aplikacionet dhe ADB</string>
     <string name="settings_su_app">Vetëm aplikacionet</string>

--- a/app/core/src/main/res/values-sv/strings.xml
+++ b/app/core/src/main/res/values-sv/strings.xml
@@ -115,7 +115,6 @@
     <string name="settings_download_path_title">Nedladdningsmapp</string>
     <string name="settings_download_path_message">Filer kommer att spara till %1$s</string>
     <string name="settings_hide_app_title">Göm Magisk-appen</string>
-    <string name="settings_hide_app_summary">Installera en proxy-app med ett slumpmässigt paket-ID och appnamn</string>
     <string name="settings_restore_app_title">Återställ Magisk-appen</string>
     <string name="settings_restore_app_summary">Ta bort proxy-appen och återställ den ursprungliga APK filen</string>
     <string name="language">Språk</string>

--- a/app/core/src/main/res/values-sv/strings.xml
+++ b/app/core/src/main/res/values-sv/strings.xml
@@ -129,7 +129,7 @@
     <string name="settings_hosts_title">Systemfri hosts</string>
     <string name="settings_hosts_summary">Stöd för Adblock-appar med systemfri hosts-fil</string>
     <string name="settings_hosts_toast">Lagt till modul för systemfri hosts-fil</string>
-    <string name="settings_app_name_hint">Nytt namn</string>
+    <string name="settings_app_name_label_hint">Nytt namn</string>
     <string name="settings_app_name_helper">Appen kommer att pacakas om till detta namn</string>
     <string name="settings_app_name_error">Ogiltigt format</string>
     <string name="settings_su_app_adb">Appar och ADB</string>

--- a/app/core/src/main/res/values-sv/strings.xml
+++ b/app/core/src/main/res/values-sv/strings.xml
@@ -130,7 +130,7 @@
     <string name="settings_hosts_summary">Stöd för Adblock-appar med systemfri hosts-fil</string>
     <string name="settings_hosts_toast">Lagt till modul för systemfri hosts-fil</string>
     <string name="settings_app_name_label_hint">Nytt namn</string>
-    <string name="settings_app_name_helper">Appen kommer att pacakas om till detta namn</string>
+    <string name="settings_app_name_label_helper">Appen kommer att pacakas om till detta namn</string>
     <string name="settings_app_name_error">Ogiltigt format</string>
     <string name="settings_su_app_adb">Appar och ADB</string>
     <string name="settings_su_app">Bara Appar</string>

--- a/app/core/src/main/res/values-sw/strings.xml
+++ b/app/core/src/main/res/values-sw/strings.xml
@@ -139,7 +139,7 @@
     <string name="settings_hosts_title">Systemless hosts</string>
     <string name="settings_hosts_summary">Systemless hosts support for ad blocking apps</string>
     <string name="settings_hosts_toast">Added systemless hosts module</string>
-    <string name="settings_app_name_hint">New name</string>
+    <string name="settings_app_name_label_hint">New name</string>
     <string name="settings_app_name_helper">App will be repackaged with this name</string>
     <string name="settings_app_name_error">Invalid format</string>
     <string name="settings_su_app_adb">Apps and ADB</string>

--- a/app/core/src/main/res/values-sw/strings.xml
+++ b/app/core/src/main/res/values-sw/strings.xml
@@ -140,7 +140,7 @@
     <string name="settings_hosts_summary">Systemless hosts support for ad blocking apps</string>
     <string name="settings_hosts_toast">Added systemless hosts module</string>
     <string name="settings_app_name_label_hint">New name</string>
-    <string name="settings_app_name_helper">App will be repackaged with this name</string>
+    <string name="settings_app_name_label_helper">App will be repackaged with this name</string>
     <string name="settings_app_name_error">Invalid format</string>
     <string name="settings_su_app_adb">Apps and ADB</string>
     <string name="settings_su_app">Apps only</string>

--- a/app/core/src/main/res/values-sw/strings.xml
+++ b/app/core/src/main/res/values-sw/strings.xml
@@ -120,7 +120,6 @@
     <string name="settings_download_path_title">Download path</string>
     <string name="settings_download_path_message">Files will be saved to %1$s</string>
     <string name="settings_hide_app_title">Hide the Magisk app</string>
-    <string name="settings_hide_app_summary">Install a proxy app with a random package ID and custom app label</string>
     <string name="settings_restore_app_title">Restore the Magisk app</string>
     <string name="settings_restore_app_summary">Unhide the app and restore the original APK</string>
     <string name="language">Language</string>

--- a/app/core/src/main/res/values-ta/strings.xml
+++ b/app/core/src/main/res/values-ta/strings.xml
@@ -130,7 +130,7 @@
     <string name="settings_hosts_title">கணினி இல்லாத ஹோஸ்ட்கள்</string>
     <string name="settings_hosts_summary">கணினி இல்லாத ஹோஸ்ட்கள் Adblock பயன்பாடுகளுக்கு ஆதரவளிக்கின்றன</string>
     <string name="settings_hosts_toast">கணினி இல்லாத ஹோஸ்ட்கள் தொகுதி சேர்க்கப்பட்டது</string>
-    <string name="settings_app_name_hint">புதிய பெயர்</string>
+    <string name="settings_app_name_label_hint">புதிய பெயர்</string>
     <string name="settings_app_name_helper">பயன்பாடு இந்த பெயருக்கு மீண்டும் தொகுக்கப்படும்</string>
     <string name="settings_app_name_error">தவறான வடிவம்</string>
     <string name="settings_su_app_adb">பயன்பாடுகள் மற்றும் ADB</string>

--- a/app/core/src/main/res/values-ta/strings.xml
+++ b/app/core/src/main/res/values-ta/strings.xml
@@ -116,7 +116,6 @@
     <string name="settings_download_path_title">பதிவிறக்க இடம்</string>
     <string name="settings_download_path_message">%1$s ல் கோப்புகள் சேமிக்கப்படும்</string>
     <string name="settings_hide_app_title">மேஜிஸ்க் செயலியை மறைக்கவும்</string>
-    <string name="settings_hide_app_summary">சீரற்ற தொகுப்பு ஐடி மற்றும் தனிப்பயன் பயன்பாட்டு லேபிளுடன் ப்ராக்ஸி பயன்பாட்டை நிறுவவும்</string>
     <string name="settings_restore_app_title">மேஜிஸ்க் பயன்பாட்டை மீட்டமை</string>
     <string name="settings_restore_app_summary">பயன்பாட்டை மறைத்து, அசல் APK க்கு மீண்டும் மீட்டமைக்கவும்</string>
     <string name="language">மொழி</string>

--- a/app/core/src/main/res/values-ta/strings.xml
+++ b/app/core/src/main/res/values-ta/strings.xml
@@ -131,7 +131,7 @@
     <string name="settings_hosts_summary">கணினி இல்லாத ஹோஸ்ட்கள் Adblock பயன்பாடுகளுக்கு ஆதரவளிக்கின்றன</string>
     <string name="settings_hosts_toast">கணினி இல்லாத ஹோஸ்ட்கள் தொகுதி சேர்க்கப்பட்டது</string>
     <string name="settings_app_name_label_hint">புதிய பெயர்</string>
-    <string name="settings_app_name_helper">பயன்பாடு இந்த பெயருக்கு மீண்டும் தொகுக்கப்படும்</string>
+    <string name="settings_app_name_label_helper">பயன்பாடு இந்த பெயருக்கு மீண்டும் தொகுக்கப்படும்</string>
     <string name="settings_app_name_error">தவறான வடிவம்</string>
     <string name="settings_su_app_adb">பயன்பாடுகள் மற்றும் ADB</string>
     <string name="settings_su_app">பயன்பாடுகள் மட்டும்</string>

--- a/app/core/src/main/res/values-tr/strings.xml
+++ b/app/core/src/main/res/values-tr/strings.xml
@@ -147,7 +147,7 @@
     <string name="settings_hosts_title">Sistemsiz ana makineler (systemless hosts)</string>
     <string name="settings_hosts_summary">Reklam engelleme uygulamaları için sistemsiz ana makineler (systemless hosts) desteği</string>
     <string name="settings_hosts_toast">Sistemsiz ana makineler (systemless hosts) modülü eklendi</string>
-    <string name="settings_app_name_hint">Yeni ad</string>
+    <string name="settings_app_name_label_hint">Yeni ad</string>
     <string name="settings_app_name_helper">Uygulama bu isimle yeniden paketlenecek</string>
     <string name="settings_app_name_error">Geçersiz format</string>
     <string name="settings_su_app_adb">Uygulamalar ve ADB</string>

--- a/app/core/src/main/res/values-tr/strings.xml
+++ b/app/core/src/main/res/values-tr/strings.xml
@@ -128,7 +128,6 @@
     <string name="settings_download_path_title">İndirme Yolu</string>
     <string name="settings_download_path_message">Dosyalar %1$s konumuna kaydedilecek</string>
     <string name="settings_hide_app_title">Magisk uygulamasını gizle</string>
-    <string name="settings_hide_app_summary">Rastgele bir paket kimliği ve özel uygulama etiketi olan bir vekil (proxy) uygulaması yükleyin</string>
     <string name="settings_restore_app_title">Magisk uygulamasını geri yükle</string>
     <string name="settings_restore_app_summary">Uygulamayı göster ve orijinal APK\'yı geri yükle</string>
     <string name="language">Dil</string>

--- a/app/core/src/main/res/values-tr/strings.xml
+++ b/app/core/src/main/res/values-tr/strings.xml
@@ -148,7 +148,7 @@
     <string name="settings_hosts_summary">Reklam engelleme uygulamaları için sistemsiz ana makineler (systemless hosts) desteği</string>
     <string name="settings_hosts_toast">Sistemsiz ana makineler (systemless hosts) modülü eklendi</string>
     <string name="settings_app_name_label_hint">Yeni ad</string>
-    <string name="settings_app_name_helper">Uygulama bu isimle yeniden paketlenecek</string>
+    <string name="settings_app_name_label_helper">Uygulama bu isimle yeniden paketlenecek</string>
     <string name="settings_app_name_error">Geçersiz format</string>
     <string name="settings_su_app_adb">Uygulamalar ve ADB</string>
     <string name="settings_su_app">Sadece Uygulamalar</string>

--- a/app/core/src/main/res/values-uk/strings.xml
+++ b/app/core/src/main/res/values-uk/strings.xml
@@ -117,7 +117,6 @@
     <string name="settings_download_path_title">Шлях завантаження</string>
     <string name="settings_download_path_message">Файли зберігатимуться в %1$s</string>
     <string name="settings_hide_app_title">Сховати застосунок Magisk</string>
-    <string name="settings_hide_app_summary">Встановити проксі-застосунок з довільним ID пакунку та назвою</string>
     <string name="settings_restore_app_title">Відновити застосунок Magisk</string>
     <string name="settings_restore_app_summary">Відновити застосунок з оригінального APK та показати його</string>
     <string name="language">Мова</string>

--- a/app/core/src/main/res/values-uk/strings.xml
+++ b/app/core/src/main/res/values-uk/strings.xml
@@ -137,7 +137,7 @@
     <string name="settings_hosts_summary">Підтримка позасистемних хостів для застосунків блокування реклами</string>
     <string name="settings_hosts_toast">Додано модуль позасистемних хостів</string>
     <string name="settings_app_name_label_hint">Нове ім\’я</string>
-    <string name="settings_app_name_helper">Застосунок буде перезібрано з цим ім\’ям</string>
+    <string name="settings_app_name_label_helper">Застосунок буде перезібрано з цим ім\’ям</string>
     <string name="settings_app_name_error">Неправильний формат</string>
     <string name="settings_su_app_adb">Застосунки і ADB</string>
     <string name="settings_su_app">Застосунки</string>

--- a/app/core/src/main/res/values-uk/strings.xml
+++ b/app/core/src/main/res/values-uk/strings.xml
@@ -136,7 +136,7 @@
     <string name="settings_hosts_title">Позасистемні хости</string>
     <string name="settings_hosts_summary">Підтримка позасистемних хостів для застосунків блокування реклами</string>
     <string name="settings_hosts_toast">Додано модуль позасистемних хостів</string>
-    <string name="settings_app_name_hint">Нове ім\’я</string>
+    <string name="settings_app_name_label_hint">Нове ім\’я</string>
     <string name="settings_app_name_helper">Застосунок буде перезібрано з цим ім\’ям</string>
     <string name="settings_app_name_error">Неправильний формат</string>
     <string name="settings_su_app_adb">Застосунки і ADB</string>

--- a/app/core/src/main/res/values-vi/strings.xml
+++ b/app/core/src/main/res/values-vi/strings.xml
@@ -122,7 +122,6 @@
     <string name="settings_download_path_title">Đường dẫn tải xuống</string>
     <string name="settings_download_path_message">Các tệp sẽ được lưu vào %1$s</string>
     <string name="settings_hide_app_title">Ẩn ứng dụng Magisk</string>
-    <string name="settings_hide_app_summary">Cài đặt ứng dụng proxy với ID gói ngẫu nhiên và nhãn ứng dụng tùy chỉnh</string>
     <string name="settings_restore_app_title">Khôi phục ứng dụng Magisk</string>
     <string name="settings_restore_app_summary">Bỏ ẩn ứng dụng và khôi phục nó về APK ban đầu</string>
     <string name="language">Ngôn ngữ</string>
@@ -142,7 +141,7 @@
     <string name="settings_hosts_title">Systemless hosts</string>
     <string name="settings_hosts_summary">Hỗ trợ systemless hosts cho các ứng dụng chặn quảng cáo</string>
     <string name="settings_hosts_toast">Đã thêm mô-đun systemless hosts</string>
-    <string name="settings_app_name_hint">Tên mới</string>
+    <string name="settings_app_name_label_hint">Tên mới</string>
     <string name="settings_app_name_helper">Ứng dụng sẽ được đóng gói lại với tên này</string>
     <string name="settings_app_name_error">Định dạng không hợp lệ</string>
     <string name="settings_su_app_adb">Ứng dụng và ADB</string>

--- a/app/core/src/main/res/values-vi/strings.xml
+++ b/app/core/src/main/res/values-vi/strings.xml
@@ -142,7 +142,7 @@
     <string name="settings_hosts_summary">Hỗ trợ systemless hosts cho các ứng dụng chặn quảng cáo</string>
     <string name="settings_hosts_toast">Đã thêm mô-đun systemless hosts</string>
     <string name="settings_app_name_label_hint">Tên mới</string>
-    <string name="settings_app_name_helper">Ứng dụng sẽ được đóng gói lại với tên này</string>
+    <string name="settings_app_name_label_helper">Ứng dụng sẽ được đóng gói lại với tên này</string>
     <string name="settings_app_name_error">Định dạng không hợp lệ</string>
     <string name="settings_su_app_adb">Ứng dụng và ADB</string>
     <string name="settings_su_app">Chỉ ứng dụng</string>

--- a/app/core/src/main/res/values-zh-rCN/strings.xml
+++ b/app/core/src/main/res/values-zh-rCN/strings.xml
@@ -129,7 +129,6 @@
     <string name="settings_download_path_title">下载路径</string>
     <string name="settings_download_path_message">文件将保存到 %1$s</string>
     <string name="settings_hide_app_title">隐藏 Magisk 应用</string>
-    <string name="settings_hide_app_summary">安装具有随机包名和自定义应用名称的代理应用</string>
     <string name="settings_restore_app_title">还原 Magisk 应用</string>
     <string name="settings_restore_app_summary">取消隐藏，恢复到原始应用</string>
     <string name="language">语言</string>

--- a/app/core/src/main/res/values-zh-rCN/strings.xml
+++ b/app/core/src/main/res/values-zh-rCN/strings.xml
@@ -148,7 +148,7 @@
     <string name="settings_hosts_title">Systemless hosts</string>
     <string name="settings_hosts_summary">为广告屏蔽应用提供 Systemless hosts 支持</string>
     <string name="settings_hosts_toast">已添加 systemless hosts 模块</string>
-    <string name="settings_app_name_hint">新的应用名称</string>
+    <string name="settings_app_name_label_hint">新的应用名称</string>
     <string name="settings_app_name_helper">将使用新名称重新安装本应用</string>
     <string name="settings_app_name_error">无效输入</string>
     <string name="settings_su_app_adb">应用和 ADB</string>

--- a/app/core/src/main/res/values-zh-rCN/strings.xml
+++ b/app/core/src/main/res/values-zh-rCN/strings.xml
@@ -149,7 +149,7 @@
     <string name="settings_hosts_summary">为广告屏蔽应用提供 Systemless hosts 支持</string>
     <string name="settings_hosts_toast">已添加 systemless hosts 模块</string>
     <string name="settings_app_name_label_hint">新的应用名称</string>
-    <string name="settings_app_name_helper">将使用新名称重新安装本应用</string>
+    <string name="settings_app_name_label_helper">将使用新名称重新安装本应用</string>
     <string name="settings_app_name_error">无效输入</string>
     <string name="settings_su_app_adb">应用和 ADB</string>
     <string name="settings_su_app">仅应用</string>

--- a/app/core/src/main/res/values-zh-rTW/strings.xml
+++ b/app/core/src/main/res/values-zh-rTW/strings.xml
@@ -143,7 +143,7 @@
     <string name="settings_hosts_title">主機（hosts）模組化</string>
     <string name="settings_hosts_summary">為廣告阻擋程式提供主機模組</string>
     <string name="settings_hosts_toast">已安裝主機模組</string>
-    <string name="settings_app_name_hint">新的名稱</string>
+    <string name="settings_app_name_label_hint">新的名稱</string>
     <string name="settings_app_name_helper">應用程式將以此名稱重新封裝</string>
     <string name="settings_app_name_error">無效的格式</string>
     <string name="settings_su_app_adb">應用程式及 ADB</string>

--- a/app/core/src/main/res/values-zh-rTW/strings.xml
+++ b/app/core/src/main/res/values-zh-rTW/strings.xml
@@ -144,7 +144,7 @@
     <string name="settings_hosts_summary">為廣告阻擋程式提供主機模組</string>
     <string name="settings_hosts_toast">已安裝主機模組</string>
     <string name="settings_app_name_label_hint">新的名稱</string>
-    <string name="settings_app_name_helper">應用程式將以此名稱重新封裝</string>
+    <string name="settings_app_name_label_helper">應用程式將以此名稱重新封裝</string>
     <string name="settings_app_name_error">無效的格式</string>
     <string name="settings_su_app_adb">應用程式及 ADB</string>
     <string name="settings_su_app">僅限應用程式</string>

--- a/app/core/src/main/res/values-zh-rTW/strings.xml
+++ b/app/core/src/main/res/values-zh-rTW/strings.xml
@@ -124,7 +124,6 @@
     <string name="settings_download_path_title">下載路徑</string>
     <string name="settings_download_path_message">檔案將被儲存在：%1$s</string>
     <string name="settings_hide_app_title">隱藏 Magisk</string>
-    <string name="settings_hide_app_summary">安裝一個隨機套件名稱和客製化應用程式名稱的代理應用程式</string>
     <string name="settings_restore_app_title">還原 Magisk</string>
     <string name="settings_restore_app_summary">取消隱藏並還原為原始套件</string>
     <string name="language">語言</string>

--- a/app/core/src/main/res/values/strings.xml
+++ b/app/core/src/main/res/values/strings.xml
@@ -150,7 +150,7 @@
     <string name="settings_hosts_summary">Systemless hosts support for ad blocking apps</string>
     <string name="settings_hosts_toast">Added systemless hosts module</string>
     <string name="settings_app_name_label_hint">New name</string>
-    <string name="settings_app_name_label_helper">Name for hidden app in your launcher</string>
+    <string name="settings_app_name_label_helper">App will be repackaged with this name</string>
     <string name="settings_app_name_pkg_hint_focused">Package Name</string>
     <string name="settings_app_name_pkg_hint">(random)</string>
     <string name="settings_app_name_pkg_helper">App will be repackaged with this package name. Leave blank to randomly generate. DO NOT use the name of another package in the system!</string>

--- a/app/core/src/main/res/values/strings.xml
+++ b/app/core/src/main/res/values/strings.xml
@@ -129,7 +129,7 @@
     <string name="settings_download_path_title">Download path</string>
     <string name="settings_download_path_message">Files will be saved to %1$s</string>
     <string name="settings_hide_app_title">Hide the Magisk app</string>
-    <string name="settings_hide_app_summary">Install a proxy app with a random package ID and custom app label</string>
+    <string name="settings_hide_app_summary">Install a proxy app with a custom package ID and app label</string>
     <string name="settings_restore_app_title">Restore the Magisk app</string>
     <string name="settings_restore_app_summary">Unhide the app and restore the original APK</string>
     <string name="language">Language</string>
@@ -149,8 +149,11 @@
     <string name="settings_hosts_title">Systemless hosts</string>
     <string name="settings_hosts_summary">Systemless hosts support for ad blocking apps</string>
     <string name="settings_hosts_toast">Added systemless hosts module</string>
-    <string name="settings_app_name_hint">New name</string>
-    <string name="settings_app_name_helper">App will be repackaged with this name</string>
+    <string name="settings_app_name_label_hint">New name</string>
+    <string name="settings_app_name_label_helper">Name for hidden app in your launcher</string>
+    <string name="settings_app_name_pkg_hint_focused">Package Name</string>
+    <string name="settings_app_name_pkg_hint">(random)</string>
+    <string name="settings_app_name_pkg_helper">App will be repackaged with this package name. Leave blank to randomly generate. DO NOT use the name of another package in the system!</string>
     <string name="settings_app_name_error">Invalid format</string>
     <string name="settings_su_app_adb">Apps and ADB</string>
     <string name="settings_su_app">Apps only</string>

--- a/app/core/src/main/res/values/strings.xml
+++ b/app/core/src/main/res/values/strings.xml
@@ -223,6 +223,10 @@
     <string name="done_action">Done running action of %1$s</string>
     <string name="failure">Failed!</string>
     <string name="hide_app_title">Hiding the Magisk app…</string>
+    <string name="hide_app_package_collision_dialog_title">Package ID Collision</string>
+    <string name="hide_app_package_collision_dialog_message">Package with ID %s already exists on system. Please choose another.</string>
+    <string name="hide_app_package_error_dialog_title">Package ID Check Failed</string>
+    <string name="hide_app_package_error_dialog_message">An error occurred when looking for packages with id %s. Please try again.</string>
     <string name="open_link_failed_toast">No app found to open the link</string>
     <string name="complete_uninstall">Complete Uninstall</string>
     <string name="restore_img">Restore Images</string>


### PR DESCRIPTION
I've encountered an instance where a root checker looking for Magisk determines that a "random" package ID like the ones used to hide the manager app are a sign of modification, and the app using the checker will refuse to work.

This PR modifies the hide app process, to allow the user to choose the package ID they want the hidden app to use, along with the custom app name. This is done by:

1. Adding a new EditText to the dialog, to allow the user to enter the package ID. If the field is left blank (the default) the hide process will use a random package ID as before
2. The new EditText has validation checks for a valid package ID
3. When the user goes to hide the app w/ a custom package ID, I check to ensure the package ID isn't already in use on the system, by quering PackageManager. If it is in use (or the check fails for some reason), an error dialog is displayed and the hide process is aborted