### PR TITLE
Run app in root mode only if root solution is Magisk

### DIFF
--- a/app/core/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/utils/ShellInit.kt
@@ -9,6 +9,7 @@ import com.topjohnwu.magisk.core.ktx.cachedFile
 import com.topjohnwu.magisk.core.ktx.deviceProtectedContext
 import com.topjohnwu.magisk.core.ktx.writeTo
 import com.topjohnwu.superuser.Shell
+import com.topjohnwu.superuser.ShellUtils.fastCmdResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import java.io.File
@@ -16,7 +17,7 @@ import java.util.jar.JarFile
 
 class ShellInit : Shell.Initializer() {
     override fun onInit(context: Context, shell: Shell): Boolean {
-        if (shell.isRoot) {
+        if (shell.isRoot && fastCmdResult(shell, "magisk")) {
             Info.isRooted = true
             RootUtils.bindTask?.let { shell.execTask(it) }
             RootUtils.bindTask = null


### PR DESCRIPTION
Current code assumes device is rooted with Magisk, so we need to enforce it or people will ask "why magisk cannot be installed with other root solutions, i have already gave it root".