### PR TITLE
core: use a new tmpfs as worker

### DIFF
--- a/native/src/init/mount.cpp
+++ b/native/src/init/mount.cpp
@@ -253,7 +253,7 @@ void MagiskInit::setup_tmp(const char *path) {
     chdir(path);
 
     // Prepare worker
-    xmount(WORKERDIR, WORKERDIR, nullptr, MS_BIND, nullptr);
+    xmount("magisk", WORKERDIR, "tmpfs", 0, "mode=755");
 
     // Use isolated devpts if kernel support
     if (access("/dev/pts/ptmx", F_OK) == 0) {


### PR DESCRIPTION
make worker dir empty
```
# ls -l /debug_ramdisk/.magisk/worker/system/bin/id
lrwxrwxrwx 1 root shell 6 2024-12-06 12:40 /debug_ramdisk/.magisk/worker/system/bin/id -> toybox
# ls -l /system/bin/id
lrwxrwxrwx 1 root shell 6 2024-12-06 12:40 /system/bin/id -> toybox
# rm /system/bin/id
rm: /system/bin/id: Read-only file system
# rm /debug_ramdisk/.magisk/worker/system/bin/id
# ls -l /system/bin/id
ls: /system/bin/id: No such file or directory
```