### PR TITLE
Support systemlessly deleting files or folders

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -124,6 +124,8 @@ If you place a file named `.replace` in any of the folders, instead of merging i
 
 If you want to replace files in `/vendor`, `/product`, or `/system_ext`, please place them under `system/vendor`, `system/product`, and `system/system_ext` respectively. Magisk will transparently handle whether these partitions are in a separate partition or not.
 
+If you want to remove a specific file or folder, please place a dummy character device with major number 0 and minor number 0 in the same path. For example, if you want to remove `/system/app/GoogleCamera`, you can `mknod GoogleCamera c 0 0` in `$MODDIR/system/app`.
+
 #### Zygisk
 
 Zygisk is a feature of Magisk that allows advanced module developers to run code directly in every Android applications' processes before they are specialized and running. For more details about the Zygisk API and building a Zygisk module, please checkout the [Zygisk Module Sample](https://github.com/topjohnwu/zygisk-module-sample) project.
@@ -212,7 +214,7 @@ set_perm_recursive <directory> <owner> <group> <dirpermission> <filepermission> 
 
 For convenience, you can also declare a list of folders you want to replace in the variable name `REPLACE`. The module installer script will create the `.replace` file into the folders listed in `REPLACE`. For example:
 
-```
+```sh
 REPLACE="
 /system/app/YouTube
 /system/app/Bloatware
@@ -220,6 +222,17 @@ REPLACE="
 ```
 
 The list above will result in the following files being created: `$MODPATH/system/app/YouTube/.replace` and `$MODPATH/system/app/Bloatware/.replace`.
+
+For convenience, you can also declare a list of files/folders you want to remove in the variable name `REMOVE`. The module installer script will create the corresponding dummy devices. For example:
+
+```sh
+REMOVE="
+/system/app/YouTube
+/system/fonts/Roboto.ttf
+"
+```
+
+The list above will result in the following dummy devices being created: `$MODPATH/system/app/YouTube` and `$MODPATH/system/fonts/Roboto.ttf`.
 
 #### Notes
 

--- a/native/src/core/module.cpp
+++ b/native/src/core/module.cpp
@@ -51,13 +51,14 @@ bool dir_node::prepare() {
     for (auto it = children.begin(); it != children.end();) {
         // We also need to upgrade to tmpfs node if any child:
         // - Target does not exist
-        // - Source or target is a symlink (since we cannot bind mount symlink)
+        // - Source or target is a symlink (since we cannot bind mount symlink) or whiteout
         bool cannot_mnt;
         if (struct stat st{}; lstat(it->second->node_path().data(), &st) != 0) {
-            cannot_mnt = true;
+            // if it's a whiteout, we don't care if the target doesn't exist
+            cannot_mnt = !it->second->is_wht();
         } else {
             it->second->set_exist(true);
-            cannot_mnt = it->second->is_lnk() || S_ISLNK(st.st_mode);
+            cannot_mnt = it->second->is_lnk() || S_ISLNK(st.st_mode) || it->second->is_wht();
         }
 
         if (cannot_mnt) {
@@ -107,6 +108,11 @@ void dir_node::collect_module_files(const char *module, int dfd) {
                 node->collect_module_files(module, dirfd(dir.get()));
             }
         } else {
+            if (struct stat st{}; entry->d_type == DT_CHR && fstatat(dirfd(dir.get()),
+                                  entry->d_name, &st, AT_SYMLINK_NOFOLLOW) == 0 && st.st_rdev == 0) {
+                // if the file is a whiteout, mark it as such
+                entry->d_type = DT_WHT;
+            }
             emplace<module_node>(entry->d_name, module, entry);
         }
     }
@@ -136,6 +142,10 @@ void node_entry::create_and_mount(const char *reason, const string &src, bool ro
 }
 
 void module_node::mount() {
+    if (is_wht()) {
+        VLOGD("delete", "null", node_path().data());
+        return;
+    }
     std::string path = module + (parent()->root()->prefix + node_path());
     string mnt_src = module_mnt + path;
     {

--- a/native/src/core/node.hpp
+++ b/native/src/core/node.hpp
@@ -37,6 +37,7 @@ public:
     bool is_dir() const { return file_type() == DT_DIR; }
     bool is_lnk() const { return file_type() == DT_LNK; }
     bool is_reg() const { return file_type() == DT_REG; }
+    bool is_wht() const { return file_type() == DT_WHT; }
     const string &name() const { return _name; }
     dir_node *parent() const { return _parent; }
 

--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -702,6 +702,11 @@ install_module() {
     mktouch $MODPATH$TARGET/.replace
   done
 
+  for TARGET in $REMOVE; do
+    ui_print "- Remove target: $TARGET"
+    mknod $MODPATH$TARGET c 0 0
+  done
+
   if $BOOTMODE; then
     # Update info for Magisk app
     mktouch /data/adb/modules/$MODID/update


### PR DESCRIPTION
After we refactor the magic mount and always mount folder as tmpfs, we can easily support deleting files or folders now. We recognize dummy devices with major number 0 and minor number 0 as an indicator for removing files and folders. This indicator is borrowed from overlayfs.