### PR TITLE
Use /metadata/watchdog as preinit dir if exists

### DIFF
--- a/native/src/base/files.cpp
+++ b/native/src/base/files.cpp
@@ -144,6 +144,8 @@ string resolve_preinit_dir(const char *base_dir) {
         dir += "/unencrypted/magisk";
     } else if (access((dir + "/adb").data(), F_OK) == 0) {
         dir += "/adb/modules";
+    } else if (access((dir + "/watchdog").data(), F_OK) == 0) {
+        dir += "/watchdog/magisk";
     } else {
         dir += "/magisk";
     }

--- a/scripts/uninstaller.sh
+++ b/scripts/uninstaller.sh
@@ -151,7 +151,7 @@ rm -rf \
 /cache/*magisk* /cache/unblock /data/*magisk* /data/cache/*magisk* /data/property/*magisk* \
 /data/Magisk.apk /data/busybox /data/custom_ramdisk_patch.sh /data/adb/*magisk* \
 /data/adb/post-fs-data.d /data/adb/service.d /data/adb/modules* \
-/data/unencrypted/magisk /metadata/magisk /persist/magisk /mnt/vendor/persist/magisk
+/data/unencrypted/magisk /metadata/magisk /metadata/watchdog/magisk /persist/magisk /mnt/vendor/persist/magisk
 
 ADDOND=/system/addon.d/99-magisk.sh
 if [ -f $ADDOND ]; then


### PR DESCRIPTION
Since Android 15, all domains are allowed to search /metadata so preinit dir will be exposed. Use /metadata/watchdog when /metadata is chosen as preinit device, and the dir is available (since Android 11).