### PR TITLE
Avoid hardcoding max fd size

### DIFF
--- a/native/src/core/zygisk/hook.cpp
+++ b/native/src/core/zygisk/hook.cpp
@@ -1,4 +1,5 @@
 #include <sys/mount.h>
+#include <sys/resource.h>
 #include <dlfcn.h>
 #include <unwind.h>
 #include <span>
@@ -217,6 +218,7 @@ DCL_HOOK_FUNC(static int, pthread_attr_destroy, void *target) {
 
 ZygiskContext::ZygiskContext(JNIEnv *env, void *args) :
     env(env), args{args}, process(nullptr), pid(-1), flags(0), info_flags(0),
+    allowed_fds([] static { rlimit r{32768, 32768}; getrlimit(RLIMIT_NOFILE, &r); return r.rlim_max; }()),
     hook_info_lock(PTHREAD_MUTEX_INITIALIZER) { g_ctx = this; }
 
 ZygiskContext::~ZygiskContext() {

--- a/native/src/core/zygisk/module.cpp
+++ b/native/src/core/zygisk/module.cpp
@@ -226,7 +226,7 @@ void ZygiskContext::sanitize_fds() {
             env->SetIntArrayRegion(
                     array, old_len, static_cast<int>(exempted_fds.size()), exempted_fds.data());
             for (int fd : exempted_fds) {
-                if (fd >= 0 && fd < MAX_FD_SIZE) {
+                if (fd >= 0 && fd < allowed_fds.size()) {
                     allowed_fds[fd] = true;
                 }
             }
@@ -239,7 +239,7 @@ void ZygiskContext::sanitize_fds() {
             int len = env->GetArrayLength(fdsToIgnore);
             for (int i = 0; i < len; ++i) {
                 int fd = arr[i];
-                if (fd >= 0 && fd < MAX_FD_SIZE) {
+                if (fd >= 0 && fd < allowed_fds.size()) {
                     allowed_fds[fd] = true;
                 }
             }
@@ -257,7 +257,7 @@ void ZygiskContext::sanitize_fds() {
     int dfd = dirfd(dir.get());
     for (dirent *entry; (entry = xreaddir(dir.get()));) {
         int fd = parse_int(entry->d_name);
-        if ((fd < 0 || fd >= MAX_FD_SIZE || !allowed_fds[fd]) && fd != dfd) {
+        if ((fd < 0 || fd >= allowed_fds.size() || !allowed_fds[fd]) && fd != dfd) {
             close(fd);
         }
     }
@@ -296,7 +296,7 @@ void ZygiskContext::fork_pre() {
     auto dir = xopen_dir("/proc/self/fd");
     for (dirent *entry; (entry = xreaddir(dir.get()));) {
         int fd = parse_int(entry->d_name);
-        if (fd < 0 || fd >= MAX_FD_SIZE) {
+        if (fd < 0 || fd >= allowed_fds.size()) {
             close(fd);
             continue;
         }

--- a/native/src/core/zygisk/module.hpp
+++ b/native/src/core/zygisk/module.hpp
@@ -224,7 +224,7 @@ enum : uint32_t {
     SKIP_CLOSE_LOG_PIPE = (1u << 5),
 };
 
-#define MAX_FD_SIZE 1024
+#define MAX_FD_SIZE 32768
 
 #define DCL_PRE_POST(name) \
 void name##_pre();         \

--- a/native/src/core/zygisk/module.hpp
+++ b/native/src/core/zygisk/module.hpp
@@ -224,8 +224,6 @@ enum : uint32_t {
     SKIP_CLOSE_LOG_PIPE = (1u << 5),
 };
 
-#define MAX_FD_SIZE 32768
-
 #define DCL_PRE_POST(name) \
 void name##_pre();         \
 void name##_post();
@@ -244,7 +242,7 @@ struct ZygiskContext {
     int pid;
     uint32_t flags;
     uint32_t info_flags;
-    std::bitset<MAX_FD_SIZE> allowed_fds;
+    std::vector<bool> allowed_fds;
     std::vector<int> exempted_fds;
 
     struct RegisterInfo {


### PR DESCRIPTION
Android changed max fd limit to 32768 since Android 9: https://github.com/aosp-mirror/platform_system_core/commit/cb5fccc83c6c757f25436884e96c318f72743ffd