### PR TITLE
Fix sterm parsing logic for ioctl

### DIFF
--- a/native/src/sepolicy/statement.rs
+++ b/native/src/sepolicy/statement.rs
@@ -96,12 +96,18 @@ fn parse_term<'a>(tokens: &mut Tokens<'a>) -> ParseResult<'a, Vec<&'a str>> {
 //     sterm ::= LB names(n) RB { n };
 fn parse_sterm<'a>(tokens: &mut Tokens<'a>) -> ParseResult<'a, Vec<&'a str>> {
     match tokens.next() {
+        Some(Token::IO) => Ok(vec!["ioctl"]),
         Some(Token::ID(name)) => Ok(vec![name]),
         Some(Token::ST) => Ok(vec![]),
         Some(Token::LB) => {
             let mut names = Some(Vec::new());
             loop {
                 match tokens.next() {
+                    Some(Token::IO) => {
+                        if let Some(ref mut names) = names {
+                            names.push("ioctl")
+                        }
+                    }
                     Some(Token::ID(name)) => {
                         if let Some(ref mut names) = names {
                             names.push(name)


### PR DESCRIPTION
Before:
```console
# cat ioctl.te                                                                                                                                            
allow hal_audio_default vendor_xdsp_device chr_file { read write getattr ioctl }
# magiskpolicy --live --apply ioctl.te                                                                                                                         
Load policy from: /sys/fs/selinux/policy
Syntax error in: "allow hal_audio_default vendor_xdsp_device chr_file { read write getattr ioctl }"
# magiskpolicy --print-rules | grep hal_audio_default | grep xdsp                                                                                       
# echo $?
1
```

After:
```console
# ./magiskpolicy --live --apply ioctl.te                                                                                                                  
Load policy from: /sys/fs/selinux/policy
# ./magiskpolicy --print-rules | grep hal_audio_default | grep xdsp                                                                                     
Load policy from: /sys/fs/selinux/policy
allow hal_audio_default vendor_xdsp_device chr_file { ioctl read write getattr }
```

Fixes #8665