### PR TITLE
Introduce post-mount stage scripts

### DIFF
--- a/docs/details.md
+++ b/docs/details.md
@@ -51,6 +51,9 @@ SECURE_DIR=/data/adb
 # Folder storing general post-fs-data scripts
 $SECURE_DIR/post-fs-data.d
 
+# Folder storing general post-mount scripts
+$SECURE_DIR/post-mount.d
+
 # Folder storing general late_start service scripts
 $SECURE_DIR/service.d
 
@@ -88,6 +91,10 @@ DATABIN=$SECURE_DIR/magisk
 ### post-fs-data
 
 This triggers on `post-fs-data` when `/data` is decrypted and mounted. The daemon `magiskd` will be launched, post-fs-data scripts are executed, and module files are magic mounted.
+
+### post-mount
+
+This triggers on `post-fs-data` but instantly after magic mount completes. In this mode, post-mount scripts are executed.
 
 ### late_start
 

--- a/native/src/core/bootstages.cpp
+++ b/native/src/core/bootstages.cpp
@@ -41,6 +41,7 @@ static bool magisk_env() {
     xmkdir(DATABIN, 0755);
     xmkdir(MODULEROOT, 0755);
     xmkdir(SECURE_DIR "/post-fs-data.d", 0755);
+    xmkdir(SECURE_DIR "/post-mount.d", 0755);
     xmkdir(SECURE_DIR "/service.d", 0755);
     restorecon();
 
@@ -180,6 +181,10 @@ bool MagiskD::post_fs_data() const noexcept {
     setup_mounts();
     handle_modules();
     load_modules();
+
+    LOGI("** post-mount mode running\n");
+    exec_common_scripts("post-mount");
+    exec_module_scripts("post-mount");
     return false;
 }
 

--- a/native/src/core/scripting.cpp
+++ b/native/src/core/scripting.cpp
@@ -63,7 +63,7 @@ if (pfs) { \
     if (timer_pid < 0) \
         continue; \
     if (int pid = waitpid(-1, nullptr, 0); pid == timer_pid) { \
-        LOGW("* post-fs-data scripts blocking phase timeout\n"); \
+        LOGW("* post-fs-data or post-mount scripts blocking phase timeout\n"); \
         timer_pid = -1; \
     } \
 }
@@ -82,6 +82,7 @@ void exec_common_scripts(const char *stage) {
     auto dir = xopen_dir(path);
     if (!dir) return;
 
+    // No need to check post-mount becasue it is not a separate stage
     bool pfs = stage == "post-fs-data"sv;
     int timer_pid = -1;
     if (pfs) {
@@ -122,7 +123,7 @@ void exec_module_scripts(const char *stage, const vector<string_view> &modules) 
     if (modules.empty())
         return;
 
-    bool pfs = stage == "post-fs-data"sv;
+    bool pfs = stage == "post-fs-data"sv || stage == "post-mount"sv;
     if (pfs) {
         timespec now{};
         clock_gettime(CLOCK_MONOTONIC, &now);

--- a/scripts/avd_magisk.sh
+++ b/scripts/avd_magisk.sh
@@ -125,6 +125,7 @@ mkdir -p $MAGISKBIN 2>/dev/null
 unzip -oj magisk.apk 'assets/*.sh' -d $MAGISKBIN
 mkdir /data/adb/modules 2>/dev/null
 mkdir /data/adb/post-fs-data.d 2>/dev/null
+mkdir /data/adb/post-mount.d 2>/dev/null
 mkdir /data/adb/service.d 2>/dev/null
 
 for file in magisk magisk32 magiskpolicy stub.apk; do

--- a/scripts/uninstaller.sh
+++ b/scripts/uninstaller.sh
@@ -150,7 +150,7 @@ ui_print "- Removing Magisk files"
 rm -rf \
 /cache/*magisk* /cache/unblock /data/*magisk* /data/cache/*magisk* /data/property/*magisk* \
 /data/Magisk.apk /data/busybox /data/custom_ramdisk_patch.sh /data/adb/*magisk* \
-/data/adb/post-fs-data.d /data/adb/service.d /data/adb/modules* \
+/data/adb/post-fs-data.d /data/adb/post-mount.d /data/adb/service.d /data/adb/modules* \
 /data/unencrypted/magisk /metadata/magisk /metadata/watchdog/magisk /persist/magisk /mnt/vendor/persist/magisk
 
 ADDOND=/system/addon.d/99-magisk.sh


### PR DESCRIPTION
Same as post-fs-data mode, only difference is that scripts run after magic mount completes. This provides a stage where scripts can be instantly executed after module mount is ready to keep a clean memory map/mount namespace for new exec.