### PR TITLE
Fix su with tty

### DIFF
--- a/native/src/core/socket.rs
+++ b/native/src/core/socket.rs
@@ -137,7 +137,11 @@ impl UnixSocketExt for UnixStream {
 
 pub fn send_fd(socket: RawFd, fd: RawFd) -> bool {
     let mut socket = ManuallyDrop::new(unsafe { UnixStream::from_raw_fd(socket) });
-    socket.send_fds(&[fd]).log().is_ok()
+    if fd < 0 {
+        socket.send_fds(&[]).log().is_ok()
+    } else {
+        socket.send_fds(&[fd]).log().is_ok()
+    }
 }
 
 pub fn send_fds(socket: RawFd, fds: &[RawFd]) -> bool {


### PR DESCRIPTION
```
emulator64_arm64:/ $ su
[core/socket.rs:140] Bad file descriptor (os error 9)
[core/socket.rs:140] Bad file descriptor (os error 9)
[core/socket.rs:140] Bad file descriptor (os error 9)
```

ref:
https://github.com/topjohnwu/Magisk/blob/15dca29a87b25a416eb4444ff7064106bd60ac0f/native/src/core/su/su.cpp#L214-L219