### PR TITLE
Fix off-by-one when calling getxattr

### DIFF
--- a/native/src/init/rootdir.rs
+++ b/native/src/init/rootdir.rs
@@ -21,7 +21,11 @@ fn get_context<const N: usize>(path: &str, con: &mut Utf8CStrBufArr<N>) -> std::
             con.capacity(),
         )
         .check_os_err()?;
-        con.set_len((sz - 1) as usize);
+        if sz > 0 && *con.as_ptr().add((sz - 1) as usize) == 0 {
+            con.set_len((sz - 1) as usize);
+        } else {
+            con.set_len(sz as usize);
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
```
[    0.923585][  T342] magiskinit: set context: /system/etc/init/hw/init.rc -> u:object_r:system_file:s
[    0.923614][  T342] SELinux:  Context u:object_r:system_file:s is not valid (left unmapped).
[    0.923617][   T79] audit: type=1400 audit(3288926.947:3): avc:  denied  { mac_admin } for  pid=342 comm="init" capability=33  scontext=u:r:kernel:s0 tcontext=u:r:kernel:s0 tclass=capability2 permissive=1
[    0.923625][  T342] magiskinit: [init\rootdir.rs:75] reset context /system/etc/init/hw/init.rc: Invalid argument (os error 22)
```