### PR TITLE
avd_magisk: support rootfs without sbin

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,3 +20,9 @@ Magisk no longer handles root hiding. There are plenty of Magisk/Zygisk modules 
 When hiding the Magisk app, it will install a "stub" APK that has nothing in it. The only functionality this stub app has is downloading the full Magisk app APK into its internal storage and dynamically loading it. Due to the fact that the APK is literally _empty_, it does not contain the image resource for the app icon.
 
 When you open the hidden Magisk app, it will offer you the option to create a shortcut in the homescreen (which has both the correct app name and icon) for your convenience. You can also manually ask the app to create the icon in app settings.
+
+### Q: How to use Magisk in the emulator?
+
+[avd_magisk.sh](../scripts/avd_magisk.sh) script can run Magisk in the emulator, Magisk will be lost after reboot, so please re-execute the script instead of tapping the reboot button.
+Only official Android Virtual Device (AVD) is supported, other emulators may work, but emulators without SELinux will never be supported.
+For more information, read the script comments.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,9 +7,10 @@ If you have USB debugging enabled in developer options, connect your phone to th
 If unfortunately you do not have USB debugging enabled you can boot using the Safe Mode key combo to cause Magisk to create an empty file named 'disable' in modules directories which disables modules when next booted with Magisk. Most modern Android devices support such a special key combo at boot to enter system Safe Mode as an emergency option, but **please note** that Magisk's key combo detection occurs _earlier_ than system detection so the key combo timing indicated by many online guides may need to be altered to activate Magisk's Safe Mode. (It's possible to activate system Safe Mode but not Magisk Safe Mode and vice versa.)
 
 The following details should ensure that modules are properly disabled:
-1) Many online guides for entering Safe Mode say 'When the animated logo appears, press and hold the volume down button until the system boots' or similar. This may actually be _too late_ for Magisk detection however and result in activating system Safe Mode but modules are not disabled.
-2) By pressing the volume down button some seconds before the animation and releasing it as soon as the boot animation appears, Magisk's Safe Mode should be activated without activating system Safe Mode (thus avoiding disabling other device and app settings) and the device should then simply boot to normal system with modules disabled.
-3) By pressing the volume down button some seconds before the animation and holding it until the system boots, both Magisk's Safe Mode and system Safe Mode should be activated. Next, after booting back to normal system, modules will be disabled.
+
+1. Many online guides for entering Safe Mode say 'When the animated logo appears, press and hold the volume down button until the system boots' or similar. This may actually be _too late_ for Magisk detection however and result in activating system Safe Mode but modules are not disabled.
+2. By pressing the volume down button some seconds before the animation and releasing it as soon as the boot animation appears, Magisk's Safe Mode should be activated without activating system Safe Mode (thus avoiding disabling other device and app settings) and the device should then simply boot to normal system with modules disabled.
+3. By pressing the volume down button some seconds before the animation and holding it until the system boots, both Magisk's Safe Mode and system Safe Mode should be activated. Next, after booting back to normal system, modules will be disabled.
 
 ### Q: Why is X app detecting root?
 
@@ -23,6 +24,6 @@ When you open the hidden Magisk app, it will offer you the option to create a sh
 
 ### Q: How to use Magisk in the emulator?
 
-[avd_magisk.sh](../scripts/avd_magisk.sh) script can run Magisk in the emulator, Magisk will be lost after reboot, so please re-execute the script instead of tapping the reboot button.
-Only official Android Virtual Device (AVD) is supported, other emulators may work, but emulators without SELinux will never be supported.
-For more information, read the script comments.
+With the emulator running and accessible via ADB, run `./build.py emulator <path to Magisk APK>` to temporarily install Magisk on to the emulator. The patch is not persistent, meaning Magisk will be lost after a reboot, so re-execute the script to emulate a reboot if required.
+
+The script is only tested on the official Android Virtual Device (AVD) shipped alongside Android Studio; other emulators may work, but the emulator must have SELinux enabled.

--- a/scripts/avd_magisk.sh
+++ b/scripts/avd_magisk.sh
@@ -93,8 +93,8 @@ if mount | grep -q rootfs; then
   # Legacy rootfs
   mount -o rw,remount /
   rm -rf /root
-  mkdir /root
-  chmod 750 /root
+  mkdir /root /sbin 2>/dev/null
+  chmod 750 /root /sbin
   ln /sbin/* /root
   mount -o ro,remount /
   mount_sbin

--- a/scripts/avd_magisk.sh
+++ b/scripts/avd_magisk.sh
@@ -4,7 +4,14 @@
 #
 # Support API level: 23 - 34
 #
-# With an emulator booted and accessible via ADB, usage:
+# Push files to AVD:
+# /data/local/tmp/magisk.apk
+# /data/local/tmp/busybox (extract from apk)
+# /data/local/tmp/avd_magisk.sh (this file)
+# Then execute, you must use non-interactive shell:
+# adb shell sh /data/local/tmp/avd_magisk.sh
+#
+# For developing Magisk, just use:
 # ./build.py emulator
 #
 # This script will stop zygote, simulate the Magisk start up process

--- a/scripts/avd_magisk.sh
+++ b/scripts/avd_magisk.sh
@@ -2,14 +2,7 @@
 #   AVD Magisk Setup
 #####################################################################
 #
-# Support API level: 23 - 34
-#
-# Push files to AVD:
-# /data/local/tmp/magisk.apk
-# /data/local/tmp/busybox (extract from apk)
-# /data/local/tmp/avd_magisk.sh (this file)
-# Then execute, you must use non-interactive shell:
-# adb shell sh /data/local/tmp/avd_magisk.sh
+# Support API level: 23 - 35
 #
 # For developing Magisk, just use:
 # ./build.py emulator

--- a/scripts/avd_patch.sh
+++ b/scripts/avd_patch.sh
@@ -2,7 +2,7 @@
 #   AVD MagiskInit Setup
 #####################################################################
 #
-# Support API level: 23 - 34
+# Support API level: 23 - 35
 #
 # With an emulator booted and accessible via ADB, usage:
 # ./build.py avd_patch path/to/booted/avd-image/ramdisk.img
@@ -18,7 +18,7 @@
 # rootfs w/o early mount: API 23 - 25
 # rootfs with early mount: API 26 - 27
 # Legacy system-as-root: API 28
-# 2 stage init: API 29 - 34
+# 2 stage init: API 29 - 35
 #####################################################################
 
 if [ ! -f /system/build.prop ]; then

--- a/scripts/avd_test.sh
+++ b/scripts/avd_test.sh
@@ -146,7 +146,7 @@ test_main() {
 
   if [ -z "$AVD_TEST_SKIP_DEBUG" ]; then
     # Patch and test debug build
-    ./build.py avd_patch -s "$ramdisk" magisk_patched.img
+    ./build.py avd_patch "$ramdisk" magisk_patched.img
     kill -INT $emu_pid
     wait $emu_pid
     test_emu debug $api
@@ -154,7 +154,7 @@ test_main() {
 
   if [ -z "$AVD_TEST_SKIP_RELEASE" ]; then
     # Patch and test release build
-    ./build.py -r avd_patch -s "$ramdisk" magisk_patched.img
+    ./build.py -r avd_patch "$ramdisk" magisk_patched.img
     kill -INT $emu_pid
     wait $emu_pid
     test_emu release $api

--- a/scripts/cuttlefish.sh
+++ b/scripts/cuttlefish.sh
@@ -84,11 +84,11 @@ test_main() {
   adb wait-for-device
 
   # Patch and test debug build
-  ./build.py avd_patch -s "$CF_HOME/init_boot.img" magisk_patched.img
+  ./build.py avd_patch "$CF_HOME/init_boot.img" magisk_patched.img
   test_cf debug
 
   # Patch and test release build
-  ./build.py -r avd_patch -s "$CF_HOME/init_boot.img" magisk_patched.img
+  ./build.py -r avd_patch "$CF_HOME/init_boot.img" magisk_patched.img
   test_cf release
 
   # Cleanup


### PR DESCRIPTION
https://github.com/topjohnwu/Magisk/pull/8630#discussion_r1972898930

This script will stop zygote and adbd, if you use
```sh
adb shell
sh /data/local/tmp/avd_magisk.sh
```
Commands after `start` will not be executed
```sh
start
$MAGISKTMP/magisk --service
# Make sure reset nb prop after zygote starts
sleep 2
$MAGISKTMP/magisk --boot-complete
```
Add general usage to let users know how to use it.