### PR TITLE
Adding additional control layer to /scripts/boot_patch.sh

### DIFF
--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -255,7 +255,7 @@ if [ -f kernel ]; then
   # keep raw kernel to avoid bootloops on some weird devices
   $PATCHEDKERNEL || rm -f kernel
   
-elif [ $RAMDISK_EXISTS -eq 1 ]; then
+elif [ $RAMDISK_EXISTS -eq 0 ]; then
   abort "! Selected boot image does not contain anything to patch"
 fi
 

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -155,6 +155,8 @@ else
     RAMDISK_EXISTS=0
 fi
 
+ui_print "- toto 1"
+
 if [ -f config.orig ]; then
   # Read existing configs
   chmod 0644 config.orig
@@ -165,6 +167,8 @@ if [ -f config.orig ]; then
   fi
   rm config.orig
 fi
+
+ui_print "- toto 2"
 
 ##################
 # Ramdisk Patches
@@ -207,6 +211,8 @@ if [ $RAMDISK_EXISTS -eq 1 ]; then
   
 fi
 
+ui_print "- toto 3"
+
 #################
 # Binary Patches
 #################
@@ -222,6 +228,8 @@ for dt in dtb kernel_dtb extra; do
     fi
   fi
 done
+
+ui_print "- toto 4"
 
 if [ -f kernel ]; then
   PATCHEDKERNEL=false
@@ -254,12 +262,16 @@ if [ -f kernel ]; then
   # If the kernel doesn't need to be patched at all,
   # keep raw kernel to avoid bootloops on some weird devices
   $PATCHEDKERNEL || rm -f kernel
+
+  ui_print "- toto 5"
   
 elif [ $RAMDISK_EXISTS -eq 1 ] then
   ui_print "- Warning"
   ui_print "- Selected boot image does not contain anything to patch"
 fi
 
+ui_print "- toto 6
+"
 #################
 # Repack & Flash
 #################
@@ -267,6 +279,8 @@ fi
 if [ $RAMDISK_EXISTS -eq 1 ]; then
   ui_print "- Repacking boot image"
   ./magiskboot repack "$BOOTIMAGE" || abort "! Unable to repack boot image"
+
+  ui_print "- toto 7"
   
   # Sign chromeos boot
   $CHROMEOS && sign_chromeos

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -152,12 +152,8 @@ else
     fi  
     ui_print "- No ramdisk file in the root directory"
     ui_print "- Skipping ramdisk patching"
-    ui_print "- coucou"
     RAMDISK_EXISTS=0
-    ui_print "- dugnou"
 fi
-ui_print "- monq"
-ui_print "- toto 1"
 
 if [ -f config.orig ]; then
   # Read existing configs
@@ -169,8 +165,6 @@ if [ -f config.orig ]; then
   fi
   rm config.orig
 fi
-
-ui_print "- toto 2"
 
 ##################
 # Ramdisk Patches
@@ -213,8 +207,6 @@ if [ $RAMDISK_EXISTS -eq 1 ]; then
   
 fi
 
-ui_print "- toto 3"
-
 #################
 # Binary Patches
 #################
@@ -230,8 +222,6 @@ for dt in dtb kernel_dtb extra; do
     fi
   fi
 done
-
-ui_print "- toto 4"
 
 if [ -f kernel ]; then
   PATCHEDKERNEL=false
@@ -267,7 +257,7 @@ if [ -f kernel ]; then
 
   ui_print "- toto 5"
   
-elif [ $RAMDISK_EXISTS -eq 1 ] then
+elif [ $RAMDISK_EXISTS -eq 1 ]; then
   ui_print "- Warning"
   ui_print "- Selected boot image does not contain anything to patch"
 fi

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -140,10 +140,10 @@ if [ -e ramdisk.cpio ]; then
     esac
 else 
   #checking if other cpio exist in the boot image
-   if find . -name "*.cpio" | grep -vF "./ramdisk.cpio" >null; then NONCOMPLIANT=1; fi #searching for any cpio file other than ./ramdisk.cpio
-   if [ $NONCOMPLIANT -eq 1 ]; then 
+   if find . -name "*.cpio" | grep -vF "./ramdisk.cpio" >null; then NOTSUPPORTED=1; fi #searching for any cpio file other than ./ramdisk.cpio
+   if [ $NOTSUPPORTED -eq 1 ]; then 
      ui_print "- Information"
-     ui_print "- This boot image contains the following unsupported cpio:"
+     ui_print "- This boot image contains the following not supported cpio:"
      find . -name "*.cpio" | grep -vF "./ramdisk.cpio" > tmp.log
      while read p; do
        ui_print "- $p"

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -152,9 +152,11 @@ else
     fi  
     ui_print "- No ramdisk file in the root directory"
     ui_print "- Skipping ramdisk patching"
+    ui_print "- coucou"
     RAMDISK_EXISTS=0
+    ui_print "- dugnou"
 fi
-
+ui_print "- monq"
 ui_print "- toto 1"
 
 if [ -f config.orig ]; then

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -118,11 +118,12 @@ else
   #checking if non compliant implementation
    if find . -name "*.cpio" | grep -vF "./ramdisk.cpio" >null; then NONCOMPLIANT=1; fi #searching for any cpio file other than ./ramdisk.cpio
    if [ $NONCOMPLIANT -eq 1 ]; then 
-     ui_print "This boot image contains the following non standard cpio:"
+     ui_print "- This boot image contains non standard cpio:"
      find . -name "*.cpio" | grep -vF "./ramdisk.cpio" | xargs ui_print
-     abort "! The selected boot image does not comply with standard boot images structure. This configuration is not supported"
+     abort "! This boot image is unsupported"
    fi  
-  ui_print "No ramdisk file found in the root directory of the boot image. Skipping ramdisk patching"
+  ui_print "- No ramdisk file in the root directory"
+  ui_print "- Skipping ramdisk patching"
   RAMDISK_EXISTS=0
 fi
 case $STATUS in
@@ -250,7 +251,8 @@ if [ -f kernel ]; then
   $PATCHEDKERNEL || rm -f kernel
   
 elif [ $RAMDISK_EXISTS -eq 1 ] then
-  ui_print "Error - The selected boot image does not contain anything to patch"
+ ui_print "- Warning"
+  ui_print "- Selected boot image does not contain anything to patch"
 fi
 
 #################

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -256,21 +256,18 @@ if [ -f kernel ]; then
   $PATCHEDKERNEL || rm -f kernel
   
 elif [ $RAMDISK_EXISTS -eq 1 ]; then
-  ui_print "- Warning"
-  ui_print "- Selected boot image does not contain anything to patch"
+  abort "! Selected boot image does not contain anything to patch"
 fi
 
 #################
 # Repack & Flash
 #################
 
-if [ $RAMDISK_EXISTS -eq 1 ]; then
-  ui_print "- Repacking boot image"
-  ./magiskboot repack "$BOOTIMAGE" || abort "! Unable to repack boot image"
+ui_print "- Repacking boot image"
+./magiskboot repack "$BOOTIMAGE" || abort "! Unable to repack boot image"
   
-  # Sign chromeos boot
-  $CHROMEOS && sign_chromeos
-fi
+# Sign chromeos boot
+$CHROMEOS && sign_chromeos
 
 # Restore the original boot partition path
 [ -e "$BOOTNAND" ] && BOOTIMAGE="$BOOTNAND"

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -150,7 +150,7 @@ else
      done <tmp.log
      rm tmp.log
     fi  
-    ui_print "- No ramdisk file in the root directory"
+    ui_print "- No ramdisk file found in the root directory"
     ui_print "- Skipping ramdisk patching"
     RAMDISK_EXISTS=0
 fi

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -142,13 +142,14 @@ else
   #checking if non compliant implementation
    if find . -name "*.cpio" | grep -vF "./ramdisk.cpio" >null; then NONCOMPLIANT=1; fi #searching for any cpio file other than ./ramdisk.cpio
    if [ $NONCOMPLIANT -eq 1 ]; then 
+     ui_print "- Information"
      ui_print "- This boot image contains non standard cpio:"
      find . -name "*.cpio" | grep -vF "./ramdisk.cpio" > tmp.log
      while read p; do
        ui_print "- $p"
      done <tmp.log
      rm tmp.log
-     abort "! This boot image is unsupported"
+     ui_print "- They are not supported and wont be processed"
     fi  
     ui_print "- No ramdisk file in the root directory"
     ui_print "- Skipping ramdisk patching"

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -225,7 +225,7 @@ done
 
 if [ -f kernel ]; then
   PATCHEDKERNEL=false
-   ui_print "! Patching kernel"
+   ui_print "- Patching kernel"
   # Remove Samsung RKP
   ./magiskboot hexpatch kernel \
   49010054011440B93FA00F71E9000054010840B93FA00F7189000054001840B91FA00F7188010054 \

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -139,17 +139,16 @@ if [ -e ramdisk.cpio ]; then
       ;;
     esac
 else 
-  #checking if non compliant implementation
+  #checking if other cpio exist in the boot image
    if find . -name "*.cpio" | grep -vF "./ramdisk.cpio" >null; then NONCOMPLIANT=1; fi #searching for any cpio file other than ./ramdisk.cpio
    if [ $NONCOMPLIANT -eq 1 ]; then 
      ui_print "- Information"
-     ui_print "- This boot image contains non standard cpio:"
+     ui_print "- This boot image contains the following unsupported cpio:"
      find . -name "*.cpio" | grep -vF "./ramdisk.cpio" > tmp.log
      while read p; do
        ui_print "- $p"
      done <tmp.log
      rm tmp.log
-     ui_print "- They are not supported and wont be processed"
     fi  
     ui_print "- No ramdisk file in the root directory"
     ui_print "- Skipping ramdisk patching"

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -225,7 +225,7 @@ done
 
 if [ -f kernel ]; then
   PATCHEDKERNEL=false
-   ui_print "Kernel file found - Patching"
+   ui_print "! Patching kernel"
   # Remove Samsung RKP
   ./magiskboot hexpatch kernel \
   49010054011440B93FA00F71E9000054010840B93FA00F7189000054001840B91FA00F7188010054 \
@@ -254,16 +254,12 @@ if [ -f kernel ]; then
   # If the kernel doesn't need to be patched at all,
   # keep raw kernel to avoid bootloops on some weird devices
   $PATCHEDKERNEL || rm -f kernel
-
-  ui_print "- toto 5"
   
 elif [ $RAMDISK_EXISTS -eq 1 ]; then
   ui_print "- Warning"
   ui_print "- Selected boot image does not contain anything to patch"
 fi
 
-ui_print "- toto 6
-"
 #################
 # Repack & Flash
 #################
@@ -271,8 +267,6 @@ ui_print "- toto 6
 if [ $RAMDISK_EXISTS -eq 1 ]; then
   ui_print "- Repacking boot image"
   ./magiskboot repack "$BOOTIMAGE" || abort "! Unable to repack boot image"
-
-  ui_print "- toto 7"
   
   # Sign chromeos boot
   $CHROMEOS && sign_chromeos

--- a/scripts/boot_patch.sh
+++ b/scripts/boot_patch.sh
@@ -119,7 +119,11 @@ else
    if find . -name "*.cpio" | grep -vF "./ramdisk.cpio" >null; then NONCOMPLIANT=1; fi #searching for any cpio file other than ./ramdisk.cpio
    if [ $NONCOMPLIANT -eq 1 ]; then 
      ui_print "- This boot image contains non standard cpio:"
-     find . -name "*.cpio" | grep -vF "./ramdisk.cpio" | xargs ui_print
+     find . -name "*.cpio" | grep -vF "./ramdisk.cpio" > tmp.log
+     while read p; do
+       ui_print "- $p"
+     done <tmp.log
+     rm tmp.log
      abort "! This boot image is unsupported"
    fi  
   ui_print "- No ramdisk file in the root directory"


### PR DESCRIPTION
Checks if: 

- a ramdisk exists before trying to unpack, patch and repack it,

- either a ramdisk or kernel is beeing processed,

-  the boot image contains additional not supported cpios (but dont process them, just inform that they exist).