### PR TITLE
feat: remove animations when it's disabled in system settings

### DIFF
--- a/app/apk/src/main/java/com/topjohnwu/magisk/arch/NavigationActivity.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/arch/NavigationActivity.kt
@@ -5,6 +5,8 @@ import androidx.databinding.ViewDataBinding
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.navOptions
+import com.topjohnwu.magisk.utils.AccessibilityUtils
 
 abstract class NavigationActivity<Binding : ViewDataBinding> : UIActivity<Binding>() {
 
@@ -32,6 +34,12 @@ abstract class NavigationActivity<Binding : ViewDataBinding> : UIActivity<Bindin
     }
 
     fun NavDirections.navigate() {
-        navigation.navigate(this)
+        if (AccessibilityUtils.isAnimationEnabled(contentResolver)) {
+            navigation.navigate(this)
+        } else {
+            navigation.navigate(this, navOptions {
+                anim { enter = 0; exit = 0; popEnter = 0; popExit = 0 }
+            })
+        }
     }
 }

--- a/app/apk/src/main/java/com/topjohnwu/magisk/arch/NavigationActivity.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/arch/NavigationActivity.kt
@@ -1,5 +1,6 @@
 package com.topjohnwu.magisk.arch
 
+import android.content.ContentResolver
 import android.view.KeyEvent
 import androidx.databinding.ViewDataBinding
 import androidx.navigation.NavController
@@ -33,13 +34,19 @@ abstract class NavigationActivity<Binding : ViewDataBinding> : UIActivity<Bindin
         }
     }
 
-    fun NavDirections.navigate() {
-        if (AccessibilityUtils.isAnimationEnabled(contentResolver)) {
-            navigation.navigate(this)
-        } else {
-            navigation.navigate(this, navOptions {
-                anim { enter = 0; exit = 0; popEnter = 0; popExit = 0 }
-            })
+    companion object {
+        fun navigate(directions: NavDirections, navigation: NavController, cr: ContentResolver) {
+            if (AccessibilityUtils.isAnimationEnabled(cr)) {
+                navigation.navigate(directions)
+            } else {
+                navigation.navigate(directions, navOptions {
+                    anim { enter = 0; exit = 0; popEnter = 0; popExit = 0 }
+                })
+            }
         }
+    }
+
+    fun NavDirections.navigate() {
+        navigate(this, navigation, contentResolver)
     }
 }

--- a/app/apk/src/main/java/com/topjohnwu/magisk/arch/NavigationActivity.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/arch/NavigationActivity.kt
@@ -39,9 +39,7 @@ abstract class NavigationActivity<Binding : ViewDataBinding> : UIActivity<Bindin
             if (AccessibilityUtils.isAnimationEnabled(cr)) {
                 navigation.navigate(directions)
             } else {
-                navigation.navigate(directions, navOptions {
-                    anim { enter = 0; exit = 0; popEnter = 0; popExit = 0 }
-                })
+                navigation.navigate(directions, navOptions {})
             }
         }
     }

--- a/app/apk/src/main/java/com/topjohnwu/magisk/ui/home/HomeFragment.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/ui/home/HomeFragment.kt
@@ -17,6 +17,8 @@ import com.topjohnwu.magisk.core.Info
 import com.topjohnwu.magisk.core.download.DownloadEngine
 import com.topjohnwu.magisk.databinding.FragmentHomeMd2Binding
 import com.topjohnwu.magisk.core.R as CoreR
+import androidx.navigation.findNavController
+import com.topjohnwu.magisk.arch.NavigationActivity
 
 class HomeFragment : BaseFragment<FragmentHomeMd2Binding>(), MenuProvider {
 
@@ -68,7 +70,13 @@ class HomeFragment : BaseFragment<FragmentHomeMd2Binding>(), MenuProvider {
     override fun onMenuItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.action_settings ->
-                HomeFragmentDirections.actionHomeFragmentToSettingsFragment().navigate()
+                activity?.let {
+                    NavigationActivity.navigate(
+                        HomeFragmentDirections.actionHomeFragmentToSettingsFragment(),
+                        it.findNavController(R.id.main_nav_host),
+                        it.contentResolver,
+                    )
+                }
             R.id.action_reboot -> activity?.let { RebootMenu.inflate(it).show() }
             else -> return super.onOptionsItemSelected(item)
         }

--- a/app/apk/src/main/java/com/topjohnwu/magisk/ui/log/LogFragment.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/ui/log/LogFragment.kt
@@ -5,6 +5,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.widget.HorizontalScrollView
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import com.topjohnwu.magisk.R
@@ -12,6 +13,7 @@ import com.topjohnwu.magisk.arch.BaseFragment
 import com.topjohnwu.magisk.arch.viewModel
 import com.topjohnwu.magisk.databinding.FragmentLogMd2Binding
 import com.topjohnwu.magisk.ui.MainActivity
+import com.topjohnwu.magisk.utils.AccessibilityUtils
 import com.topjohnwu.magisk.utils.MotionRevealHelper
 import rikka.recyclerview.addEdgeSpacing
 import rikka.recyclerview.addItemSpacing
@@ -55,6 +57,11 @@ class LogFragment : BaseFragment<FragmentLogMd2Binding>(), MenuProvider {
             addEdgeSpacing(bottom = R.dimen.l1)
             addItemSpacing(R.dimen.l1, R.dimen.l_50, R.dimen.l1)
             fixEdgeEffect()
+        }
+
+        if (!AccessibilityUtils.isAnimationEnabled(requireContext().contentResolver)) {
+            val scrollView = view.findViewById<HorizontalScrollView>(R.id.log_scroll_magisk)
+            scrollView.setOverScrollMode(View.OVER_SCROLL_NEVER)
         }
     }
 

--- a/app/apk/src/main/java/com/topjohnwu/magisk/utils/AccessibilityUtils.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/utils/AccessibilityUtils.kt
@@ -1,0 +1,14 @@
+package com.topjohnwu.magisk.utils
+
+import android.content.ContentResolver
+import android.provider.Settings
+
+class AccessibilityUtils {
+    companion object {
+        fun isAnimationEnabled(cr: ContentResolver): Boolean {
+            return !(Settings.Global.getFloat(cr, Settings.Global.ANIMATOR_DURATION_SCALE, 1.0f) == 0.0f
+                && Settings.Global.getFloat(cr, Settings.Global.TRANSITION_ANIMATION_SCALE, 1.0f) == 0.0f
+                && Settings.Global.getFloat(cr, Settings.Global.WINDOW_ANIMATION_SCALE, 1.0f) == 0.0f)
+        }
+    }
+}

--- a/app/apk/src/main/res/layout/include_log_magisk.xml
+++ b/app/apk/src/main/res/layout/include_log_magisk.xml
@@ -16,6 +16,7 @@
         android:layout_height="match_parent">
 
         <HorizontalScrollView
+            android:id="@+id/log_scroll_magisk"
             gone="@{viewModel.loading}"
             android:layout_width="match_parent"
             android:layout_height="match_parent"


### PR DESCRIPTION
This removes animations when it's disabled in system settings *Settings* -> `Accessibility` -> `Display` `Colour and Motion` -> `Experimental` `Remove animations` `Reduce movement on the screen`.

I've tried to keep the extra code surrounding this minimal. Happy to make any changes.

I would greatly appreciate if you can give this PR is a chance. UI animations make me really frustrated and gives me a headache. There's enough people who feel the same, that *Android* even has a setting for this. Thanks in advance, and thank you so much for *Magisk*.