### PR TITLE
Updated install.md to avoid the Fake Odin Release for Windows

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -80,7 +80,7 @@ Before proceeding, please acknowledge that:
 
 ### Flashing Tools
 
-- [Samsung Odin3](https://dl2018.sammobile.com/Odin.zip) (Windows only) (requires [Samsung USB Drivers](https://developer.samsung.com/android-usb-driver))
+- [Samsung Odin3](https://xdaforums.com/t/patched-odin-3-13-1.3762572/) (Windows only) (requires [Samsung USB Drivers](https://developer.samsung.com/android-usb-driver))
 - [Samsung Odin4](https://forum.xda-developers.com/t/official-samsung-odin-v4-1-2-1-dc05e3ea-for-linux.4453423/) (Linux only)
 - [Heimdall](https://www.glassechidna.com.au/heimdall/) (or [Grimler's fork](https://git.sr.ht/~grimler/Heimdall))
 


### PR DESCRIPTION
Magisk documents linked to the fake Odin Release for Windows I've updated the link to avoid the fake one

The user in XDA forums said this:
All v3.14.4 are hoax/fake versions of odin. It is version 3.14.1; same filesize (and one other variant in size, due to larger resource changes). All have internal resource modifications to report 3.14.4. Often includes a known cloud-based client-server communication dll (cpprest141_2_10.dll). I suggest that it be avoided. It adds no additional functionality over 3.14.1. See post here for more detail.