### PR TITLE
State that debug builds are available for canary version only.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ""
 
 ## READ BEFORE OPENING ISSUES
 
-All bug reports require you to **USE DEBUG BUILDS**. Please include the version name and version code in the bug report.
+All bug reports require you to **USE DEBUG BUILDS**. Debug builds are available only for the canary version, not for stable or beta versions. Please include the version name and version code in the bug report.
 
 If you experience a bootloop, attach a `dmesg` (kernel logs) when the device refuse to boot. This may very likely require a custom kernel on some devices as `last_kmsg` or `pstore ramoops` are usually not enabled by default. In addition, please also upload the result of `cat /proc/mounts` when your device is working correctly **WITHOUT MAGISK**.
 

--- a/README.MD
+++ b/README.MD
@@ -33,7 +33,7 @@ Click the icon below to download Magisk apk.
 
 ## Bug Reports
 
-**Only bug reports from Debug builds will be accepted.**
+**Only bug reports from Debug builds will be accepted.** Debug builds are available only for the canary version, not for stable or beta versions.
 
 For installation issues, upload both boot image and install logs.<br>
 For Magisk issues, upload boot logcat or dmesg.<br>


### PR DESCRIPTION
Closes #9062.