### PR TITLE
Skip symlink in restore_tmpcon()

### DIFF
--- a/native/src/core/selinux.rs
+++ b/native/src/core/selinux.rs
@@ -83,8 +83,10 @@ pub(crate) fn restore_tmpcon() -> LoggedResult<()> {
     let mut path = cstr::buf::default();
     let mut dir = Directory::open(tmp)?;
     while let Some(ref e) = dir.read()? {
-        e.resolve_path(&mut path)?;
-        path.set_secontext(SYSTEM_CON)?;
+        if !e.is_symlink() {
+            e.resolve_path(&mut path)?;
+            path.set_secontext(SYSTEM_CON)?;
+        }
     }
 
     path.clear();


### PR DESCRIPTION
If magisktmp is /sbin, there may exist files which is symlink to files in root dir. As root is RO, setcontext will fail and break iterating loop.