### PR TITLE
Ignore set_context() error if magisktmp is /sbin

### DIFF
--- a/native/src/core/selinux.rs
+++ b/native/src/core/selinux.rs
@@ -85,7 +85,7 @@ pub(crate) fn restore_tmpcon() -> LoggedResult<()> {
     while let Some(ref e) = dir.read()? {
         if !e.is_symlink() {
             e.resolve_path(&mut path)?;
-            path.set_secontext(SYSTEM_CON)?;
+            path.set_secontext(SYSTEM_CON).log_ok();
         }
     }
 


### PR DESCRIPTION
recreate_sbin() will bind mount original files in /sbin to tmpfs /sbin, so we have no choice but just log here to let the loop continue.