### PR TITLE
README note about  commonly reported issue - Zygisk on various ROMs - why it can't even be enabled sometimes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -39,6 +39,11 @@ For installation issues, upload both boot image and install logs.<br>
 For Magisk issues, upload boot logcat or dmesg.<br>
 For Magisk app crashes, record and upload the logcat when the crash occurs.
 
+## Notable Limitations
+
+Zygisk may not work for all ROMs, especially custom ROMs such as GrapheneOS (changed zygote method signature).<br>
+You might try out forks of Zygisk (but beware of their licenses and coding practices, review carefully).<br>
+
 ## Translation Contributions
 
 Default string resources for the Magisk app and its stub APK are located here:


### PR DESCRIPTION
Adding note about Zygisk not working/being enabled, since this is commonly reported issue, but is not mentioned anywhere in README, Install, FAQ (only that it may not always hide root, not about not being enabled at all, without explanation of reason or warning).

I think due to sheer amount of related issues with this it warrants note directly in README (it hopefully should save you time on the issues).

It states clear reason on why (unlike "won't implement/not planned") - based on https://github.com/topjohnwu/Magisk/issues/9116#issuecomment-2981385567 and https://github.com/topjohnwu/Magisk/issues/7489#issuecomment-1841767693