### PR TITLE
scripts: fix modules_update dir context

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -663,6 +663,7 @@ install_module() {
   # Create mod paths
   rm -rf $MODPATH
   mkdir -p $MODPATH
+  chcon u:object_r:system_file:s0 $MODPATH
 
   if is_legacy_script; then
     unzip -oj "$ZIPFILE" module.prop install.sh uninstall.sh 'common/*' -d $TMPDIR >&2


### PR DESCRIPTION
When upgrading a module, the context of the module dir inherits modules_update dir, and the modules_update dir inherits the context of /data/adb, is `adb_data_file` not `system_file`. This breaks zygisk's `getModuleDir` API: 
```
type=1400 audit(1752118695.217:112): avc: denied { read } for comm="main" path="/data/adb/modules/fontloader" dev="dm-34" ino=319522 scontext=u:r:zygote:s0 tcontext=u:object_r:adb_data_file:s0 tclass=dir permissive=0
```