### PR TITLE
Fix `set_zygisk_prop` when nb is not yet reset to the original one

### DIFF
--- a/native/src/core/zygisk/entry.cpp
+++ b/native/src/core/zygisk/entry.cpp
@@ -115,7 +115,7 @@ rust::Str get_zygisk_lib_name() {
 }
 
 void set_zygisk_prop() {
-    string native_bridge_orig = get_prop(NBPROP);
+    static string native_bridge_orig = get_prop(NBPROP);
     if (native_bridge_orig.empty()) {
         native_bridge_orig = "0";
     }


### PR DESCRIPTION
Fix test on AVD 28