### PR TITLE
Fix zygisk native bridge library name concatenation order

### DIFF
--- a/native/src/core/zygisk/daemon.rs
+++ b/native/src/core/zygisk/daemon.rs
@@ -136,7 +136,7 @@ impl ZygiskState {
         self.lib_name = if orig.is_empty() || orig == "0" {
             ZYGISKLDR.to_string()
         } else {
-            orig + ZYGISKLDR
+            ZYGISKLDR.to_string() + &orig
         };
         set_prop(NBPROP, Utf8CStr::from_string(&mut self.lib_name));
         // Whether Huawei's Maple compiler is enabled.


### PR DESCRIPTION
When migrating zygisk property handling from C++ to Rust in commit https://github.com/topjohnwu/Magisk/commit/8d10ab89f2958f398685042743d86dea1fb4e1bc, the string concatenation order was inadvertently changed from "libzygisk.so" + original_lib to original_lib + "libzygisk.so".

This caused the native bridge restoration logic in hook.cpp to extract the wrong library name, resulting in truncated library names like "lation.solibzygisk.so" instead of "libndk_translation.so".

```
❯ adb logcat  | grep zygisk
09-10 17:20:20.401    91    93 D Magisk  : resetprop: update prop [ro.dalvik.vm.native.bridge]=[libndk_translation.solibzygisk.so] by direct modification
09-10 17:20:20.408    91    93 D Magisk  : mount   : /sbin/.magisk/worker/system/lib64/libndk_translation.solibzygisk.so <- /sbin/magisk
09-10 17:20:20.889   104   104 I zygote64: option[47]=-XX:NativeBridge=libndk_translation.solibzygisk.so
09-10 17:20:20.955   105   105 I zygote  : option[46]=-XX:NativeBridge=libndk_translation.solibzygisk.so
09-10 17:20:20.988   104   104 W nativebridge: Unsupported native bridge API in libndk_translation.solibzygisk.so (is version 2 not compatible with 3)
09-10 17:20:20.989   104   104 D Magisk  : resetprop: get prop [ro.dalvik.vm.native.bridge]=[libndk_translation.solibzygisk.so]
09-10 17:20:20.989   104   104 W nativebridge: Failed to load native bridge implementation: dlopen failed: library "lation.solibzygisk.so" not found
09-10 17:20:21.018   105   105 W nativebridge: Failed to load native bridge implementation: dlopen failed: library "libndk_translation.solibzygisk.so" not found
09-10 17:20:33.633    91    93 D Magisk  : resetprop: update prop [ro.dalvik.vm.native.bridge]=[lation.solibzygisk.so] by direct modification
```