### PR TITLE
Sync libsepol with AOSP for Android 16 QPR2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, "36.0-CANARY"]
+        version: [23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, "CANARY"]
         type: [""]
         include:
-          - version: "36.0-CANARY"
+          - version: "CANARY"
             type: "google_apis_ps16k"
 
     steps:

--- a/native/src/external/Android.mk
+++ b/native/src/external/Android.mk
@@ -81,6 +81,7 @@ LOCAL_SRC_FILES := \
     selinux/libsepol/cil/src/cil_binary.c \
     selinux/libsepol/cil/src/cil_build_ast.c \
     selinux/libsepol/cil/src/cil_copy_ast.c \
+    selinux/libsepol/cil/src/cil_deny.c \
     selinux/libsepol/cil/src/cil_find.c \
     selinux/libsepol/cil/src/cil_fqn.c \
     selinux/libsepol/cil/src/cil_lexer.c \

--- a/scripts/avd.sh
+++ b/scripts/avd.sh
@@ -91,7 +91,7 @@ resolve_vars() {
     UpsideDownCakePrivacySandbox) api=34 ;;
     VanillaIceCream) api=35 ;;
     Baklava) api=36 ;;
-    36*CANARY) api=10000 ;;
+    *CANARY) api=10000 ;;
     *)
       print_error "! Unknown system image version '$ver'"
       exit 1


### PR DESCRIPTION
This makes it available to parse sepolicy database with nlmsg permissions, thus fixes https://github.com/topjohnwu/Magisk/issues/9348. https://android.googlesource.com/platform/external/selinux/+/ba7945a250c0794837f94ee1fb124426166bbc6e