### PR TITLE
util_functions: Define NVBASE to fix module compatibility

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -761,3 +761,4 @@ install_module() {
 
 TMPDIR=/dev/tmp
 MAGISKBIN="/data/adb/magisk"
+NVBASE=/data/adb


### PR DESCRIPTION
This fixes quickswitch errors on recent magisk versions.