### PR TITLE
Free regex resources in plt_hook_commit

### DIFF
--- a/native/src/core/zygisk/module.cpp
+++ b/native/src/core/zygisk/module.cpp
@@ -208,6 +208,12 @@ bool ZygiskContext::plt_hook_commit() {
     {
         mutex_guard lock(hook_info_lock);
         plt_hook_process_regex();
+        for (auto& reg: register_info) {
+            regfree(&reg.regex);
+        }
+        for (auto& ign: ignore_info) {
+            regfree(&ign.regex);
+        }
         register_info.clear();
         ignore_info.clear();
     }


### PR DESCRIPTION
Free regex resources for registered and ignored hooks before clearing the lists.