### PR TITLE
magiskboot: Avoid implicit type conversion

### DIFF
--- a/native/src/boot/bootimg.cpp
+++ b/native/src/boot/bootimg.cpp
@@ -611,7 +611,9 @@ bool boot_img::parse_image(const uint8_t *addr, FileFormat type) {
 int split_image_dtb(Utf8CStr filename, bool skip_decomp) {
     mmap_data img(filename.c_str());
 
-    if (size_t off = find_dtb_offset(img.data(), img.size()); off > 0) {
+    if (int offset = find_dtb_offset(img.data(), img.size()); offset > 0) {
+        size_t off = (size_t) offset;
+
         FileFormat fmt = check_fmt_lg(img.data(), img.size());
         if (!skip_decomp && fmt_compressed(fmt)) {
             int fd = creat(KERNEL_FILE, 0644);


### PR DESCRIPTION
Fix #9607