### PR TITLE
Fix A-only addon.d retaining PREINITDEVICE on 30300+

### DIFF
--- a/scripts/addon.d.sh
+++ b/scripts/addon.d.sh
@@ -137,7 +137,9 @@ case "$1" in
     # Back up PREINITDEVICE from existing partition before OTA on A-only devices
     if ! $backuptool_ab; then
       initialize
-      RECOVERYMODE=false
+      # Suppress ui_print for this stage
+      ui_print() { return; }
+      get_flags
       find_boot_image
       $MAGISKBIN/magiskboot unpack "$BOOTIMAGE"
       $MAGISKBIN/magiskboot cpio ramdisk.cpio "extract .backup/.magisk config.orig"


### PR DESCRIPTION
- broken after https://github.com/topjohnwu/Magisk/commit/742913ebcb10cf819a54699497359535047874f7 so use get_flags to be more futureproof