### PR TITLE
Allow reacquiring capabilities if not explicitly cleared

### DIFF
--- a/native/src/core/su/su.cpp
+++ b/native/src/core/su/su.cpp
@@ -448,7 +448,7 @@ void exec_root_shell(int client, int pid, SuRequest &req, MntNsMode mode) {
         auto f = xopen_file("/proc/self/attr/exec", "we");
         if (f) fprintf(f.get(), "%s", req.context.c_str());
     }
-    if (req.target_uid != AID_ROOT || req.drop_cap || proc_is_restricted(pid))
+    if (req.drop_cap || proc_is_restricted(pid))
         drop_caps();
     if (req.target_uid != AID_ROOT || req.gids.size() > 0)
         set_identity(req.target_uid, req.gids);


### PR DESCRIPTION
- Old behavior: Switching to a non-zero UID was implicitly interpreted as a request to drop capabilities, thereby preventing subsequent reacquisition  via `su`.
- New behavior: Switching to a non-zero UID now requires the `--drop-cap` argument to explicitly prevent the reacquisition of capabilities.