### PR TITLE
app: shell-quote module ID before run_action invocation

### DIFF
--- a/app/apk/src/main/java/com/topjohnwu/magisk/ui/module/ActionViewModel.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/ui/module/ActionViewModel.kt
@@ -24,6 +24,8 @@ import java.io.IOException
 
 class ActionViewModel : BaseViewModel() {
 
+    private fun shellQuote(arg: String): String = "'${arg.replace("'", "'\"'\"'")}'"
+
     enum class State {
         RUNNING, SUCCESS, FAILED
     }
@@ -46,7 +48,7 @@ class ActionViewModel : BaseViewModel() {
     fun startRunAction() = viewModelScope.launch {
         onResult(withContext(Dispatchers.IO) {
             try {
-                Shell.cmd("run_action \'${args.id}\'")
+                Shell.cmd("run_action ${shellQuote(args.id)}")
                     .to(outItems, logItems)
                     .exec().isSuccess
             } catch (e: IOException) {


### PR DESCRIPTION
## What this changes
This PR fixes a command-injection path in module action execution.

`ActionViewModel` currently builds a root shell command using raw module ID text:

```kotlin
Shell.cmd("run_action '${args.id}'")
```

If a module ID contains shell metacharacters (for example quotes or command separators), that string can break out of quoting and change what runs as root.

This PR adds safe shell quoting for the module ID before invoking `run_action`.

## Why this matters
- `run_action` executes in a privileged shell context.
- Module metadata should be treated as untrusted input.
- Quoting user/module-controlled values is necessary to prevent command breakout.

## Implementation
File changed:
- `app/apk/src/main/java/com/topjohnwu/magisk/ui/module/ActionViewModel.kt`

Changes:
1. Add a small helper:
   - `shellQuote(arg: String): String`
   - Escapes embedded single quotes with POSIX-safe pattern.
2. Use it at call site:
   - from: `run_action '${args.id}'`
   - to: `run_action ${shellQuote(args.id)}`

## Behavior impact
- No behavior change for normal module IDs.
- `run_action` still receives exactly one `MODID` argument.
- Special characters are now passed literally instead of being interpreted by the shell parser.

## Validation
- `./gradlew :apk:compileDebugKotlin` passes.
- Focused shell-quoting checks with crafted payloads (`'`, `$()`, backticks, separators, newline) confirmed no command execution side effects.

