### PR TITLE
scripts: harden getvar assignment against eval injection

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -61,10 +61,21 @@ grep_get_prop() {
 getvar() {
   local VARNAME=$1
   local VALUE
+  local ESCAPED
   local PROPPATH='/data/.magisk /cache/.magisk'
+
+  case "$VARNAME" in
+    ''|*[!a-zA-Z0-9_]*)
+      return 1
+      ;;
+  esac
+
   [ ! -z $MAGISKTMP ] && PROPPATH="$MAGISKTMP/.magisk/config $PROPPATH"
-  VALUE=$(grep_prop $VARNAME $PROPPATH)
-  [ ! -z $VALUE ] && eval $VARNAME=\$VALUE
+  VALUE=$(grep_prop "$VARNAME" $PROPPATH)
+  [ -z "$VALUE" ] && return 0
+
+  ESCAPED=$(printf '%s' "$VALUE" | sed "s/'/'\\\\''/g")
+  eval "$VARNAME='$ESCAPED'"
 }
 
 is_mounted() {


### PR DESCRIPTION
## Summary
Harden `getvar` in `scripts/util_functions.sh` to prevent command execution through unescaped `eval` assignment.

## Problem
Current code uses:

```sh
eval $VARNAME=\$VALUE
```

`VALUE` is sourced from property/config files. If it contains shell metacharacters or command substitution payloads, this can be interpreted by `eval`.

## Changes
File changed:
- `scripts/util_functions.sh`

In `getvar`:
1. Validate `VARNAME` as a safe shell identifier (`[A-Za-z0-9_]` only).
2. Quote `VARNAME` when reading properties.
3. Return early for empty values.
4. Escape single quotes in `VALUE` and assign via single-quoted eval payload.

## Behavior impact
- Existing dynamic variable assignment behavior is preserved.
- Invalid variable names now return failure instead of being evaluated.
- Values are assigned literally, including strings containing shell syntax.

## Validation
- Focused harness tests with crafted values (`$(...)`, quote-breakout text) confirmed no side-effect command execution.
- `./gradlew :apk:compileDebugKotlin` remains successful.

