### PR TITLE
core: shell-quote FlashZip installer paths

### DIFF
--- a/app/core/src/main/java/com/topjohnwu/magisk/core/tasks/FlashZip.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/tasks/FlashZip.kt
@@ -20,6 +20,7 @@ open class FlashZip(
     private val console: MutableList<String>,
     private val logs: MutableList<String>
 ) {
+    private fun shellQuote(arg: String): String = "'${arg.replace("'", "'\"'\"'")}'"
 
     private val installDir = File(AppContext.cacheDir, "flash")
     private lateinit var zipFile: File
@@ -46,8 +47,8 @@ open class FlashZip(
             }
         }
 
+        val binary = File(installDir, "update-binary")
         try {
-            val binary = File(installDir, "update-binary")
             AppContext.assets.open("module_installer.sh").use { it.writeTo(binary) }
         } catch (e: IOException) {
             console.add("! Unzip error")
@@ -56,7 +57,9 @@ open class FlashZip(
 
         console.add("- Installing ${mUri.displayName}")
 
-        return Shell.cmd("sh $installDir/update-binary dummy 1 \'$zipFile\'")
+        return Shell.cmd(
+            "sh ${shellQuote(binary.path)} dummy 1 ${shellQuote(zipFile.path)}"
+        )
             .to(console, logs).exec().isSuccess
     }
 


### PR DESCRIPTION
## Summary
Harden module ZIP flashing command construction by shell-quoting installer arguments.

## Problem
`FlashZip` currently executes:

```kotlin
Shell.cmd("sh $installDir/update-binary dummy 1 '$zipFile'")
```

`zipFile` can come from user-selected file paths. If a path contains shell metacharacters, command parsing can be altered in a privileged shell context.

## Changes
File changed:
- `app/core/src/main/java/com/topjohnwu/magisk/core/tasks/FlashZip.kt`

Changes made:
1. Add a local `shellQuote(arg: String)` helper (POSIX-safe single-quote escaping).
2. Use quoted arguments when building installer command for:
   - `update-binary` path
   - selected zip path

## Behavior impact
- Installer arguments and flow are unchanged functionally.
- Paths are now treated as literal values by the shell.

## Validation
- `./gradlew :apk:compileDebugKotlin` passes.

