### PR TITLE
scripts: remove eval from flash_image stream execution

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -402,12 +402,14 @@ find_boot_image() {
   fi
 }
 
-flash_image() {
-  local CMD1
+stream_image() {
   case "$1" in
-    *.gz) CMD1="gzip -d < '$1' 2>/dev/null";;
-    *)    CMD1="cat '$1'";;
+    *.gz) gzip -d < "$1" 2>/dev/null;;
+    *)    cat "$1";;
   esac
+}
+
+flash_image() {
   if [ -b "$2" ]; then
     local img_sz=$(stat -c '%s' "$1")
     local blk_sz=$(blockdev --getsize64 "$2")
@@ -415,13 +417,13 @@ flash_image() {
     blockdev --setrw "$2"
     local blk_ro=$(blockdev --getro "$2")
     [ "$blk_ro" -eq 1 ] && return 2
-    eval "$CMD1" | cat - /dev/zero > "$2" 2>/dev/null
+    stream_image "$1" | cat - /dev/zero > "$2" 2>/dev/null
   elif [ -c "$2" ]; then
     flash_eraseall "$2" >&2
-    eval "$CMD1" | nandwrite -p "$2" - >&2
+    stream_image "$1" | nandwrite -p "$2" - >&2
   else
     ui_print "- Not block or char device, storing image"
-    eval "$CMD1" > "$2" 2>/dev/null
+    stream_image "$1" > "$2" 2>/dev/null
   fi
   return 0
 }


### PR DESCRIPTION
## Summary
Harden `flash_image` by removing `eval` from image-stream command execution.

## Problem
`flash_image` currently builds a command string from path input and executes it with `eval`:

```sh
CMD1="cat '$1'"            # or gzip -d < '$1'
eval "$CMD1" | ...
```

Using `eval` on path-derived text allows shell re-parsing, which can be abused by crafted filenames containing shell metacharacters.

## Changes
File changed:
- `scripts/util_functions.sh`

Changes made:
1. Add `stream_image()` helper:
   - `*.gz` -> `gzip -d < "$1"`
   - otherwise -> `cat "$1"`
2. Replace all `eval "$CMD1"` usages in `flash_image` with direct
   `stream_image "$1"` pipelines/redirects.

## Behavior impact
- Existing functional behavior is preserved for:
  - block device targets
  - char device targets
  - regular file targets
- Only command construction is hardened (no command-string eval).

## Validation
- Focused harness with malicious filename payloads confirmed:
  - no command-breakout side effects
  - correct output content for plain and gz inputs
- `sh -n scripts/util_functions.sh` passes.
- `./gradlew :apk:compileDebugKotlin` remains successful.

