### PR TITLE
scripts: validate REPLACE/REMOVE targets under MODPATH

### DIFF
--- a/scripts/util_functions.sh
+++ b/scripts/util_functions.sh
@@ -624,6 +624,19 @@ mktouch() {
   chmod 644 $1
 }
 
+resolve_module_target() {
+  local ROOT="$1"
+  local TARGET="$2"
+  local REL="${TARGET#/}"
+
+  case "$REL" in
+    ''|/*|*'//'*) return 1;;
+    ..|../*|*/../*|*/..) return 1;;
+  esac
+
+  printf '%s/%s' "$ROOT" "$REL"
+}
+
 boot_actions() { return; }
 
 # Require ZIPFILE to be set
@@ -713,14 +726,24 @@ install_module() {
 
   # Handle replace folders
   for TARGET in $REPLACE; do
+    local TARGET_PATH
     ui_print "- Replace target: $TARGET"
-    mktouch $MODPATH$TARGET/.replace
+    TARGET_PATH=$(resolve_module_target "$MODPATH" "$TARGET") || {
+      ui_print "! Invalid replace target: $TARGET"
+      continue
+    }
+    mktouch "$TARGET_PATH/.replace"
   done
 
   for TARGET in $REMOVE; do
+    local TARGET_PATH
     ui_print "- Remove target: $TARGET"
-    mkdir -p $(dirname $MODPATH$TARGET) 2>/dev/null
-    mknod $MODPATH$TARGET c 0 0
+    TARGET_PATH=$(resolve_module_target "$MODPATH" "$TARGET") || {
+      ui_print "! Invalid remove target: $TARGET"
+      continue
+    }
+    mkdir -p "$(dirname "$TARGET_PATH")" 2>/dev/null
+    mknod "$TARGET_PATH" c 0 0
   done
 
   if $BOOTMODE; then


### PR DESCRIPTION
## Summary
Harden module installation by validating `REPLACE`/`REMOVE` targets before filesystem writes.

## Problem
`install_module()` currently appends module-provided `REPLACE`/`REMOVE` entries directly to `MODPATH`:

```sh
mktouch $MODPATH$TARGET/.replace
mknod $MODPATH$TARGET c 0 0
```

Because `TARGET` comes from module metadata/customization, traversal patterns like `../` can escape module scope and write outside the intended module directory.

## Changes
File changed:
- `scripts/util_functions.sh`

Changes made:
1. Add `resolve_module_target(ROOT, TARGET)` helper.
2. Reject invalid targets (empty, traversal segments, malformed slash forms).
3. Use resolved paths for both `REPLACE` and `REMOVE` handling.
4. Skip invalid entries with explicit installer warnings.

## Behavior impact
- Valid `REPLACE`/`REMOVE` entries continue to work normally.
- Unsafe targets are ignored rather than written outside `MODPATH`.

## Validation
- Focused harness test verified valid targets resolve under `MODPATH`, invalid traversal targets are rejected, and no outside-path artifacts are created.
- `sh -n scripts/util_functions.sh` passes.
- `./gradlew :apk:compileDebugKotlin` remains successful.

