### PR TITLE
core: fail closed when security feature checks are disabled

### DIFF
--- a/native/src/core/daemon.rs
+++ b/native/src/core/daemon.rs
@@ -173,7 +173,7 @@ impl MagiskD {
 
     #[cfg(not(feature = "check-client"))]
     fn is_client(&self, pid: i32) -> bool {
-        true
+        false
     }
 
     fn handle_requests(&'static self, mut client: UnixStream) {

--- a/native/src/core/su/daemon.rs
+++ b/native/src/core/su/daemon.rs
@@ -288,6 +288,6 @@ impl MagiskD {
 
     #[cfg(not(feature = "su-check-db"))]
     fn build_su_info(&self, uid: i32) -> Arc<SuInfo> {
-        Arc::new(SuInfo::allow(uid))
+        Arc::new(SuInfo::deny(uid))
     }
 }


### PR DESCRIPTION
## Summary
This PR changes two security-sensitive fallback paths to deny by default when compile-time checks are disabled.

## Problem
Two `#[cfg(not(feature = ...))]` branches were fail-open:
- `check-client` disabled: `is_client()` returned `true`
- `su-check-db` disabled: `build_su_info()` returned `SuInfo::allow(uid)`

If these features are excluded (accidentally or by build variation), untrusted requests can be treated as trusted and SU policy enforcement can be bypassed.

## Changes
- `native/src/core/daemon.rs`
  - `is_client()` fallback now returns `false`
- `native/src/core/su/daemon.rs`
  - `build_su_info()` fallback now returns `SuInfo::deny(uid)`

## Security impact
- Converts both fallbacks from fail-open to fail-closed.
- Prevents silent insecure behavior in builds missing these feature gates.

## Validation
- `./gradlew :apk:compileDebugKotlin` passes.
- Native `cargo check` in this environment is currently blocked by missing vendored dependency path (`native/src/external/cxx-rs`).
