### PR TITLE
Don't immediately abort on panic

### DIFF
--- a/native/src/Cargo.toml
+++ b/native/src/Cargo.toml
@@ -61,12 +61,12 @@ unwrap_used = "deny"
 [profile.dev]
 opt-level = "z"
 lto = "thin"
-panic = "immediate-abort"
+panic = "abort"
 debug = "none"
 
 [profile.release]
 opt-level = "z"
 lto = "fat"
 codegen-units = 1
-panic = "immediate-abort"
+panic = "abort"
 strip = true


### PR DESCRIPTION
This will change any panic into single brk instruction and leave no message for debug. Without this, debugging https://github.com/topjohnwu/Magisk/issues/9687 takes a few months.