### PR TITLE
Update resetprop to support --compact

### DIFF
--- a/native/src/core/resetprop/cli.rs
+++ b/native/src/core/resetprop/cli.rs
@@ -27,6 +27,8 @@ struct ResetProp {
     context: bool,
     #[argh(switch, short = 'n', long = none)]
     skip_svc: bool,
+    #[argh(switch, short = 'c', long = "compact")]
+    compact: bool,
     #[argh(option, short = 'f')]
     file: Option<Utf8CString>,
     #[argh(option, short = 'd', long = "delete")]
@@ -59,6 +61,7 @@ General flags:
    -h,--help         show this message
    -v,--verbose      print verbose output to stderr
    -w                switch to wait mode
+   -c,--compact      compact property area (optional: context label)
 
 Read mode flags:
    -p      also read persistent properties from storage
@@ -177,6 +180,16 @@ impl ResetProp {
         ret
     }
 
+    fn compact(&self) -> bool {
+        if let Some(context) = self.args.first() {
+            debug!("resetprop: compact property area [{context}]");
+            SYS_PROP.compact_context(context)
+        } else {
+            debug!("resetprop: compact property area");
+            SYS_PROP.compact()
+        }
+    }
+
     fn wait(&self) {
         let key = &self.args[0];
         let val = self.args.get(1).map(|s| &**s);
@@ -227,7 +240,11 @@ impl ResetProp {
     }
 
     fn run(self) -> LoggedResult<()> {
-        if self.wait_mode {
+        if self.compact {
+            if !self.compact() {
+                return log_err!();
+            }
+        } else if self.wait_mode {
             self.wait();
         } else if let Some(file) = &self.file {
             self.load_file(file)?;
@@ -267,6 +284,9 @@ pub fn resetprop_main(argc: i32, argv: *mut *mut c_char) -> i32 {
                     missing.missing_positional_arg("NAME");
                     missing.err_on_any()?;
                 }
+                special_mode += 1;
+            }
+            if cli.compact {
                 special_mode += 1;
             }
             if cli.file.is_some() {

--- a/native/src/core/resetprop/mod.rs
+++ b/native/src/core/resetprop/mod.rs
@@ -82,6 +82,10 @@ unsafe extern "C" {
     fn sys_prop_delete(key: CharPtr, prune: bool) -> i32;
     #[link_name = "__system_property_get_context"]
     fn sys_prop_get_context(key: CharPtr) -> CharPtr;
+    #[link_name = "__system_property_compact"]
+    fn sys_prop_compact() -> bool;
+    #[link_name = "__system_property_compact_context"]
+    fn sys_prop_compact_context(context: CharPtr) -> bool;
     #[link_name = "__system_property_area_serial2"]
     fn sys_prop_area_serial() -> u32;
 }
@@ -173,6 +177,14 @@ impl SysProp {
 
     fn get_context(&self, key: &Utf8CStr) -> &'static Utf8CStr {
         unsafe { Utf8CStr::from_ptr_unchecked(sys_prop_get_context(key.as_ptr())) }
+    }
+
+    fn compact(&self) -> bool {
+        unsafe { sys_prop_compact() }
+    }
+
+    fn compact_context(&self, context: &Utf8CStr) -> bool {
+        unsafe { sys_prop_compact_context(context.as_ptr()) }
     }
 
     fn area_serial(&self) -> u32 {


### PR DESCRIPTION
This allows compacting property area to remove holes after deleting prop. Usage:

`resetprop --compact`
`resetprop -c`
`resetprop -c u:object_r:ab_update_gki_prop:s0`
