### PR TITLE
fix: nine instances of unsafe sprintf calls in selin... in policydb.cpp

### DIFF
--- a/native/src/sepolicy/policydb.cpp
+++ b/native/src/sepolicy/policydb.cpp
@@ -41,7 +41,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = PLAT_POLICY_DIR "plat_and_mapping_sepolicy.cil.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.plat_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.plat_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha))
             return false;
     }
@@ -49,7 +49,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = PLAT_POLICY_DIR "plat_sepolicy_and_mapping.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.plat_sepolicy_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.plat_sepolicy_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha))
             return false;
     }
@@ -57,7 +57,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = PROD_POLICY_DIR "product_sepolicy_and_mapping.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.product_sepolicy_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.product_sepolicy_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha) != 0)
             return false;
     }
@@ -65,7 +65,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = SYSEXT_POLICY_DIR "system_ext_sepolicy_and_mapping.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.system_ext_sepolicy_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.system_ext_sepolicy_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha) != 0)
             return false;
     }
@@ -160,19 +160,19 @@ SePolicy SePolicy::compile_split() noexcept {
     // plat
     load_cil(db, SPLIT_PLAT_CIL);
 
-    sprintf(path, PLAT_POLICY_DIR "mapping/%s.cil", plat_ver);
+    snprintf(path, sizeof(path), PLAT_POLICY_DIR "mapping/%s.cil", plat_ver);
     load_cil(db, path);
 
-    sprintf(path, PLAT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
+    snprintf(path, sizeof(path), PLAT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 
     // system_ext
-    sprintf(path, SYSEXT_POLICY_DIR "mapping/%s.cil", plat_ver);
+    snprintf(path, sizeof(path), SYSEXT_POLICY_DIR "mapping/%s.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 
-    sprintf(path, SYSEXT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
+    snprintf(path, sizeof(path), SYSEXT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 
@@ -181,7 +181,7 @@ SePolicy SePolicy::compile_split() noexcept {
         load_cil(db, cil_file);
 
     // product
-    sprintf(path, PROD_POLICY_DIR "mapping/%s.cil", plat_ver);
+    snprintf(path, sizeof(path), PROD_POLICY_DIR "mapping/%s.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `native/src/sepolicy/policydb.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `native/src/sepolicy/policydb.cpp:44` |
| **CWE** | CWE-120 |

**Description**: Nine instances of unsafe sprintf calls in SELinux policy compilation code perform unbounded string formatting without buffer size validation. The sprintf function writes formatted strings to fixed-size buffers (compiled_sha and path) without checking if the source strings (precompiled and plat_ver) will fit. When these parameters contain excessively long strings, sprintf writes beyond buffer boundaries, causing stack-based buffer overflow that overwrites adjacent memory including return addresses and local variables.

## Changes
- `native/src/sepolicy/policydb.cpp`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
