### PR TITLE
manager: extend versionCode to Long to exceed Int.MAX

### DIFF
--- a/app/core/src/main/java/com/topjohnwu/magisk/core/model/UpdateInfo.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/model/UpdateInfo.kt
@@ -26,7 +26,7 @@ data class UpdateInfo(
 @JsonClass(generateAdapter = true)
 data class ModuleJson(
     val version: String,
-    val versionCode: Int,
+    val versionCode: Long,
     val zipUrl: String,
     val changelog: String,
 )

--- a/app/core/src/main/java/com/topjohnwu/magisk/core/model/module/LocalModule.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/model/module/LocalModule.kt
@@ -20,7 +20,7 @@ data class LocalModule(
     override var id: String = ""
     override var name: String = ""
     override var version: String = ""
-    override var versionCode: Int = -1
+    override var versionCode: Long = -1L
     var author: String = ""
     var description: String = ""
     var updateInfo: OnlineModule? = null
@@ -79,7 +79,7 @@ data class LocalModule(
                 "id" -> id = value
                 "name" -> name = value
                 "version" -> version = value
-                "versionCode" -> versionCode = value.toInt()
+                "versionCode" -> versionCode = value.toLong()
                 "author" -> author = value
                 "description" -> description = value
                 "updateJson" -> updateUrl = value

--- a/app/core/src/main/java/com/topjohnwu/magisk/core/model/module/Module.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/model/module/Module.kt
@@ -7,7 +7,7 @@ abstract class Module : Comparable<Module> {
         protected set
     abstract var version: String
         protected set
-    abstract var versionCode: Int
+    abstract var versionCode: Long
         protected set
 
     override operator fun compareTo(other: Module) = id.compareTo(other.id)

--- a/app/core/src/main/java/com/topjohnwu/magisk/core/model/module/OnlineModule.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/model/module/OnlineModule.kt
@@ -9,7 +9,7 @@ data class OnlineModule(
     override var id: String,
     override var name: String,
     override var version: String,
-    override var versionCode: Int,
+    override var versionCode: Long,
     val zipUrl: String,
     val changelog: String,
 ) : Module(), Parcelable {

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -84,7 +84,7 @@ This is the **strict** format of `module.prop`
 id=<string>
 name=<string>
 version=<string>
-versionCode=<int>
+versionCode=<long>
 author=<string>
 description=<string>
 updateJson=<url> (optional)
@@ -103,7 +103,7 @@ Update JSON format:
 ```
 {
     "version": string,
-    "versionCode": int,
+    "versionCode": long,
     "zipUrl": url,
     "changelog": url
 }


### PR DESCRIPTION
Fixed an issue where versionCode would get stuck at 2147483647. Updated data type to Long to support larger version numbers. Some modules call multiple parameters for versionCode, causing it to reach 10 digits, which may cause issues on Android 21+. Please check for any omissions.