### PR TITLE
app: reset install method when file picker or download dialog is cancelled

### DIFF
--- a/app/apk/src/main/java/com/topjohnwu/magisk/dialog/DownloadDialog.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/dialog/DownloadDialog.kt
@@ -8,7 +8,10 @@ import com.topjohnwu.magisk.core.R
 import com.topjohnwu.magisk.events.DialogBuilder
 import com.topjohnwu.magisk.view.MagiskDialog
 
-class DownloadDialog(private val callback: (Uri) -> Unit) : DialogBuilder {
+class DownloadDialog(
+    private val callback: (Uri) -> Unit,
+    private val onCancel: (() -> Unit)? = null,
+) : DialogBuilder {
 
     override fun build(dialog: MagiskDialog) {
         val editText = EditText(dialog.context).apply {
@@ -16,6 +19,8 @@ class DownloadDialog(private val callback: (Uri) -> Unit) : DialogBuilder {
             hint = context.getString(R.string.download_dialog_msg)
             requestFocus()
         }
+
+        var confirmed = false
 
         dialog.apply {
             setTitle(R.string.download_dialog_title)
@@ -26,6 +31,7 @@ class DownloadDialog(private val callback: (Uri) -> Unit) : DialogBuilder {
                     val url = editText.text.toString().trim()
                     isValidUrl(url)?.let {
                         doNotDismiss = false
+                        confirmed = true
                         callback(it)
                     } ?: run {
                         doNotDismiss = true
@@ -37,6 +43,9 @@ class DownloadDialog(private val callback: (Uri) -> Unit) : DialogBuilder {
                 text = android.R.string.cancel
             }
             setCancelable(true)
+            setOnDismissListener {
+                if (!confirmed) onCancel?.invoke()
+            }
         }
     }
 

--- a/app/apk/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -94,8 +94,11 @@ class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() 
         when (source) {
             is PatchSource.File -> _uri.value = source.uri
             PatchSource.Cancelled -> resetMethod()
-            null -> Unit
+            null -> return@Observer
         }
+        // Consume the result so a later VM instance doesn't replay a stale
+        // selection/cancel from a previous session.
+        patchSource.value = null
     }
 
     @get:Bindable

--- a/app/apk/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -9,6 +9,7 @@ import android.widget.Toast
 import androidx.databinding.Bindable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
 import androidx.lifecycle.viewModelScope
 import com.topjohnwu.magisk.BR
 import com.topjohnwu.magisk.R
@@ -46,17 +47,29 @@ class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() 
         set(value) = set(value, field, { field = it }, BR.step)
 
     private var methodId = -1
+    // RadioGroup fires its OnCheckedChangeListener with the previously-checked id
+    // right before firing it with -1 when we clear the selection programmatically.
+    // Track the id we expect to see in that spurious callback so the setter's
+    // side-effect lambda can ignore it.
+    private var spuriousMethodId = -1
 
     @get:Bindable
     var method
         get() = methodId
         set(value) = set(value, methodId, { methodId = it }, BR.method) {
+            if (it == spuriousMethodId) {
+                spuriousMethodId = -1
+                return@set
+            }
             when (it) {
                 R.id.method_patch -> {
                     GetContentEvent("*/*", UriCallback()).publish()
                 }
                 R.id.method_download -> {
-                    DownloadDialog { url -> uri.value = url }.show()
+                    DownloadDialog(
+                        callback = { url -> _uri.value = url },
+                        onCancel = { resetMethod() },
+                    ).show()
                 }
                 R.id.method_inactive_slot -> {
                     SecondSlotWarningDialog().show()
@@ -64,13 +77,33 @@ class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() 
             }
         }
 
-    val data: LiveData<Uri?> get() = uri
+    private fun resetMethod() {
+        spuriousMethodId = methodId
+        method = -1
+    }
+
+    private val _uri = MutableLiveData<Uri?>()
+    val data: LiveData<Uri?> get() = _uri
+
+    // UriCallback is @Parcelize'd and may outlive any single ViewModel instance
+    // (it's restored from saved state after process death), so we route its
+    // results through the static `patchSource` and observe it here. This keeps
+    // the cross-instance coupling behind a single LiveData instead of a raw
+    // companion-object lambda.
+    private val sourceObserver = Observer<PatchSource?> { source ->
+        when (source) {
+            is PatchSource.File -> _uri.value = source.uri
+            PatchSource.Cancelled -> resetMethod()
+            null -> Unit
+        }
+    }
 
     @get:Bindable
     var notes: Spanned = SpannedString("")
         set(value) = set(value, field, { field = it }, BR.notes)
 
     init {
+        patchSource.observeForever(sourceObserver)
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val noteFile = File(AppContext.cacheDir, "${APP_VERSION_CODE}.md")
@@ -125,6 +158,16 @@ class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() 
         }
     }
 
+    override fun onCleared() {
+        patchSource.removeObserver(sourceObserver)
+        super.onCleared()
+    }
+
+    private sealed interface PatchSource {
+        data class File(val uri: Uri) : PatchSource
+        data object Cancelled : PatchSource
+    }
+
     @Parcelize
     class UriCallback : ContentResultCallback {
         override fun onActivityLaunch() {
@@ -132,7 +175,11 @@ class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() 
         }
 
         override fun onActivityResult(result: Uri) {
-            uri.value = result
+            patchSource.value = PatchSource.File(result)
+        }
+
+        override fun onActivityCancel() {
+            patchSource.value = PatchSource.Cancelled
         }
     }
 
@@ -147,6 +194,6 @@ class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() 
 
     companion object {
         private const val INSTALL_STATE_KEY = "install_state"
-        private val uri = MutableLiveData<Uri?>()
+        private val patchSource = MutableLiveData<PatchSource?>()
     }
 }

--- a/app/apk/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
+++ b/app/apk/src/main/java/com/topjohnwu/magisk/ui/install/InstallViewModel.kt
@@ -47,10 +47,6 @@ class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() 
         set(value) = set(value, field, { field = it }, BR.step)
 
     private var methodId = -1
-    // RadioGroup fires its OnCheckedChangeListener with the previously-checked id
-    // right before firing it with -1 when we clear the selection programmatically.
-    // Track the id we expect to see in that spurious callback so the setter's
-    // side-effect lambda can ignore it.
     private var spuriousMethodId = -1
 
     @get:Bindable
@@ -85,19 +81,12 @@ class InstallViewModel(svc: NetworkService, markwon: Markwon) : BaseViewModel() 
     private val _uri = MutableLiveData<Uri?>()
     val data: LiveData<Uri?> get() = _uri
 
-    // UriCallback is @Parcelize'd and may outlive any single ViewModel instance
-    // (it's restored from saved state after process death), so we route its
-    // results through the static `patchSource` and observe it here. This keeps
-    // the cross-instance coupling behind a single LiveData instead of a raw
-    // companion-object lambda.
     private val sourceObserver = Observer<PatchSource?> { source ->
         when (source) {
             is PatchSource.File -> _uri.value = source.uri
             PatchSource.Cancelled -> resetMethod()
             null -> return@Observer
         }
-        // Consume the result so a later VM instance doesn't replay a stale
-        // selection/cancel from a previous session.
         patchSource.value = null
     }
 

--- a/app/core/src/main/java/com/topjohnwu/magisk/core/base/BaseActivity.kt
+++ b/app/core/src/main/java/com/topjohnwu/magisk/core/base/BaseActivity.kt
@@ -23,6 +23,7 @@ import com.topjohnwu.magisk.core.utils.RequestInstall
 
 interface ContentResultCallback: ActivityResultCallback<Uri>, Parcelable {
     fun onActivityLaunch() {}
+    fun onActivityCancel() {}
     // Make the result type explicitly non-null
     override fun onActivityResult(result: Uri)
 }
@@ -65,6 +66,7 @@ class ActivityExtension(private val activity: ComponentActivity) {
     private var contentCallback: ContentResultCallback? = null
     private val getContent = activity.registerForActivityResult(GetContent()) {
         if (it != null) contentCallback?.onActivityResult(it)
+        else contentCallback?.onActivityCancel()
         contentCallback = null
     }
 


### PR DESCRIPTION
 ## Problem
  Tapping **Patch** or **Download** selects the radio and opens the picker/dialog.
  If the user cancels, the radio stays selected but no `Uri` is captured, and re-tapping the same option is a no-op. the picker can't be reopened.

  ## Fix                                                                                                                                                                                                                                                            
  - `core/BaseActivity.kt`: add `onActivityCancel()` to `ContentResultCallback`.
  - `apk/InstallViewModel.kt`: clear the radio on cancel.                                                                                                                                                                                                           
  - `apk/DownloadDialog.kt`: invoke `onCancel` on dismiss without a valid URL.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        