### PR TITLE
Update zygisk sepolicy for A17

### DIFF
--- a/native/src/sepolicy/rules.rs
+++ b/native/src/sepolicy/rules.rs
@@ -127,6 +127,7 @@ impl SePolicy {
 
             // Zygisk rules
             allow(["zygote"], ["zygote"], ["process"], ["execmem"]);
+            allow(["domain"], [proc], ["memfd_file"], ["getattr", "read", "write", "map", "execute"]);
             allow(["zygote"], ["fs_type"], ["filesystem"], ["unmount"]);
             allow(["system_server"], ["system_server"], ["process"], ["execmem"]);
 


### PR DESCRIPTION
Mainline kernel starts to use dedicated memfd_file type for memfd, which makes zygote cannot use memfd created by magiskd.