### PR TITLE
Update condition to check for newline and comma

### DIFF
--- a/native/src/boot/patch.rs
+++ b/native/src/boot/patch.rs
@@ -21,7 +21,7 @@ macro_rules! match_patterns {
             let b = $buf.get_unchecked(len..);
             if !b.is_empty() && b[0] == b'=' {
                 for c in b.iter() {
-                    if b" \n\0".contains(c) {
+                    if b" \n,\0".contains(c) {
                         break;
                     }
                     len += 1;


### PR DESCRIPTION
# Fix missing comma in pattern matching delimiter

## Summary

Fixed a missing comma in the boot image pattern matching logic that was lost during the C++ to Rust migration. This caused the pattern parser to not properly stop at comma delimiters, potentially leading to incorrect patch parsing.

## Root Cause

During commit [`9c7cf340a`](https://github.com/topjohnwu/Magisk/commit/9c7cf340a) ("Move pattern matching to Rust"), the C++ pattern matching code was migrated to Rust. The original C++ logic used:

```c++
while (!strchr(" \n,", s[skip]))
    ++skip;
```

This was incorrectly translated to Rust as:

```rust
if b" \n\0".contains(c) {
    break;
}
```

The comma delimiter was omitted in the translation, causing the parser to only recognize space, newline, and null terminator as delimiters instead of space, newline, and **comma**.

## Original Code

**C++ (pattern.cpp)** - Before migration:
- Delimiter set: `" \n,"` (space, newline, comma)
- Context: `skip_verity_pattern()` and `skip_encryption_pattern()` functions

**Rust (patch.rs)** - After buggy migration (commit `9c7cf340a`):
- Delimiter set: `" \n\0"` ❌ Missing comma
- Location: `match_patterns!` macro

## Impact

The missing comma delimiter could cause the boot image patching logic to incorrectly parse kernel command line parameters that use commas as separators, potentially leading to:
- Incomplete pattern matching
- Incorrect removal of verity or encryption patterns
- Boot image corruption or incorrect patching

## Fix

Changed the byte pattern in `native/src/boot/patch.rs` line 24:

```rust
// Before
if b" \n\0".contains(c) {

// After  
if b" \n,\0".contains(c) {
```

This restores the comma delimiter to match the original C++ behavior.
