### PR TITLE
init: check charger mode before force_normal_boot

### DIFF
--- a/native/src/init/init.rs
+++ b/native/src/init/init.rs
@@ -148,13 +148,19 @@ impl MagiskInit {
         let argv1 = unsafe { *self.argv.offset(1) };
         if !argv1.is_null() && unsafe { CStr::from_ptr(argv1) == c"selinux_setup" } {
             self.second_stage();
+        } else if unsafe { CStr::from_ptr(self.config.boot_mode.as_ptr()) } == c"charger" {
+            // Charger (off-mode charging) must abort before any normal-boot path
+            // (skip_initramfs / force_normal_boot). Some devices (e.g. Motorola) set
+            // androidboot.force_normal_boot=1 during off-mode charging, which would otherwise
+            // route to first_stage() and load Magisk in charger mode, bumping the never-reset
+            // bootloop counter until safe mode trips. AOSP likewise treats charger first.
+            self.recovery_or_charger();
         } else if self.config.skip_initramfs {
             self.legacy_system_as_root();
         } else if self.config.force_normal_boot {
             self.first_stage();
         } else if cstr!("/sbin/recovery").exists()
             || cstr!("/system/bin/recovery").exists()
-            || unsafe { CStr::from_ptr(self.config.boot_mode.as_ptr()) } == c"charger"
         {
             self.recovery_or_charger();
         } else if self.check_two_stage() {


### PR DESCRIPTION
## Problem

Fixes #9967.

Off-mode charging on some devices runs a near-full boot that reaches `post_fs_data` (mounts `/data`, starts magiskd) but never reaches `boot_complete`, so the bootloop counter is incremented and never reset. Two such charger boots leave it at ≥2 and the next real boot falsely enters safe mode (all modules + zygisk disabled).

`b55f597c` already aborts charger mode via the `androidboot.mode` check in `init/init.rs`, but the check is placed *after* the `force_normal_boot` branch:

```rust
} else if self.config.force_normal_boot {
    self.first_stage();
} else if recovery || boot_mode == "charger" {   // unreachable when fnb=1
    self.recovery_or_charger();
```

Devices that set `androidboot.force_normal_boot=1` during off-mode charging take `first_stage()` and never reach the charger check.

Confirmed on two Motorola devices; both expose `androidboot.mode=charger` in charger boot, differing only in `force_normal_boot`:

| device | SoC | charger `force_normal_boot` | v30.7 aborts charger? |
|--------|-----|-----------------------------|-----------------------|
| XT2533 | Snapdragon SM7435 | 0 | yes (already fixed by b55f597c) |
| XT2435 | MediaTek MT6855 | 1 | no |

## Fix

Move the charger check ahead of `skip_initramfs`/`force_normal_boot` (right after the second-stage check) so charger boots abort regardless of `force_normal_boot`, matching how AOSP treats charger mode first. Recovery detection stays after `force_normal_boot` (unchanged).

This replaces the `post_fs_data` counter-guard from the previous revision of this PR: aborting in magiskinit means Magisk never loads in charger mode at all (no magiskd, no modules, no counter to guard) — the same layer `b55f597c` operates on.

## Testing

Real hardware, on both affected Motorola devices:

- **XT2435 (fnb=1, which `b55f597c` does not fix)**: with the patch, repeated off-mode-charging boots no longer start magiskd at all (no charger-mode entry appears in the Magisk log); the bootloop counter stays `0` and safe mode is no longer triggered. Normal boots are unaffected (magiskd runs, modules load, `boot_complete` resets the counter).
- **XT2533 (fnb=0, already handled by `b55f597c`)**: still aborts charger mode after the reorder; normal boots unaffected.
