### PR TITLE
fix: use bounded strlcpy/snprintf in logcat.cpp...

### DIFF
--- a/native/src/core/deny/logcat.cpp
+++ b/native/src/core/deny/logcat.cpp
@@ -92,14 +92,14 @@ bool logcat_exit;
 
 static int read_ns(const int pid, struct stat *st) {
     char path[32];
-    sprintf(path, "/proc/%d/ns/mnt", pid);
+    snprintf(path, sizeof(path), "/proc/%d/ns/mnt", pid);
     return stat(path, st);
 }
 
 static int parse_ppid(int pid) {
     char path[32];
     int ppid;
-    sprintf(path, "/proc/%d/stat", pid);
+    snprintf(path, sizeof(path), "/proc/%d/stat", pid);
     auto stat = open_file(path, "re");
     if (!stat) return -1;
     // PID COMM STATE PPID .....
@@ -149,7 +149,7 @@ static void process_main_buffer(struct log_msg *msg) {
     ready = false;
 
     char cmdline[1024];
-    sprintf(cmdline, "/proc/%d/cmdline", msg->entry.pid);
+    snprintf(cmdline, sizeof(cmdline), "/proc/%d/cmdline", msg->entry.pid);
     if (auto f = open_file(cmdline, "re")) {
         fgets(cmdline, sizeof(cmdline), f.get());
     } else {


### PR DESCRIPTION
## Summary
Address high severity security finding in `native/src/core/deny/logcat.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | utils.custom.buffer-overflow-strcpy |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `utils.custom.buffer-overflow-strcpy` |
| **File** | `native/src/core/deny/logcat.cpp:95` |
| **Assessment** | Pattern match — needs manual review |

**Description**: Unsafe C buffer function used without size checking. This can lead to buffer overflow vulnerabilities. Use size-bounded alternatives like strncpy(), strncat(), snprintf(), or fgets().


## Evidence

**Scanner confirmation**: semgrep rule `utils.custom.buffer-overflow-strcpy` matched this pattern as utils.custom.buffer-overflow-strcpy.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `native/src/core/deny/logcat.cpp`

> **Note**: The following lines in the same file use a similar pattern and may also need review: `native/src/core/deny/logcat.cpp:102`, `native/src/core/deny/logcat.cpp:152`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
