### PR TITLE
fix: error paths free memory without proper cleanup ... in policydb.cpp

### DIFF
--- a/native/src/sepolicy/policydb.cpp
+++ b/native/src/sepolicy/policydb.cpp
@@ -41,7 +41,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = PLAT_POLICY_DIR "plat_and_mapping_sepolicy.cil.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.plat_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.plat_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha))
             return false;
     }
@@ -49,7 +49,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = PLAT_POLICY_DIR "plat_sepolicy_and_mapping.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.plat_sepolicy_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.plat_sepolicy_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha))
             return false;
     }
@@ -57,7 +57,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = PROD_POLICY_DIR "product_sepolicy_and_mapping.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.product_sepolicy_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.product_sepolicy_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha) != 0)
             return false;
     }
@@ -65,7 +65,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = SYSEXT_POLICY_DIR "system_ext_sepolicy_and_mapping.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.system_ext_sepolicy_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.system_ext_sepolicy_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha) != 0)
             return false;
     }
@@ -91,6 +91,7 @@ SePolicy SePolicy::from_data(rust::Slice<const uint8_t> data) noexcept {
     auto db = static_cast<policydb_t *>(malloc(sizeof(policydb_t)));
     if (policydb_init(db) || policydb_read(db, &pf, 0)) {
         LOGE("Fail to load policy from data\n");
+        policydb_destroy(db);
         free(db);
         return {};
     }
@@ -110,6 +111,7 @@ SePolicy SePolicy::from_file(::Utf8CStr file) noexcept {
     auto db = static_cast<policydb_t *>(malloc(sizeof(policydb_t)));
     if (policydb_init(db) || policydb_read(db, &pf, 0)) {
         LOGE("Fail to load policy from %.*s\n", static_cast<int>(file.size()), file.data());
+        policydb_destroy(db);
         free(db);
         return {};
     }
@@ -160,19 +162,19 @@ SePolicy SePolicy::compile_split() noexcept {
     // plat
     load_cil(db, SPLIT_PLAT_CIL);
 
-    sprintf(path, PLAT_POLICY_DIR "mapping/%s.cil", plat_ver);
+    snprintf(path, sizeof(path), PLAT_POLICY_DIR "mapping/%s.cil", plat_ver);
     load_cil(db, path);
 
-    sprintf(path, PLAT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
+    snprintf(path, sizeof(path), PLAT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 
     // system_ext
-    sprintf(path, SYSEXT_POLICY_DIR "mapping/%s.cil", plat_ver);
+    snprintf(path, sizeof(path), SYSEXT_POLICY_DIR "mapping/%s.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 
-    sprintf(path, SYSEXT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
+    snprintf(path, sizeof(path), SYSEXT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 
@@ -181,7 +183,7 @@ SePolicy SePolicy::compile_split() noexcept {
         load_cil(db, cil_file);
 
     // product
-    sprintf(path, PROD_POLICY_DIR "mapping/%s.cil", plat_ver);
+    snprintf(path, sizeof(path), PROD_POLICY_DIR "mapping/%s.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 


### PR DESCRIPTION
## Summary
Fix high severity security issue in `native/src/sepolicy/policydb.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `native/src/sepolicy/policydb.cpp:88` |
| **Assessment** | Likely exploitable |

**Description**: Error paths free memory without proper cleanup of libsepol internal structures. If policydb_init() allocates sub-structures and policydb_read() fails, calling free(db) may cause memory corruption or leaks.

## Evidence

**Exploitation scenario**: Attacker provides malformed SELinux policy file to trigger error path, potentially causing memory corruption in error handling code.

**Scanner confirmation**: multi_agent_ai rule `V-003` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `native/src/sepolicy/policydb.cpp`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
