### PR TITLE
fix: use snprintf in policydb.cpp

### DIFF
--- a/native/src/sepolicy/policydb.cpp
+++ b/native/src/sepolicy/policydb.cpp
@@ -41,7 +41,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = PLAT_POLICY_DIR "plat_and_mapping_sepolicy.cil.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.plat_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.plat_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha))
             return false;
     }
@@ -49,7 +49,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = PLAT_POLICY_DIR "plat_sepolicy_and_mapping.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.plat_sepolicy_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.plat_sepolicy_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha))
             return false;
     }
@@ -57,7 +57,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = PROD_POLICY_DIR "product_sepolicy_and_mapping.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.product_sepolicy_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.product_sepolicy_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha) != 0)
             return false;
     }
@@ -65,7 +65,7 @@ static bool check_precompiled(const char *precompiled) {
     actual_sha = SYSEXT_POLICY_DIR "system_ext_sepolicy_and_mapping.sha256";
     if (access(actual_sha, R_OK) == 0) {
         ok = true;
-        sprintf(compiled_sha, "%s.system_ext_sepolicy_and_mapping.sha256", precompiled);
+        snprintf(compiled_sha, sizeof(compiled_sha), "%s.system_ext_sepolicy_and_mapping.sha256", precompiled);
         if (!cmp_sha256(actual_sha, compiled_sha) != 0)
             return false;
     }
@@ -160,19 +160,19 @@ SePolicy SePolicy::compile_split() noexcept {
     // plat
     load_cil(db, SPLIT_PLAT_CIL);
 
-    sprintf(path, PLAT_POLICY_DIR "mapping/%s.cil", plat_ver);
+    snprintf(path, sizeof(path), PLAT_POLICY_DIR "mapping/%s.cil", plat_ver);
     load_cil(db, path);
 
-    sprintf(path, PLAT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
+    snprintf(path, sizeof(path), PLAT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 
     // system_ext
-    sprintf(path, SYSEXT_POLICY_DIR "mapping/%s.cil", plat_ver);
+    snprintf(path, sizeof(path), SYSEXT_POLICY_DIR "mapping/%s.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 
-    sprintf(path, SYSEXT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
+    snprintf(path, sizeof(path), SYSEXT_POLICY_DIR "mapping/%s.compat.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 
@@ -181,7 +181,7 @@ SePolicy SePolicy::compile_split() noexcept {
         load_cil(db, cil_file);
 
     // product
-    sprintf(path, PROD_POLICY_DIR "mapping/%s.cil", plat_ver);
+    snprintf(path, sizeof(path), PROD_POLICY_DIR "mapping/%s.cil", plat_ver);
     if (access(path, R_OK) == 0)
         load_cil(db, path);
 


### PR DESCRIPTION
## Summary
Fix high severity security issue in `native/src/sepolicy/policydb.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `native/src/sepolicy/policydb.cpp:38` |
| **Assessment** | Likely exploitable |

**Description**: Multiple sprintf calls in policydb.cpp write into fixed-size buffers (compiled_sha[128], path[128]) without bounds checking. The precompiled path argument and plat_ver string from file input could overflow these buffers if they exceed available space.

## Evidence

**Exploitation scenario**: Attacker with write access to vendor partition modifies VEND_POLICY_DIR/plat_sepolicy_vers.txt with >90 character string, triggering buffer overflow when compile_split() reads it and uses sprintf.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `native/src/sepolicy/policydb.cpp`

> **Note**: The following lines in the same file use a similar pattern and may also need review: `native/src/sepolicy/policydb.cpp:44`, `native/src/sepolicy/policydb.cpp:52`, `native/src/sepolicy/policydb.cpp:60`, `native/src/sepolicy/policydb.cpp:68`, `native/src/sepolicy/policydb.cpp:163` (and 4 more)

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
