### PR TITLE
magiskboot: Lower the compression presets for XZ & LZMA

### DIFF
--- a/native/src/boot/compress.rs
+++ b/native/src/boot/compress.rs
@@ -222,13 +222,13 @@ pub fn get_encoder<'a, W: Write + 'a>(
 ) -> std::io::Result<Box<dyn WriteFinish<W> + 'a>> {
     Ok(match format {
         FileFormat::XZ => {
-            let mut opt = XzOptions::with_preset(9);
+            let mut opt = XzOptions::with_preset(6);
             opt.set_check_sum_type(CheckType::Crc32);
             Box::new(XzWriter::new(w, opt)?)
         }
         FileFormat::LZMA => Box::new(LzmaWriter::new_use_header(
             w,
-            &LzmaOptions::with_preset(9),
+            &LzmaOptions::with_preset(6),
             None,
         )?),
         FileFormat::BZIP2 => Box::new(BzEncoder::new(w, BzCompression::best())),


### PR DESCRIPTION
Fixes #10019.

### Problem
When using `magiskboot` to repack a kernel image that uses XZ/LZMA, it crashes with `SIGILL` (Illegal Instruction) leaving an incomplete `boot.img`.

### Root cause
The compression routine always uses the maximum compression preset for all formats.
This is problematic with XZ and LZMA because they use far more memory than the other formats, while just providing a very marginal advantage in the resulting file size.
By trying to allocate a big block of contiguous memory, the process goes OOM (Out of memory) and since Rust components at magisk get compiled with `panic = "immediate-abort"`, an undefined instruction gets placed at the memory allocator function, which gets called by the OOM triggering the `SIGILL`.

### Fix
`compress.rs` - The compression presets used in for both XZ and LZMA formats was changed:
- when `get_encoder()` initializes the XZ/LZMA file writers, it now uses `with_preset(6)` which is often the default value on command line tools and provides more than enough compression.

### Verified
On Samsung Galaxy Fame (512MB RAM, perfect for this), boot images that previously failed now get repacked properly.